### PR TITLE
Adds group feature for injecting kwargs

### DIFF
--- a/hamilton/function_modifiers/__init__.py
+++ b/hamilton/function_modifiers/__init__.py
@@ -45,6 +45,7 @@ parameterize_sources = expanders.parameterize_sources
 parameterize_values = expanders.parameterize_values
 parameterize_extract_columns = expanders.parameterize_extract_columns
 ParameterizedExtract = expanders.ParameterizedExtract
+inject = expanders.inject
 
 # The older ones that will be deprecated
 parametrized = expanders.parametrized

--- a/hamilton/function_modifiers/dependencies.py
+++ b/hamilton/function_modifiers/dependencies.py
@@ -1,7 +1,10 @@
 import abc
 import dataclasses
 import enum
-from typing import Any
+import typing
+from typing import Any, List, Sequence, Type
+
+import typing_inspect
 
 """Utilities for specifying dependencies/dependency types in other decorators."""
 
@@ -9,12 +12,17 @@ from typing import Any
 class ParametrizedDependencySource(enum.Enum):
     LITERAL = "literal"
     UPSTREAM = "upstream"
+    GROUPED_LIST = "grouped_list"
 
 
 class ParametrizedDependency:
     @abc.abstractmethod
     def get_dependency_type(self) -> ParametrizedDependencySource:
         pass
+
+
+class SingleDependency(ParametrizedDependency, abc.ABC):
+    pass
 
 
 @dataclasses.dataclass
@@ -31,6 +39,32 @@ class UpstreamDependency(ParametrizedDependency):
 
     def get_dependency_type(self) -> ParametrizedDependencySource:
         return ParametrizedDependencySource.UPSTREAM
+
+
+@dataclasses.dataclass
+class GroupedListDependency(ParametrizedDependency):
+    @staticmethod
+    def get_type(containing_type: Type[Sequence[Type]], param_name: str):
+        origin = typing_inspect.get_origin(containing_type)
+        if origin is None or not issubclass(origin, typing.Sequence):
+            raise ValueError(
+                f"Type: {containing_type} for parameter: {param_name} needs to be "
+                f"sequence to use the group() dependency specification. Otherwise hamilton"
+                f"cannot validate that the types are correct."
+            )
+        args = typing_inspect.get_args(containing_type)
+        if not len(args) == 1:
+            raise ValueError(
+                f"Type: {containing_type} for parameter: {param_name} needs to be "
+                f"sequence with one type argument to use the group() dependency specification. "
+                f"Otherwise Hamilton cannot validate that the types are correct."
+            )
+        return args[0]
+
+    def get_dependency_type(self) -> ParametrizedDependencySource:
+        return ParametrizedDependencySource.GROUPED_LIST
+
+    sources: List[ParametrizedDependency]
 
 
 def value(literal_value: Any) -> LiteralDependency:
@@ -58,3 +92,19 @@ def source(dependency_on: Any) -> UpstreamDependency:
     if isinstance(dependency_on, UpstreamDependency):
         return dependency_on
     return UpstreamDependency(source=dependency_on)
+
+
+def group(*dependencies: ParametrizedDependency) -> GroupedListDependency:
+    """Specifies that a parameterized dependency comes from a "grouped" source.
+
+    This means that it gets injected into a list of dependencies that are grouped together. E.G.
+    dep=group(source("foo"), source("bar")) for the function:
+
+    def f(dep: List[pd.Series]) -> pd.Series:
+        return ...
+
+    Would result in dep getting foo and bar dependencies injected.
+    :param dependencies: Dependencies, list of dependencies
+    :return:
+    """
+    return GroupedListDependency(sources=list(dependencies))

--- a/hamilton/function_modifiers/dependencies.py
+++ b/hamilton/function_modifiers/dependencies.py
@@ -2,9 +2,11 @@ import abc
 import dataclasses
 import enum
 import typing
-from typing import Any, List, Sequence, Type
+from typing import Any, List, Mapping, Sequence, Type
 
 import typing_inspect
+
+from hamilton.function_modifiers.base import InvalidDecoratorException
 
 """Utilities for specifying dependencies/dependency types in other decorators."""
 
@@ -13,6 +15,7 @@ class ParametrizedDependencySource(enum.Enum):
     LITERAL = "literal"
     UPSTREAM = "upstream"
     GROUPED_LIST = "grouped_list"
+    GROUPED_DICT = "grouped_dict"
 
 
 class ParametrizedDependency:
@@ -41,21 +44,37 @@ class UpstreamDependency(ParametrizedDependency):
         return ParametrizedDependencySource.UPSTREAM
 
 
