### PR TITLE
Fixes to allow nesting of subdags

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -11,7 +11,7 @@ except ImportError:
     EllipsisType = type(...)
 from typing import Any, Callable, Collection, Dict, List, Optional, Union
 
-from hamilton import node, registry
+from hamilton import node, registry, settings
 
 logger = logging.getLogger(__name__)
 
@@ -476,16 +476,22 @@ def resolve_config(
     :param config_optional_with_defaults:
     :return:
     """
+    config_optional_with_global_defaults_applied = config_optional_with_defaults.copy()
+    config_optional_with_global_defaults_applied[
+        settings.ENABLE_POWER_USER_MODE
+    ] = config_optional_with_global_defaults_applied.get(settings.ENABLE_POWER_USER_MODE, False)
     missing_keys = (
-        set(config_required) - set(config.keys()) - set(config_optional_with_defaults.keys())
+        set(config_required)
+        - set(config.keys())
+        - set(config_optional_with_global_defaults_applied.keys())
     )
     if len(missing_keys) > 0:
         raise MissingConfigParametersException(
             f"The following configurations are required by {name_for_error}: {missing_keys}"
         )
     config_out = {key: config[key] for key in config_required}
-    for key in config_optional_with_defaults:
-        config_out[key] = config.get(key, config_optional_with_defaults[key])
+    for key in config_optional_with_global_defaults_applied:
+        config_out[key] = config.get(key, config_optional_with_global_defaults_applied[key])
     return config_out
 
 

--- a/hamilton/function_modifiers/recursive.py
+++ b/hamilton/function_modifiers/recursive.py
@@ -256,16 +256,13 @@ class subdag(base.NodeCreator):
         :param nodes:
         :return:
         """
-        already_namespaced_nodes = []
+        # already_namespaced_nodes = []
         new_nodes = []
         new_name_map = {}
         # First pass we validate + collect names so we can alter dependencies
         for node_ in nodes:
             new_name = assign_namespace(node_.name, namespace)
             new_name_map[node_.name] = new_name
-            current_node_namespaces = node_.namespace
-            if current_node_namespaces:
-                already_namespaced_nodes.append(node_)
         for dep, value in self.inputs.items():
             # We create nodes for both namespace assignment and source assignment
             # Why? Cause we need unique parameter names, and with source() some can share params
@@ -274,11 +271,6 @@ class subdag(base.NodeCreator):
         for dep, value in self.config.items():
             new_name_map[dep] = assign_namespace(dep, namespace)
 
-        if already_namespaced_nodes:
-            raise ValueError(
-                f"The following nodes are already namespaced: {already_namespaced_nodes}. "
-                f"We currently do not allow for multiple namespaces (E.G. layered subDAGs)."
-            )
         # Reassign sources
         for node_ in nodes:
             new_name = new_name_map[node_.name]

--- a/tests/function_modifiers/test_base.py
+++ b/tests/function_modifiers/test_base.py
@@ -2,7 +2,7 @@ from typing import Collection, Dict, List
 
 import pytest as pytest
 
-from hamilton import node
+from hamilton import node, settings
 from hamilton.function_modifiers import InvalidDecoratorException, base
 from hamilton.function_modifiers.base import (
     MissingConfigParametersException,
@@ -11,16 +11,36 @@ from hamilton.function_modifiers.base import (
 )
 from hamilton.node import Node
 
+power_mode_k = settings.ENABLE_POWER_USER_MODE
+
 
 @pytest.mark.parametrize(
     "config,config_required,config_optional_with_defaults,expected",
     [
-        ({"foo": 1}, ["foo"], {}, {"foo": 1}),
-        ({"foo": 1, "bar": 2}, ["foo"], {}, {"foo": 1}),
-        ({"foo": 1, "bar": 2}, ["foo"], {"bar": 3}, {"foo": 1, "bar": 2}),
-        ({"foo": 1}, [], {"bar": 3}, {"bar": 3}),
+        ({"foo": 1}, ["foo"], {}, {"foo": 1, power_mode_k: False}),
+        ({"foo": 1, "bar": 2}, ["foo"], {}, {"foo": 1, power_mode_k: False}),
+        ({"foo": 1, "bar": 2}, ["foo"], {"bar": 3}, {"foo": 1, "bar": 2, power_mode_k: False}),
+        ({"foo": 1}, [], {"bar": 3}, {"bar": 3, power_mode_k: False}),
+        ({"foo": 1, power_mode_k: True}, ["foo"], {}, {"foo": 1, power_mode_k: True}),
+        ({"foo": 1, "bar": 2, power_mode_k: True}, ["foo"], {}, {"foo": 1, power_mode_k: True}),
+        (
+            {"foo": 1, "bar": 2, power_mode_k: True},
+            ["foo"],
+            {"bar": 3},
+            {"foo": 1, "bar": 2, power_mode_k: True},
+        ),
+        ({"foo": 1, power_mode_k: True}, [], {"bar": 3}, {"bar": 3, power_mode_k: True}),
     ],
-    ids=["all_present", "all_present_extra", "no_apply_default", "yes_apply_default"],
+    ids=[
+        "all_present",
+        "all_present_extra",
+        "no_apply_default",
+        "yes_apply_default",
+        "all_present_with_power_user_mode",
+        "all_present_extra_with_power_user_mode",
+        "no_apply_default_with_power_user_mode",
+        "yes_apply_default_with_power_user_mode",
+    ],
 )
 def test_merge_config_happy(config, config_required, config_optional_with_defaults, expected):
     assert (


### PR DESCRIPTION
decorators

Every decorator should have access to this, just in case, so we don't have to worry about passing it through. This changes the resolve_config function in function_modifiers.base to pass it through globally. Note that this also *removes* the default setting of this in the @resolve(...) decorator as it is no longer necessary.

Furthermore, this cleans up some issues in which the optional configs provided by a decorator was a list instead of a dictionary.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
