### PR TITLE
Sets typing_extensions minimum

### DIFF
--- a/hamilton/function_modifiers/recursive.py
+++ b/hamilton/function_modifiers/recursive.py
@@ -1,7 +1,19 @@
+import sys
 from types import ModuleType
 from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Type, Union
 
-from typing_extensions import NotRequired, TypedDict
+_sys_version_info = sys.version_info
+_version_tuple = (_sys_version_info.major, _sys_version_info.minor, _sys_version_info.micro)
+
+if _version_tuple < (3, 11, 0):
+    from typing_extensions import NotRequired
+else:
+    from typing import NotRequired
+
+if _version_tuple < (3, 8, 0):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 # Copied this over from function_graph
 # TODO -- determine the best place to put this code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 pandas
+typing_extensions > 4.0.0
 typing_inspect


### PR DESCRIPTION
We are using features that come after `4.0.0` and so we should set the minimum, else users will encounter errors if their version of typing_extensions isn't greater than 4.0.0. 

Also fixed places in code where we were not checking appropriately for the right version and importing
from the right place.

## Changes
 - requirements.txt
 - recursive.py

## How I tested this
 - unit tests

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
