### PR TITLE
Avoid get_dummies dtype change in pandas v2 (keep backwards compatible)

### DIFF
--- a/examples/data_quality/pandera/feature_logic.py
+++ b/examples/data_quality/pandera/feature_logic.py
@@ -95,7 +95,7 @@ def seasons_encoded__base(seasons: pd.Series) -> pd.DataFrame:
     3 - third season
     4 - fourth season
     """
-    return pd.get_dummies(seasons, prefix="seasons")
+    return pd.get_dummies(seasons, prefix="seasons", dtype=np.uint8)
 
 
 @check_output(schema=seasons_encoded_schema)
@@ -110,7 +110,7 @@ def seasons_encoded__dask(seasons: pd.Series) -> pd.DataFrame:
     import dask.dataframe as dd
 
     categorized = seasons.astype(str).to_frame().categorize()
-    df = dd.get_dummies(categorized, prefix="seasons")
+    df = dd.get_dummies(categorized, prefix="seasons", dtype=np.uint8)
     return df
 
 
@@ -165,7 +165,7 @@ def day_of_week_encoded__base(day_of_the_week: pd.Series) -> pd.DataFrame:
     """One hot encodes day of week into five dimensions -- Saturday & Sunday weren't present.
     1 - Sunday, 2 - Monday, 3 - Tuesday, 4 - Wednesday, 5 - Thursday, 6 - Friday, 7 - Saturday.
     """
-    return pd.get_dummies(day_of_the_week, prefix="day_of_the_week")
+    return pd.get_dummies(day_of_the_week, prefix="day_of_the_week", dtype=np.uint8)
 
 
 @check_output(schema=day_of_week_encoded_schema)
@@ -177,7 +177,7 @@ def day_of_week_encoded__dask(day_of_the_week: pd.Series) -> pd.DataFrame:
     import dask.dataframe as dd
 
     categorized = day_of_the_week.astype(str).to_frame().categorize()
-    df = dd.get_dummies(categorized, prefix="day_of_the_week")
+    df = dd.get_dummies(categorized, prefix="day_of_the_week", dtype=np.uint8)
     return df
 
 

--- a/examples/data_quality/pandera/feature_logic_spark.py
+++ b/examples/data_quality/pandera/feature_logic_spark.py
@@ -87,7 +87,7 @@ def seasons_encoded(seasons: pd.Series) -> pd.DataFrame:
     3 - third season
     4 - fourth season
     """
-    return ps.get_dummies(seasons, prefix="seasons")
+    return ps.get_dummies(seasons, prefix="seasons", dtype=np.uint8)
 
 
 seasons_schema = pa.SeriesSchema(
@@ -140,7 +140,7 @@ def day_of_week_encoded(day_of_the_week: pd.Series) -> pd.DataFrame:
     """One hot encodes day of week into five dimensions -- Saturday & Sunday weren't present.
     1 - Sunday, 2 - Monday, 3 - Tuesday, 4 - Wednesday, 5 - Thursday, 6 - Friday, 7 - Saturday.
     """
-    return ps.get_dummies(day_of_the_week, prefix="day_of_the_week")
+    return ps.get_dummies(day_of_the_week, prefix="day_of_the_week", dtype=np.uint8)
 
 
 day_of_week_schema = pa.SeriesSchema(


### PR DESCRIPTION
- #227

## Changes

- The `dtype` argument has been added to all uses of `get_dummies`, as the default value changed in pandas v2

## How I tested this

- `python run.py` no longer produces errors

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.