### PR TITLE
Adds `group` to docs

### DIFF
--- a/docs/reference/api-reference/decorators.rst
+++ b/docs/reference/api-reference/decorators.rst
@@ -53,6 +53,8 @@ Classes to help with @parameterize:
 
 .. autoclass:: hamilton.function_modifiers.value
 
+.. autoclass:: hamilton.function_modifiers.group
+
 
 Actual decorators:
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/hamilton/function_modifiers/dependencies.py
+++ b/hamilton/function_modifiers/dependencies.py
@@ -186,11 +186,15 @@ def group(
     This means that it gets injected into a list of dependencies that are grouped together. E.G.
     dep=group(source("foo"), source("bar")) for the function:
 
-    def f(dep: List[pd.Series]) -> pd.Series:
-        return ...
+    .. code-block:: python
+
+        @inject(dep=group(source("foo"), source("bar")))
+        def f(dep: List[pd.Series]) -> pd.Series:
+            return ...
 
     Would result in dep getting foo and bar dependencies injected.
-    :param dependencies: Dependencies, list of dependencies
+    :param dependency_args: Dependencies, list of dependencies (e.g. source("foo"), source("bar"))
+    :param dependency_kwargs: Dependencies, kwarg dependencies (e.g. foo=source("foo"))
     :return:
     """
     _validate_group_params(dependency_args, dependency_kwargs)


### PR DESCRIPTION
We hadn't exposed it. This adds that and corrects the doc string that will be exposed.


## Changes
 - docs changes

## How I tested this
 - CI
 
## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
