### PR TITLE
Changes name of `htype` to `column` and moves it

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, 
 from hamilton import base, node
 from hamilton.function_modifiers import base as fm_base
 from hamilton.graph_utils import find_functions
-from hamilton.type_utils import types_match
+from hamilton.htypes import types_match
 
 logger = logging.getLogger(__name__)
 

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -97,23 +97,40 @@ def types_match(
 _sys_version_info = sys.version_info
 _version_tuple = (_sys_version_info.major, _sys_version_info.minor, _sys_version_info.micro)
 
-# The following is purely for backwards compatibility
-# The behavior of annotated/get_args/get_origin has changed in recent versions
-# So we have to handle it accordingly
-# In 3.8/below we have to use the typing_extensions version
+"""
+The following is purely for backwards compatibility
+The behavior of annotated/get_args/get_origin has changed in recent versions
+So we have to handle it accordingly
+In 3.8/below we have to use the typing_extensions version
+
+Also, note that it is currently called `column`, but
+we will eventually want more options. E.G.
+
+`dataset`
+`scalar`
+`tensor`
+
+etc...
+
+To do this, we'll likely extend from annotated, and add new types.
+See `annotated` source code: https://github.com/python/cpython/blob/3.11/Lib/typing.py#L2122.
+
+We can also potentially add validation in the types, and remove it from the validate.
+"""
+
 ANNOTATE_ALLOWED = False
 if _version_tuple < (3, 9, 0):
     # Before 3.9 we use typing_extensions
     import typing_extensions
 
-    htype = typing_extensions.Annotated
+    column = typing_extensions.Annotated
 
 
 else:
     ANNOTATE_ALLOWED = True
     from typing import Annotated, Type
 
-    htype = Annotated
+    column = Annotated
 
 
 if _version_tuple < (3, 9, 0):
@@ -128,7 +145,7 @@ else:
 
 def _is_annotated_type(type_: Type[Type]) -> bool:
     """Utility function to tell if a type is Annotated"""
-    return _get_origin(type_) == htype
+    return _get_origin(type_) == column
 
 
 # Placeholder exception for invalid hamilton types

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import hamilton.graph_utils
-import hamilton.type_utils
+import hamilton.htypes
 import tests.resources.bad_functions
 import tests.resources.config_modifier
 import tests.resources.cyclic_functions

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -3,7 +3,7 @@ import typing
 import pandas as pd
 import pytest
 
-from hamilton import base, type_utils
+from hamilton import base, htypes
 
 
 class X:
@@ -55,7 +55,7 @@ custom_type = typing.TypeVar("FOOBAR")
 )
 def test_custom_subclass_check(param_type, required_type, expected):
     """Tests the custom_subclass_check"""
-    actual = type_utils.custom_subclass_check(required_type, param_type)
+    actual = htypes.custom_subclass_check(required_type, param_type)
     assert actual == expected
 
 
@@ -86,7 +86,7 @@ adapter = TestAdapter()
 )
 def test_types_match(adapter, param_type, required_type, expected):
     """Tests the types_match function"""
-    actual = type_utils.types_match(adapter, param_type, required_type)
+    actual = htypes.types_match(adapter, param_type, required_type)
     assert actual == expected
 
 
@@ -98,26 +98,26 @@ def test_types_match(adapter, param_type, required_type, expected):
         float,
         pd.Series,
         pd.DataFrame,
-        type_utils.htype[pd.Series, int],
-        type_utils.htype[pd.Series, float],
-        type_utils.htype[pd.Series, bool],
-        type_utils.htype[pd.Series, str],
+        htypes.column[pd.Series, int],
+        htypes.column[pd.Series, float],
+        htypes.column[pd.Series, bool],
+        htypes.column[pd.Series, str],
     ],
 )
 def test_validate_types_happy(type_):
     """Tests that validate_types works when the type is valid"""
-    type_utils.validate_type_annotation(type_)
+    htypes.validate_type_annotation(type_)
 
 
 @pytest.mark.parametrize(
     "type_",
     [
-        type_utils.htype[pd.DataFrame, int],
-        type_utils.htype[pd.DataFrame, float],
-        type_utils.htype[pd.Series, typing.Dict[str, typing.Any]],
+        htypes.column[pd.DataFrame, int],
+        htypes.column[pd.DataFrame, float],
+        htypes.column[pd.Series, typing.Dict[str, typing.Any]],
     ],
 )
 def test_validate_types_sad(type_):
     """Tests that validate_types works when the type is valid"""
-    with pytest.raises(type_utils.InvalidTypeException):
-        type_utils.validate_type_annotation(type_)
+    with pytest.raises(htypes.InvalidTypeException):
+        htypes.validate_type_annotation(type_)


### PR DESCRIPTION
This enables a cleaner import. Furthermore, it opens up the ability to add more annotations later on.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
