### PR TITLE
Fixes whitespace in `group` doc string

### DIFF
--- a/hamilton/function_modifiers/dependencies.py
+++ b/hamilton/function_modifiers/dependencies.py
@@ -193,6 +193,7 @@ def group(
             return ...
 
     Would result in dep getting foo and bar dependencies injected.
+
     :param dependency_args: Dependencies, list of dependencies (e.g. source("foo"), source("bar"))
     :param dependency_kwargs: Dependencies, kwarg dependencies (e.g. foo=source("foo"))
     :return:


### PR DESCRIPTION
So that the parameters render properly.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
