### PR TITLE
Adds google collab gdrive mounting instructions to HW

### DIFF
--- a/examples/hello_world/my_notebook.ipynb
+++ b/examples/hello_world/my_notebook.ipynb
@@ -1,17 +1,53 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "source": [
+    "Uncomment and run the cell below if you are in a Google Colab environment. It will:\n",
+    "1. Mount google drive. You will be asked to authenticate and give permissions.\n",
+    "2. Change directory to google drive.\n",
+    "3. Make a directory \"hamilton-tutorials\"\n",
+    "4. Change directory to it.\n",
+    "5. Clone this repository to your google drive\n",
+    "6. Move your current directory to the hello_world example\n",
+    "7. Install requirements.\n",
+    "\n",
+    "This means that any modifications will be saved, and you won't lose them if you close your browser."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "## 1. Mount google drive\n",
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')\n",
+    "## 2. Change directory to google drive.\n",
+    "# %cd /content/drive/MyDrive\n",
+    "## 3. Make a directory \"hamilton-tutorials\"\n",
+    "# !mkdir hamilton-tutorials\n",
+    "## 4. Change directory to it.\n",
+    "# %cd hamilton-tutorials\n",
+    "## 5. Clone this repository to your google drive\n",
+    "# !git clone https://github.com/DAGWorks-Inc/hamilton/\n",
+    "## 6. Move your current directory to the hello_world example\n",
+    "# %cd hamilton/examples/hello_world\n",
+    "## 7. Install requirements.\n",
+    "# %pip install -r requirements.txt\n",
+    "# clear_output()  # optionally clear outputs\n",
+    "# To check your current working directory you can type `!pwd` in a cell and run it."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2023-05-22T22:27:16.952106Z",
-     "start_time": "2023-05-22T22:27:15.116241Z"
-    }
-   },
    "outputs": [],
    "source": [
     "# Cell 1 - import the things you need\n",
@@ -24,7 +60,14 @@
     "from hamilton import ad_hoc_utils, driver\n",
     "\n",
     "logging.basicConfig(stream=sys.stdout)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-05-22T22:27:16.952106Z",
+     "start_time": "2023-05-22T22:27:15.116241Z"
+    }
+   }
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
So that people don't lose their work in case they want to play around with Hamilton in google collab. I.e. by default google collab only allows you to create files locally in the VM it is running on. Thus to share work/modifications you need to really use google drive / commit things in git and push them...

## Changes
 - hello world notebook

## How I tested this
 - tried it out on google collab with another notebook

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
