### PR TITLE
Fixes error message if no combine is passed to materializer

### DIFF
--- a/hamilton/io/materialization.py
+++ b/hamilton/io/materialization.py
@@ -107,8 +107,8 @@ class MaterializerFactory:
         if self.result_builder is None:
             if len(node_dependencies) != 1:
                 raise ValueError(
-                    "Must specify result builder if the materializer has more than one dependency "
-                    "it is materializing. Otherwise we have no way to join them before storage! "
+                    "Must specify result builder via combine= key word argument if the materializer has more than "
+                    "one dependency it is materializing. Otherwise we have no way to join them and know what to pass! "
                     f"See materializer {self.id}."
                 )
             save_dep = node_dependencies[0]


### PR DESCRIPTION
I had a typo and the error was cryptic. This fixes that to explain that the `combine=` kwarg needs to be used.

## Changes
 - materialization.py

## How I tested this
 - locally

## Notes
 - I don't like `_build_result` being the default node name post combine.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
