### PR TITLE
Rename to output

### DIFF
--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -397,11 +397,11 @@ class SaveToDecorator(SingleNodeNodeTransformer):
     def __init__(
         self,
         saver_classes_: typing.Sequence[Type[DataSaver]],
-        node_name_: str = None,
+        output_name_: str = None,
         **kwargs: ParametrizedDependency,
     ):
         super(SaveToDecorator, self).__init__()
-        self.artifact_name = node_name_
+        self.artifact_name = output_name_
         self.saver_classes = saver_classes_
         self.kwargs = kwargs
 
@@ -502,7 +502,7 @@ class save_to(metaclass=save_to__meta__):
 
     .. code-block:: python
 
-        @save_to.json(path=source("raw_data_path"), artifact_="data_save_output")
+        @save_to.json(path=source("raw_data_path"), output_name_="data_save_output")
         def final_output(data: dict, valid_keys: List[str]) -> dict:
             return [item for item in data if item in valid_keys]
 
@@ -535,7 +535,7 @@ class save_to(metaclass=save_to__meta__):
 
     .. code-block:: python
 
-        @save_to.json(path=value('/path/my_data.json'), artifact_="data_save_output")
+        @save_to.json(path=value('/path/my_data.json'), output_name_="data_save_output")
         def final_output(data: dict, valid_keys: List[str]) -> dict:
             return [item for item in data if item in valid_keys]
 

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -370,7 +370,7 @@ def test_pandas_extensions_end_to_end(tmp_path_factory):
     output_path = tmp_path_factory.mktemp("test_pandas_extensions_end_to_end") / "output.csv"
     input_path = "tests/resources/data/test_load_from_data.csv"
 
-    @save_to.csv(path=source("output_path"), node_name_="save_df")
+    @save_to.csv(path=source("output_path"), output_name_="save_df")
     @load_from.csv(path=source("input_path"))
     def df(data: pd.DataFrame) -> pd.DataFrame:
         return data
@@ -425,7 +425,7 @@ def test_save_to_decorator():
     marking_set_2 = set()
     decorator = SaveToDecorator(
         [MarkingSaver],
-        node_name_="save_fn",
+        output_name_="save_fn",
         markers=value(marking_set),
         more_markers=source("more_markers"),
     )


### PR DESCRIPTION
Renames `node_name_` to `output_name_` in save_to decorator.

## Changes
- renaming
- fixing earlier miss in docs

## How I tested this
 - Circle ci tests

## Notes
 - we are inconsistent; we should be more consistent moving forward.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
