### PR TITLE
Exposes more information for check_output decorator errors

### DIFF
--- a/hamilton/data_quality/default_validators.py
+++ b/hamilton/data_quality/default_validators.py
@@ -455,6 +455,6 @@ def resolve_default_validators(
                 f"No registered subclass of BaseDefaultValidator is available "
                 f"for arg: {key} and type {output_type}. This either means (a) this arg-type "
                 f"contribution isn't supported or (b) this has not been added yet (but should be). "
-                f"In the case of (b), we welcome contributions. Get started at github.com/dagworks-inc/hamilton"
+                f"In the case of (b), we welcome contributions. Get started at github.com/dagworks-inc/hamilton."
             )
     return validators

--- a/hamilton/function_modifiers/validation.py
+++ b/hamilton/function_modifiers/validation.py
@@ -175,12 +175,19 @@ class check_output(BaseDataValidationDecorator):
     """
 
     def get_validators(self, node_to_validate: node.Node) -> List[dq_base.DataValidator]:
-        return default_validators.resolve_default_validators(
-            node_to_validate.type,
-            importance=self.importance,
-            available_validators=self.default_decorator_candidates,
-            **self.default_validator_kwargs,
-        )
+        try:
+            return default_validators.resolve_default_validators(
+                node_to_validate.type,
+                importance=self.importance,
+                available_validators=self.default_decorator_candidates,
+                **self.default_validator_kwargs,
+            )
+        except ValueError as e:
+            raise ValueError(
+                f"Could not resolve validators for @check_output for function [{node_to_validate.name}]. "
+                f"Please check that `target_` is set correctly if you're using that argument.\n"
+                f"Actual error: {e}"
+            ) from e
 
     def __init__(
         self,

--- a/tests/function_modifiers/test_validation.py
+++ b/tests/function_modifiers/test_validation.py
@@ -154,3 +154,19 @@ def test_data_quality_constants_for_api_consistency():
     # simple tests to test data quality constants remain the same
     assert IS_DATA_VALIDATOR_TAG == "hamilton.data_quality.contains_dq_results"
     assert DATA_VALIDATOR_ORIGINAL_OUTPUT_TAG == "hamilton.data_quality.source_node"
+
+
+def test_check_output_validation_error():
+    """Tests that we wrap an error raised appropriately."""
+    decorator = check_output(
+        importance="warn",
+        dtype=np.int64,
+    )
+
+    def fn(input: pd.Series) -> pd.DataFrame:
+        return pd.DataFrame({"a": input})
+
+    node_ = node.Node.from_fn(fn)
+    with pytest.raises(ValueError) as e:
+        decorator.transform_node(node_, config={}, fn=fn)
+        assert "Could not resolve validators for @check_output for function [fn]" in str(e)


### PR DESCRIPTION
If the user does something that involves the mistyping `target_` or tries to use a key word argument that doesn't map to a validator for the given output type, then the error will be cryptic. This adds context that it's for the check_output decorator and which function it's for.

## Changes
 - raises nicer error message for check_output issues.

## How I tested this
 - wrote unit test

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
