### PR TITLE
Documentation: Rename subheaders in Reference section

### DIFF
--- a/docs/reference/decorators/index.rst
+++ b/docs/reference/decorators/index.rst
@@ -1,6 +1,6 @@
-===================
-Decorator Reference
-===================
+=========
+Decorators
+=========
 
 While the 1:1 mapping of output -> function implementation is powerful, we've implemented a few decorators to promote
 business-logic reuse, as well as to layer on extra capabilities. Source for these decorators can be found in the

--- a/docs/reference/decorators/index.rst
+++ b/docs/reference/decorators/index.rst
@@ -1,6 +1,6 @@
-=========
+===========
 Decorators
-=========
+===========
 
 While the 1:1 mapping of output -> function implementation is powerful, we've implemented a few decorators to promote
 business-logic reuse, as well as to layer on extra capabilities. Source for these decorators can be found in the

--- a/docs/reference/drivers/index.rst
+++ b/docs/reference/drivers/index.rst
@@ -1,6 +1,6 @@
-===================
-Driver Reference
-===================
+======
+Drivers
+======
 
 Currently, we have one `main driver <https://github.com/dagworks-inc/hamilton/blob/main/hamilton/driver.py>`__.
 It's highly parameterizable, allowing you to customize:

--- a/docs/reference/drivers/index.rst
+++ b/docs/reference/drivers/index.rst
@@ -1,6 +1,6 @@
-======
+=======
 Drivers
-======
+=======
 
 Currently, we have one `main driver <https://github.com/dagworks-inc/hamilton/blob/main/hamilton/driver.py>`__.
 It's highly parameterizable, allowing you to customize:

--- a/docs/reference/drivers/index.rst
+++ b/docs/reference/drivers/index.rst
@@ -1,6 +1,6 @@
-=======
+========
 Drivers
-=======
+========
 
 Currently, we have one `main driver <https://github.com/dagworks-inc/hamilton/blob/main/hamilton/driver.py>`__.
 It's highly parameterizable, allowing you to customize:

--- a/docs/reference/graph-adapters/index.rst
+++ b/docs/reference/graph-adapters/index.rst
@@ -1,6 +1,6 @@
-======================
-GraphAdapter Reference
-======================
+==============
+GraphAdapters
+==============
 
 This section helps determine ways to execute Hamilton.
 

--- a/docs/reference/result-builders/index.rst
+++ b/docs/reference/result-builders/index.rst
@@ -1,6 +1,6 @@
-=======================
-ResultBuilder Reference
-=======================
+===============
+ResultBuilders
+===============
 This section helps determine what comes out of the box for determining how to construct a return type from ``execute``.
 
 .. toctree::


### PR DESCRIPTION
This PR was copied from sweepai-dev#11 and generated by [Sweep](https://github.com/sweepai/sweep).
Resolves #217.

---
## Description
This PR addresses issue #217 by renaming the subheaders in the `Reference` section of the documentation. The subheaders `Decorator Reference`, `Driver Reference`, `GraphAdapter Reference`, and `ResultBuilder Reference` have been shortened to `Decorators`, `Drivers`, `GraphAdapters`, and `ResultBuilders`, respectively. This change improves readability and reduces redundancy in the documentation.

## Summary of Changes
- Modified `index.rst` file under `docs/reference/decorators`:
  - Changed subheader title from `Decorator Reference` to `Decorators`.
- Modified `index.rst` file under `docs/reference/drivers`:
  - Changed subheader title from `Driver Reference` to `Drivers`.
- Modified `index.rst` file under `docs/reference/graph-adapters`:
  - Changed subheader title from `GraphAdapter Reference` to `GraphAdapters`.
- Modified `index.rst` file under `docs/reference/result-builders`:
  - Changed subheader title from `ResultBuilder Reference` to `ResultBuilders`.

Fixes #217.