### PR TITLE
Gives user visibility into whether nodes are external inputs or not

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -69,7 +69,8 @@ class Variable:
 
     name: str
     type: typing.Type
-    tags: Dict[str, str] = field(default_factory=frozenset)
+    tags: Dict[str, str] = field(default_factory=dict)
+    is_external_input: bool = field(default=False)
 
 
 class Driver(object):
@@ -380,7 +381,10 @@ class Driver(object):
 
         :return: list of available variables (i.e. outputs).
         """
-        return [Variable(node.name, node.type, node.tags) for node in self.graph.get_nodes()]
+        return [
+            Variable(node.name, node.type, node.tags, node.user_defined)
+            for node in self.graph.get_nodes()
+        ]
 
     @capture_function_usage
     def display_all_functions(
@@ -465,7 +469,10 @@ class Driver(object):
                 in function names.
         """
         downstream_nodes = self.graph.get_impacted_nodes(list(node_names))
-        return [Variable(node.name, node.type, node.tags) for node in downstream_nodes]
+        return [
+            Variable(node.name, node.type, node.tags, node.user_defined)
+            for node in downstream_nodes
+        ]
 
     @capture_function_usage
     def display_downstream_of(
@@ -507,7 +514,9 @@ class Driver(object):
                 in function names.
         """
         upstream_nodes, _ = self.graph.get_upstream_nodes(list(node_names))
-        return [Variable(node.name, node.type, node.tags) for node in upstream_nodes]
+        return [
+            Variable(node.name, node.type, node.tags, node.user_defined) for node in upstream_nodes
+        ]
 
 
 if __name__ == "__main__":

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -379,6 +379,14 @@ class Driver(object):
     def list_available_variables(self) -> List[Variable]:
         """Returns available variables, i.e. outputs.
 
+        These variables corresond 1:1 with nodes in the DAG, and contain the following information:
+        1. name: the name of the node
+        2. tags: the tags associated with this node
+        3. type: The type of data this node returns
+        4. is_external_input: Whether this node represents an external input (required from outside),
+        or not (has a function specifying its behavior).
+
+
         :return: list of available variables (i.e. outputs).
         """
         return [

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -57,6 +57,13 @@ def test_driver_variables():
     assert tags["d"] == {"module": "tests.resources.tagging"}
 
 
+def test_driver_external_input():
+    dr = Driver({}, tests.resources.very_simple_dag)
+    input_types = {var.name: var.is_external_input for var in dr.list_available_variables()}
+    assert input_types["a"] is True
+    assert input_types["b"] is False
+
+
 @mock.patch("hamilton.telemetry.send_event_json")
 def test_capture_constructor_telemetry_disabled(send_event_json):
     """Tests that we don't do anything if telemetry is disabled."""
@@ -214,7 +221,7 @@ def test__create_final_vars():
             "C",
             tests.resources.test_default_args.B,
             tests.resources.test_default_args.A,
-            Variable("D", int, {}),
+            Variable("D", int, {}, False),
         ]
     )
     expected = ["C", "B", "A", "D"]


### PR DESCRIPTION
This allows you to programmatically determine the inputs to your DAG. One component of #97.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
