### PR TITLE
Fixes SparkSession import

### DIFF
--- a/hamilton/plugins/spark_extensions.py
+++ b/hamilton/plugins/spark_extensions.py
@@ -8,7 +8,7 @@ except ImportError:
     raise NotImplementedError("Pyspark is not installed.")
 
 from pandas import DataFrame
-from pyspark.sql.connect.session import SparkSession
+from pyspark.sql import SparkSession
 
 from hamilton import registry
 from hamilton.io import utils

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "ray": ["ray>=2.0.0", "pyarrow"],
         "pyspark": [
             # we have to run these dependencies cause Spark does not check to ensure the right target was called
-            "pyspark[pandas_on_spark,connect,sql]",
+            "pyspark[pandas_on_spark,sql]",
             # This is problematic, see https://stackoverflow.com/questions/76072664/convert-pyspark-dataframe-to-pandas-dataframe-fails-on-timestamp-column
             "pandas<2.0",
         ],  # I'm sure they'll add support soon,


### PR DESCRIPTION
It was pulling it in via non-official module import. The correct way is the simpler one.
https://spark.apache.org/docs/3.4.1/sql-getting-started.html#starting-point-sparksession

## Changes
 - fixes SparkSession import

## How I tested this
 - ran spark examples locally

## Notes
 - https://spark.apache.org/docs/3.4.1/sql-getting-started.html#starting-point-sparksession

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
