### PR TITLE
Adds ability to use variables with the driver.execute function #86

### DIFF
--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -8,7 +8,7 @@ import tests.resources.tagging
 import tests.resources.test_default_args
 import tests.resources.very_simple_dag
 from hamilton import base
-from hamilton.driver import Driver
+from hamilton.driver import Driver, Variable
 
 
 def test_driver_validate_input_types():
@@ -210,9 +210,14 @@ def test__create_final_vars():
     """Tests that the final vars are created correctly."""
     dr = Driver({"required": 1}, tests.resources.test_default_args)
     actual = dr._create_final_vars(
-        ["C", tests.resources.test_default_args.B, tests.resources.test_default_args.A]
+        [
+            "C",
+            tests.resources.test_default_args.B,
+            tests.resources.test_default_args.A,
+            Variable("D", int, {}),
+        ]
     )
-    expected = ["C", "B", "A"]
+    expected = ["C", "B", "A", "D"]
     assert actual == expected
 
 


### PR DESCRIPTION
This implements #86  and enables one to pass driver.Variable objects as expected outputs to the driver.execute(). This reduces the boiler plate for someone to massage getting variables for use with .execute().

Adds to unit test.

## Changes
 - adds to driver code for creating the final variables

## How I tested this
 - unit test

## Notes
- Closes #86 

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
