### PR TITLE
Adds the original function pointer to node/variable objects

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -71,6 +71,22 @@ class Variable:
     type: typing.Type
     tags: Dict[str, str] = field(default_factory=dict)
     is_external_input: bool = field(default=False)
+    originating_functions: Optional[Tuple[Callable, ...]] = None
+
+    @staticmethod
+    def from_node(n: node.Node) -> "Variable":
+        """Creates a Variable from a Node.
+
+        :param n: Node to create the Variable from.
+        :return: Variable created from the Node.
+        """
+        return Variable(
+            name=n.name,
+            type=n.type,
+            tags=n.tags,
+            is_external_input=n.user_defined,
+            originating_functions=n.originating_functions,
+        )
 
 
 class Driver(object):
@@ -389,10 +405,7 @@ class Driver(object):
 
         :return: list of available variables (i.e. outputs).
         """
-        return [
-            Variable(node.name, node.type, node.tags, node.user_defined)
-            for node in self.graph.get_nodes()
-        ]
+        return [Variable.from_node(n) for n in self.graph.get_nodes()]
 
     @capture_function_usage
     def display_all_functions(
@@ -477,10 +490,7 @@ class Driver(object):
                 in function names.
         """
         downstream_nodes = self.graph.get_impacted_nodes(list(node_names))
-        return [
-            Variable(node.name, node.type, node.tags, node.user_defined)
-            for node in downstream_nodes
-        ]
+        return [Variable.from_node(n) for n in downstream_nodes]
 
     @capture_function_usage
     def display_downstream_of(
@@ -522,9 +532,7 @@ class Driver(object):
                 in function names.
         """
         upstream_nodes, _ = self.graph.get_upstream_nodes(list(node_names))
-        return [
-            Variable(node.name, node.type, node.tags, node.user_defined) for node in upstream_nodes
-        ]
+        return [Variable.from_node(n) for n in upstream_nodes]
 
 
 if __name__ == "__main__":

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -1,7 +1,7 @@
 import inspect
 import typing
 from enum import Enum
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 """
 Module that contains the primitive components of the graph.
@@ -46,6 +46,7 @@ class Node(object):
         input_types: Dict[str, Union[Type, Tuple[Type, DependencyType]]] = None,
         tags: Dict[str, Any] = None,
         namespace: Tuple[str, ...] = (),
+        originating_functions: Optional[Tuple[Callable, ...]] = None,
     ):
         """Constructor for our Node object.
 
@@ -71,6 +72,7 @@ class Node(object):
         self._depended_on_by = []
         self._namespace = namespace
         self._input_types = {}
+        self._originating_functions = originating_functions
 
         if self._node_source == NodeSource.STANDARD:
             if input_types is not None:
@@ -144,6 +146,16 @@ class Node(object):
     @property
     def tags(self) -> Dict[str, str]:
         return self._tags
+
+    @property
+    def originating_functions(self) -> Optional[Tuple[Callable, ...]]:
+        """Gives all functions from which this node was created. None if the data
+        is not available (it is user-defined, or we have not added it yet). Note that this can be
+        multiple in the case of subdags (the subdag function + the other function). In that case,
+
+        :return: A Tuple consisting of functions from which this node was created.
+        """
+        return self._originating_functions
 
     def add_tag(self, tag_name: str, tag_value: str):
         self._tags[tag_name] = tag_value

--- a/tests/function_modifiers/test_base.py
+++ b/tests/function_modifiers/test_base.py
@@ -139,3 +139,13 @@ def test_select_nodes_happy(
 def test_select_nodes_sad(target: TargetType, nodes: Collection[node.Node]):
     with pytest.raises(InvalidDecoratorException):
         NodeTransformer.select_nodes(target, nodes)
+
+
+def test_add_fn_metadata():
+    nodes_og = _create_node_set({"d": ["e"]})
+    nodes = base._add_original_function_to_nodes(test_add_fn_metadata, nodes_og)
+    nodes_with_fn_pointer = [
+        n.originating_functions for n in nodes if n.originating_functions is not None
+    ]
+    assert len(nodes_with_fn_pointer) == len(nodes)
+    assert all([n.originating_functions == (test_add_fn_metadata,) for n in nodes])

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -48,7 +48,7 @@ def test_driver_cycles_execute_recursion_error():
         dr.execute(["C"], inputs={"b": 2, "c": 2})
 
 
-def test_driver_variables():
+def test_driver_variables_exposes_tags():
     dr = Driver({}, tests.resources.tagging)
     tags = {var.name: var.tags for var in dr.list_available_variables()}
     assert tags["a"] == {"module": "tests.resources.tagging", "test": "a"}
@@ -57,11 +57,20 @@ def test_driver_variables():
     assert tags["d"] == {"module": "tests.resources.tagging"}
 
 
-def test_driver_external_input():
+def test_driver_variables_external_input():
     dr = Driver({}, tests.resources.very_simple_dag)
     input_types = {var.name: var.is_external_input for var in dr.list_available_variables()}
     assert input_types["a"] is True
     assert input_types["b"] is False
+
+
+def test_driver_variables_exposes_original_function():
+    dr = Driver({}, tests.resources.very_simple_dag)
+    originating_functions = {
+        var.name: var.originating_functions for var in dr.list_available_variables()
+    }
+    assert originating_functions["b"] == (tests.resources.very_simple_dag.b,)
+    assert originating_functions["a"] is None
 
 
 @mock.patch("hamilton.telemetry.send_event_json")


### PR DESCRIPTION
Before we had no way of knowing which nodes were generated by which functions. This adds the capability. Each variable now points to the function that generated it.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
