### PR TITLE
Fixes broken unit test for materializers

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+import sys
 from io import BufferedReader, BytesIO
 from pathlib import Path
 from typing import Any, Collection, Dict, Optional, Tuple, Type, Union
@@ -185,6 +186,13 @@ class PandasPickleReader(DataLoader):
         return "pickle"
 
 
+# for python 3.7 compatibility
+if sys.version_info < (3, 8):
+    pickle_protocol_default = 4
+else:
+    pickle_protocol_default = 5
+
+
 @dataclasses.dataclass
 class PandasPickleWriter(DataSaver):
     """Class that handles saving pickle files with pandas.
@@ -194,7 +202,7 @@ class PandasPickleWriter(DataSaver):
     path: Union[str, Path, BytesIO, BufferedReader]
     # kwargs:
     compression: Union[str, Dict[str, Any], None] = "infer"
-    protocol: int = 5
+    protocol: int = pickle_protocol_default
     storage_options: Optional[Dict[str, Any]] = None
 
     @classmethod

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -27,13 +27,14 @@ def test_default_adapters_are_available():
 def test_default_adapters_are_registered_once():
     assert "json" in LOADER_REGISTRY
     count_unique = {
-        key: Counter([value.__class__.__qualname__ for value in values])
+        # we want str() of the class to get the fully qualified class name.
+        key: Counter([str(value) for value in values])
         for key, values in LOADER_REGISTRY.items()
     }
     for key, value_ in count_unique.items():
         for impl, count in value_.items():
             assert count == 1, (
-                f"Adapter registered multiple times for {impl}. This should not"
+                f"Adapter for {key} registered multiple times for {impl}. This should not"
                 f" happen, as items should just be registered once."
             )
 


### PR DESCRIPTION
The name it was getting before was ABCmeta... rather than the fully qualified class name. It seemed the simplest to just str() the object as it includes the fully qualified name in the class that way.

## Changes
 - fixes broken unit test for materializer registration

## How I tested this
 - locally

## Notes
 - not sure how this worked in the first place...?

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
