### PR TITLE
Adds reference to pyspark map UDFs for scaling

### DIFF
--- a/docs/how-tos/scale-up.rst
+++ b/docs/how-tos/scale-up.rst
@@ -4,9 +4,10 @@ Run Hamilton at Scale
 
 Hamilton enables a variety of tools for allowing you to scale your data processing by integrating with third-party libraries.
 
-Specifically, we have three examples that show how to scale Hamilton both by parallelizing transformations (ray and dask) and running
-on larger, distributed datasets (pandas on spark).
+Specifically, we have four examples that show how to scale Hamilton both by parallelizing transformations (ray and dask) and running
+on larger, distributed datasets (pandas on spark, pyspark map UDFs).
 
-1. Integrating hamilton with `pandas on spark <https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/spark>`_.
+1. Integrating hamilton with `pandas on spark <https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/spark/pandas_on_spark>`_.
 2. Integrating hamilton with `ray <https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/ray>`_.
 3. Integrating hamilton with `dask <https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/dask>`_.
+4. Integrating hamilton using `pyspark map UDFs <https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/spark/pyspark_udfs>`__.


### PR DESCRIPTION
So that people know that pyspark UDFs are now an option.


## Changes
 - adds to docs

