### PR TITLE
Example to extend #195

### DIFF
--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -111,6 +111,14 @@ class CachingAdapter(SimplePythonGraphAdapter):
         return self.readers[fmt](filepath)
 
     def execute_node(self, node: Node, kwargs: dict[str, Any]) -> Any:
+        """Executes nodes conditionally according to caching rules.
+
+        This node is executed if at least one of these is true:
+        * no cache is present,
+        * it is explicitly forced by passing it to the adapter in ``force_compute``,
+        * at least one of its upstream nodes was computed, either due to lack of cache
+          or being explicitly forced.
+        """
         cache_format = node.tags.get("cache")
         implicitly_forced = any(
             dep.name in self.computed_nodes for dep in node.dependencies

--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -116,8 +116,8 @@ class CachingAdapter(SimplePythonGraphAdapter):
         This node is executed if at least one of these is true:
         * no cache is present,
         * it is explicitly forced by passing it to the adapter in ``force_compute``,
-        * at least one of its upstream nodes was computed, either due to lack of cache
-          or being explicitly forced.
+        * at least one of its upstream nodes that had a @cache annotation was computed,
+          either due to lack of cache or being explicitly forced.
         """
         cache_format = node.tags.get("cache")
         implicitly_forced = any(

--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -1,0 +1,136 @@
+import json
+import logging
+import os
+from typing import Any, Callable, Optional
+
+import pandas as pd
+from hamilton.base import SimplePythonGraphAdapter
+from hamilton.node import Node
+
+logger = logging.getLogger(__name__)
+
+
+def write_feather(data: pd.DataFrame, filepath: str) -> None:
+    """Writes a data frame to a feather file."""
+    data.to_feather(filepath)
+
+
+def read_feather(filepath: str) -> pd.DataFrame:
+    """Reads a data frame from a feather file."""
+    return pd.read_feather(filepath)
+
+
+def write_parquet(data: pd.DataFrame, filepath: str) -> None:
+    """Writes a data frame to a parquet file."""
+    data.to_parquet(filepath)
+
+
+def read_parquet(filepath: str) -> pd.DataFrame:
+    """Reads a data frame from a parquet file."""
+    return pd.read_parquet(filepath)
+
+
+def write_json(data: dict, filepath: str) -> None:
+    """Writes a dictionary to a JSON file."""
+    with open(filepath, "w", encoding="utf8") as file:
+        json.dump(data, file)
+
+
+def read_json(filepath: str) -> dict:
+    """Reads a dictionary from a JSON file."""
+    with open(filepath, "r", encoding="utf8") as file:
+        return json.load(file)
+
+
+class CachingAdapter(SimplePythonGraphAdapter):
+    """Caching adapter.
+
+    Any node with tag "cache" will be cached (or loaded from cache) in the format defined by the
+    tag's value. There are a handful of formats supported, and other formats' readers and writers
+    can be provided to the constructor.
+
+    Values are loaded from cache if the node's file exists, unless one of these is true:
+     * node is explicitly forced to be computed with a constructor argument,
+     * any of its (potentially transitive) dependencies that are configured to be cached
+       was nevertheless computed (either forced or missing cached file).
+    """
+
+    def __init__(
+        self,
+        cache_path: str,
+        *args,
+        force_compute: Optional[set[str]] = None,
+        writers: Optional[dict[str, Callable[[Any, str], None]]] = None,
+        readers: Optional[dict[str, Callable[[str], Any]]] = None,
+        **kwargs,
+    ):
+        """Constructs the adapter.
+
+        Parameters
+        ----------
+        cache_path : str
+            Path to the directory where cached files are stored.
+        force_compute : optional, set
+            Set of nodes that should be forced to compute even if cache exists.
+        writers : optional, dict
+            A dictionary of writers for custom formats.
+        readers : optional, dict
+            A dictionary of readers for custom formats.
+        """
+
+        super().__init__(*args, **kwargs)
+        self.cache_path = cache_path
+        self.force_compute = force_compute if force_compute is not None else {}
+        self.computed_nodes = set()
+
+        self.writers = writers or {}
+        self.readers = readers or {}
+
+        self._init_default_readers_writers()
+
+    def _init_default_readers_writers(self):
+        if "json" not in self.writers:
+            self.writers["json"] = write_json
+        if "json" not in self.readers:
+            self.readers["json"] = read_json
+
+        if "feather" not in self.writers:
+            self.writers["feather"] = write_feather
+        if "feather" not in self.readers:
+            self.readers["feather"] = read_feather
+
+        if "parquet" not in self.writers:
+            self.writers["parquet"] = write_parquet
+        if "parquet" not in self.readers:
+            self.readers["parquet"] = read_parquet
+
+    def _check_format(self, fmt):
+        if fmt not in self.writers:
+            raise ValueError(f"invalid cache format: {fmt}")
+
+    def _write_cache(self, data: Any, fmt: str, filepath: str) -> None:
+        self._check_format(fmt)
+        self.writers[fmt](data, filepath)
+
+    def _read_cache(self, fmt: str, filepath: str) -> None:
+        self._check_format(fmt)
+        return self.readers[fmt](filepath)
+
+    def execute_node(self, node: Node, kwargs: dict[str, Any]) -> Any:
+        cache_format = node.tags.get("cache")
+        implicitly_forced = any(dep.name in self.computed_nodes for dep in node.dependencies)
+        if cache_format is not None:
+            filepath = f"{self.cache_path}/{node.name}.{cache_format}"
+            explicitly_forced = node.name in self.force_compute
+            if explicitly_forced or implicitly_forced or not os.path.exists(filepath):
+                result = node.callable(**kwargs)
+                self._write_cache(result, cache_format, filepath)
+                self.computed_nodes.add(node.name)
+                return result
+            return self._read_cache(cache_format, filepath)
+
+        if implicitly_forced:
+            # For purposes of caching, we only mark it as computed if any cached input was computed.
+            # Otherwise, dependants would always be recomputed if they have a non-cached dependency.
+            self.computed_nodes.add(node.name)
+        return node.callable(**kwargs)

--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -66,16 +66,10 @@ class CachingAdapter(SimplePythonGraphAdapter):
     ):
         """Constructs the adapter.
 
-        Parameters
-        ----------
-        cache_path : str
-            Path to the directory where cached files are stored.
-        force_compute : optional, set
-            Set of nodes that should be forced to compute even if cache exists.
-        writers : optional, dict
-            A dictionary of writers for custom formats.
-        readers : optional, dict
-            A dictionary of readers for custom formats.
+        :param cache_path: Path to the directory where cached files are stored.
+        :param force_compute: Set of nodes that should be forced to compute even if cache exists.
+        :param writers: A dictionary of writers for custom formats.
+        :param readers: A dictionary of readers for custom formats.
         """
 
         super().__init__(*args, **kwargs)

--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from functools import singledispatch
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, Optional, Set, Type
 
 import typing_inspect
 
@@ -161,9 +161,9 @@ class CachingAdapter(SimplePythonGraphAdapter):
         self,
         cache_path: str,
         *args,
-        force_compute: Optional[set[str]] = None,
-        writers: Optional[dict[str, Callable[[Any, str], None]]] = None,
-        readers: Optional[dict[str, Callable[[str], Any]]] = None,
+        force_compute: Optional[Set[str]] = None,
+        writers: Optional[Dict[str, Callable[[Any, str], None]]] = None,
+        readers: Optional[Dict[str, Callable[[str], Any]]] = None,
         **kwargs,
     ):
         """Constructs the adapter.
@@ -217,7 +217,7 @@ class CachingAdapter(SimplePythonGraphAdapter):
             return typing_inspect.get_origin(expected_type)()
         return expected_type()  # This ASSUMES that we can just do `str()`, `pd.DataFrame()`, etc.
 
-    def execute_node(self, node: Node, kwargs: dict[str, Any]) -> Any:
+    def execute_node(self, node: Node, kwargs: Dict[str, Any]) -> Any:
         """Executes nodes conditionally according to caching rules.
 
         This node is executed if at least one of these is true:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 graphviz
 networkx
+pyarrow
 pytest
 pytest-cov

--- a/tests/nodes.py
+++ b/tests/nodes.py
@@ -1,4 +1,7 @@
 import logging
+
+import pandas as pd
+
 from hamilton.function_modifiers import tag
 
 
@@ -19,6 +22,38 @@ def both(lowercased: str, uppercased: str) -> dict:
     logging.info("both")
     return {"lower": lowercased, "upper": uppercased}
 
+
 def b2(both: dict) -> dict:
     logging.info("b2")
     return both
+
+
+@tag(cache="json")
+def my_df() -> pd.DataFrame:
+    logging.info("json df")
+    return pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+
+@tag(cache="json")
+def my_series() -> pd.Series:
+    logging.info("json series")
+    return pd.Series([7, 8, 9])
+
+
+@tag(cache="parquet")
+def my_df2(my_df: pd.DataFrame) -> pd.DataFrame:
+    logging.info("parquet df")
+    return my_df
+
+
+@tag(cache="parquet")
+def my_series2(my_series: pd.Series) -> pd.Series:
+    logging.info("parquet series")
+    return my_series
+
+
+def combined(my_df2: pd.DataFrame, my_series2: pd.Series) -> pd.DataFrame:
+    logging.info("combined")
+    _s = pd.Series(my_series2, name="c")
+    _df = pd.concat([my_df2, _s], axis=1)
+    return _df

--- a/tests/nodes.py
+++ b/tests/nodes.py
@@ -1,0 +1,24 @@
+import logging
+from hamilton.function_modifiers import tag
+
+
+@tag(cache="str")
+def lowercased(initial: str) -> str:
+    logging.info("lowercased")
+    return initial.lower()
+
+
+@tag(cache="str")
+def uppercased(initial: str) -> str:
+    logging.info("uppercased")
+    return initial.upper()
+
+
+@tag(cache="json")
+def both(lowercased: str, uppercased: str) -> dict:
+    logging.info("both")
+    return {"lower": lowercased, "upper": uppercased}
+
+def b2(both: dict) -> dict:
+    logging.info("b2")
+    return both

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,160 @@
+import logging
+
+import pandas as pd
+import pytest
+
+from hamilton import base
+from hamilton.driver import Driver
+from hamilton.experimental.h_cache import (
+    CachingAdapter,
+    read_feather,
+    read_json,
+    read_parquet,
+    write_feather,
+    write_json,
+    write_parquet,
+)
+from tests import nodes
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+        }
+    )
+
+
+def _read_write_df_test(df, filepath, read_fn, write_fn):
+    write_fn(df, filepath)
+    pd.testing.assert_frame_equal(read_fn(filepath), df)
+
+
+def test_feather(df, tmp_path):
+    _read_write_df_test(df, tmp_path / "file.feather", read_feather, write_feather)
+
+
+def test_parquet(df, tmp_path):
+    _read_write_df_test(df, tmp_path / "file.parquet", read_parquet, write_parquet)
+
+
+def test_json(tmp_path):
+    data = {
+        "a": 1,
+        "b": 2,
+    }
+    filepath = tmp_path / "file.json"
+    write_json(data, filepath)
+    assert read_json(filepath) == data
+
+
+def test_unknown_format(tmp_path):
+    cache_path = str(tmp_path)
+    adapter = CachingAdapter(cache_path, base.DictResult())
+    data = {"a": 1, "b": 2}
+    filepath = tmp_path / "file.xyz"
+    with pytest.raises(ValueError) as err:
+        adapter._write_cache(data, "xyz", filepath)
+    assert str(err.value) == "invalid cache format: xyz"
+    with pytest.raises(ValueError) as err:
+        adapter._read_cache("xyz", filepath)
+    assert str(err.value) == "invalid cache format: xyz"
+
+
+def test_init_default_readers_writers(tmp_path):
+    cache_path = str(tmp_path / "data")
+    adapter = CachingAdapter(cache_path, base.DictResult())
+    assert adapter.writers == {
+        "json": write_json,
+        "feather": write_feather,
+        "parquet": write_parquet,
+    }
+    assert adapter.readers == {
+        "json": read_json,
+        "feather": read_feather,
+        "parquet": read_parquet,
+    }
+
+
+def read_str(filepath: str) -> str:
+    with open(filepath, "r", encoding="utf8") as file:
+        return file.read()
+
+
+def write_str(data: str, filepath: str) -> None:
+    with open(filepath, "w", encoding="utf8") as file:
+        file.write(data)
+
+
+def test_caching(tmp_path, caplog):
+    caplog.set_level(logging.INFO)
+    cache_path = str(tmp_path)
+    adapter = CachingAdapter(
+        cache_path,
+        base.DictResult(),
+        readers={"str": read_str},
+        writers={"str": write_str},
+    )
+    dr = Driver(
+        {"initial": "Hello, World!"},
+        nodes,
+        adapter=adapter,
+    )
+    assert dr.execute(["both"])["both"] == {
+        "lower": "hello, world!",
+        "upper": "HELLO, WORLD!",
+    }
+    assert {"lowercased", "uppercased", "both"} == {
+        rec.message for rec in caplog.records
+    }
+
+    assert read_str(str(tmp_path / "lowercased.str")) == "hello, world!"
+    assert read_str(str(tmp_path / "uppercased.str")) == "HELLO, WORLD!"
+    assert (
+        read_str(str(tmp_path / "both.json"))
+        == '{"lower": "hello, world!", "upper": "HELLO, WORLD!"}'
+    )
+
+    caplog.clear()
+
+    # need a new adapter for caching to take proper effect
+    adapter = CachingAdapter(
+        cache_path,
+        base.DictResult(),
+        readers={"str": read_str},
+        writers={"str": write_str},
+    )
+    dr = Driver(
+        {"initial": "Hello, World!"},
+        nodes,
+        adapter=adapter,
+    )
+    assert dr.execute(["both"])["both"] == {
+        "lower": "hello, world!",
+        "upper": "HELLO, WORLD!",
+    }
+    assert not {rec.message for rec in caplog.records}
+
+    caplog.clear()
+
+    # now we force-compute one of the dependencies
+    adapter = CachingAdapter(
+        cache_path,
+        base.DictResult(),
+        readers={"str": read_str},
+        writers={"str": write_str},
+        force_compute={"lowercased"},
+    )
+    dr = Driver(
+        {"initial": "Hello, World!"},
+        nodes,
+        adapter=adapter,
+    )
+    assert dr.execute(["both"])["both"] == {
+        "lower": "hello, world!",
+        "upper": "HELLO, WORLD!",
+    }
+    # both the forced node and the node dependent on it is computed
+    assert {"lowercased", "both"} == {rec.message for rec in caplog.records}

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -119,18 +119,6 @@ def test_caching(tmp_path, caplog):
 
     caplog.clear()
 
-    # need a new adapter for caching to take proper effect
-    adapter = CachingAdapter(
-        cache_path,
-        base.DictResult(),
-        readers={"str": read_str},
-        writers={"str": write_str},
-    )
-    dr = Driver(
-        {"initial": "Hello, World!"},
-        nodes,
-        adapter=adapter,
-    )
     assert dr.execute(["both"])["both"] == {
         "lower": "hello, world!",
         "upper": "HELLO, WORLD!",


### PR DESCRIPTION
This generalizes the capability to serialize and deserialize for caching.

It uses singledispatch to do the magic, and a cute trick on reading to also make singledispatch work.

This builds off of #195 @elshize .

## Changes
 - adds to h_cache

## How I tested this
 - via unit tests

## Notes
 - there is some duplication of functionality here with respect to the data savers and loaders. We should figure out how to combine them.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