+class GroupedDependency(ParametrizedDependency, abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    def resolve_dependency_type(cls, annotated_type: Type[Type], param_name: str) -> Type[Type]:
+        """Resolves dependency type for an annotated parameter. E.G. List[str] -> str,
+        or Dict[str, int] -> int.
+
+        :param type: Type to inspect
+        :param param_name: Name of the parameter, used for good error messages
+        :return:Resolved dependency type
+        :raises: InvalidDecoratorException if the dependency type cannot be resolved appropriately.
+        """
+
+
 @dataclasses.dataclass
 class GroupedListDependency(ParametrizedDependency):
-    @staticmethod
-    def get_type(containing_type: Type[Sequence[Type]], param_name: str):
-        origin = typing_inspect.get_origin(containing_type)
+    sources: List[ParametrizedDependency]
+
+    @classmethod
+    def resolve_dependency_type(cls, annotated_type: Type[Sequence[Type]], param_name: str):
+        origin = typing_inspect.get_origin(annotated_type)
         if origin is None or not issubclass(origin, typing.Sequence):
-            raise ValueError(
-                f"Type: {containing_type} for parameter: {param_name} needs to be "
+            raise InvalidDecoratorException(
+                f"Type: {annotated_type} for parameter: {param_name} needs to be "
                 f"sequence to use the group() dependency specification. Otherwise hamilton"
                 f"cannot validate that the types are correct."
             )
-        args = typing_inspect.get_args(containing_type)
+        args = typing_inspect.get_args(annotated_type)
         if not len(args) == 1:
-            raise ValueError(
-                f"Type: {containing_type} for parameter: {param_name} needs to be "
+            raise InvalidDecoratorException(
+                f"Type: {annotated_type} for parameter: {param_name} needs to be "
                 f"sequence with one type argument to use the group() dependency specification. "
                 f"Otherwise Hamilton cannot validate that the types are correct."
             )
@@ -64,7 +83,31 @@ class GroupedListDependency(ParametrizedDependency):
     def get_dependency_type(self) -> ParametrizedDependencySource:
         return ParametrizedDependencySource.GROUPED_LIST
 
-    sources: List[ParametrizedDependency]
+
+@dataclasses.dataclass
+class GroupedDictDependency(ParametrizedDependency):
+    sources: typing.Dict[str, ParametrizedDependency]
+
+    def get_dependency_type(self) -> ParametrizedDependencySource:
+        return ParametrizedDependencySource.GROUPED_DICT
+
+    @classmethod
+    def resolve_dependency_type(cls, annotated_type: Type[Mapping[str, Type]], param_name: str):
+        origin = typing_inspect.get_origin(annotated_type)
+        if origin is None or not issubclass(origin, typing.Mapping):
+            raise InvalidDecoratorException(
+                f"Type: {annotated_type} for parameter: {param_name} needs to be a"
+                f"mapping type to use the group() dependency specification with **kwargs. "
+                f"Otherwise hamilton cannot validate that the types are correct!"
+            )
+        args = typing_inspect.get_args(annotated_type)
+        if not len(args) == 2 or not issubclass(args[0], str):
+            raise InvalidDecoratorException(
+                f"Type: {annotated_type} for parameter: {param_name} needs to be a"
+                f"mapping with types [str, Type] to use the group() dependency specification with "
+                f"**kwargs. Otherwise Hamilton cannot validate that the types are correct."
+            )
+        return args[1]
 
 
 def value(literal_value: Any) -> LiteralDependency:
@@ -94,7 +137,9 @@ def source(dependency_on: Any) -> UpstreamDependency:
     return UpstreamDependency(source=dependency_on)
 
 
-def group(*dependencies: ParametrizedDependency) -> GroupedListDependency:
+def group(
+    *dependency_args: ParametrizedDependency, **dependency_kwargs: ParametrizedDependency
+) -> GroupedListDependency:
     """Specifies that a parameterized dependency comes from a "grouped" source.
 
     This means that it gets injected into a list of dependencies that are grouped together. E.G.
@@ -107,4 +152,10 @@ def group(*dependencies: ParametrizedDependency) -> GroupedListDependency:
     :param dependencies: Dependencies, list of dependencies
     :return:
     """
-    return GroupedListDependency(sources=list(dependencies))
+    if dependency_args and dependency_kwargs:
+        raise ValueError(
+            "group() can either represent a dictionary or a list of dpeendencies, " "not both!"
+        )
+    if dependency_args:
+        return GroupedListDependency(sources=list(dependency_args))
+    return GroupedDictDependency(sources=dependency_kwargs)

--- a/tests/function_modifiers/test_expanders.py
+++ b/tests/function_modifiers/test_expanders.py
@@ -555,3 +555,13 @@ def test_parameterized_validate_group_fails(annotation):
     )
     with pytest.raises(base.InvalidDecoratorException):
         annotation.validate(add_n)
+
+
+def test_inject():
+    annotation = function_modifiers.inject(nums=group(value(1), value(2), value(3)))
+
+    def summation(nums: List[int]) -> int:
+        return sum(nums)
+
+    (node_,) = annotation.expand_node(node.Node.from_fn(summation), {}, summation)
+    assert node_() == 6


### PR DESCRIPTION
We were doing this in the replacement function. Looks like everythin ghas to go in the replacement function, which makes things slightly trickier, but at least we can centralize the logic in that function.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
