### PR TITLE
Adds Polars Jupyter Notebook example for e.g., data scientists

### DIFF
--- a/examples/polars/notebook.ipynb
+++ b/examples/polars/notebook.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Uncomment and run the cell below if you are in a Google Colab environment. It will:\n",
+    "1. Mount google drive. You will be asked to authenticate and give permissions.\n",
+    "2. Change directory to google drive.\n",
+    "3. Make a directory \"hamilton-tutorials\"\n",
+    "4. Change directory to it.\n",
+    "5. Clone this repository to your google drive\n",
+    "6. Move your current directory to the hello_world example\n",
+    "7. Install requirements.\n",
+    "\n",
+    "This means that any modifications will be saved, and you won't lose them if you close your browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "## 1. Mount google drive\n",
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')\n",
+    "## 2. Change directory to google drive.\n",
+    "# %cd /content/drive/MyDrive\n",
+    "## 3. Make a directory \"hamilton-tutorials\"\n",
+    "# !mkdir hamilton-tutorials\n",
+    "## 4. Change directory to it.\n",
+    "# %cd hamilton-tutorials\n",
+    "## 5. Clone this repository to your google drive\n",
+    "# !git clone https://github.com/DAGWorks-Inc/hamilton/\n",
+    "## 6. Move your current directory to the hello_world example\n",
+    "# %cd hamilton/examples/hello_world\n",
+    "## 7. Install requirements.\n",
+    "# %pip install -r requirements.txt\n",
+    "# clear_output()  # optionally clear outputs\n",
+    "# To check your current working directory you can type `!pwd` in a cell and run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Cell 2 - import modules to create part of the DAG from\n",
+    "# We use the autoreload extension that comes with ipython to automatically reload modules when\n",
+    "# the code in them changes.\n",
+    "\n",
+    "# import the jupyter extension\n",
+    "%load_ext autoreload\n",
+    "# set it to only reload the modules imported\n",
+    "%autoreload 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import polars as pl\n",
+    "\n",
+    "from hamilton import (\n",
+    "    ad_hoc_utils,\n",
+    "    base,\n",
+    "    driver,\n",
+    ")\n",
+    "from hamilton.function_modifiers import extract_columns\n",
+    "from hamilton.plugins import h_polars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# We'll place the spend calculations into a new module\n",
+    "\n",
+    "@extract_columns(\"signups\", \"spend\")\n",
+    "def base_df(base_df_location: str) -> pl.DataFrame:\n",
+    "    \"\"\"Loads base dataframe of data.\n",
+    "\n",
+    "    :param base_df_location: just showing that we could load this from a file...\n",
+    "    :return:\n",
+    "    \"\"\"\n",
+    "    return pl.DataFrame(\n",
+    "        {\n",
+    "            \"signups\": pl.Series([1, 10, 50, 100, 200, 400]),\n",
+    "            \"spend\": pl.Series([10, 10, 20, 40, 40, 50]),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "def avg_3wk_spend(spend: pl.Series) -> pl.Series:\n",
+    "    \"\"\"Rolling 3 week average spend.\"\"\"\n",
+    "    return spend.rolling_mean(3)\n",
+    "\n",
+    "def spend_per_signup(spend: pl.Series, signups: pl.Series) -> pl.Series:\n",
+    "    \"\"\"The cost per signup in relation to spend.\"\"\"\n",
+    "    return spend / signups\n",
+    "\n",
+    "def spend_mean(spend: pl.Series) -> float:\n",
+    "    \"\"\"Shows function creating a scalar. In this case it computes the mean of the entire column.\"\"\"\n",
+    "    return spend.mean()\n",
+    "\n",
+    "def spend_zero_mean(spend: pl.Series, spend_mean: float) -> pl.Series:\n",
+    "    \"\"\"Shows function that takes a scalar. In this case to zero mean spend.\"\"\"\n",
+    "    return spend - spend_mean\n",
+    "\n",
+    "def spend_std_dev(spend: pl.Series) -> float:\n",
+    "    \"\"\"Function that computes the standard deviation of the spend column.\"\"\"\n",
+    "    return spend.std()\n",
+    "\n",
+    "def spend_zero_mean_unit_variance(spend_zero_mean: pl.Series, spend_std_dev: float) -> pl.Series:\n",
+    "    \"\"\"Function showing one way to make spend have zero mean and unit variance.\"\"\"\n",
+    "    return spend_zero_mean / spend_std_dev\n",
+    "\n",
+    "spend_calculations = ad_hoc_utils.create_temporary_module(\n",
+    "    base_df,\n",
+    "    avg_3wk_spend,\n",
+    "    spend_per_signup,\n",
+    "    spend_mean,\n",
+    "    spend_zero_mean,\n",
+    "    spend_std_dev,\n",
+    "    spend_zero_mean_unit_variance,\n",
+    "    module_name=\"spend_calculations\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Note: Hamilton collects completely anonymous data about usage. This will help us improve Hamilton over time. See https://github.com/dagworks-inc/hamilton#usage-analytics--data-privacy for details.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set up the driver, input and output columns\n",
+    "config = {\n",
+    "    \"base_df_location\": \"dummy_value\",\n",
+    "}\n",
+    "adapter = base.SimplePythonGraphAdapter(result_builder=h_polars.PolarsDataFrameResult())\n",
+    "dr = driver.Driver(config, spend_calculations, adapter=adapter)\n",
+    "output_columns = [\n",
+    "    \"spend\",\n",
+    "    \"signups\",\n",
+    "    \"avg_3wk_spend\",\n",
+    "    \"spend_per_signup\",\n",
+    "    \"spend_zero_mean_unit_variance\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (6, 5)\n",
+      "┌───────┬─────────┬───────────────┬──────────────────┬───────────────────────────────┐\n",
+      "│ spend ┆ signups ┆ avg_3wk_spend ┆ spend_per_signup ┆ spend_zero_mean_unit_variance │\n",
+      "│ ---   ┆ ---     ┆ ---           ┆ ---              ┆ ---                           │\n",
+      "│ i64   ┆ i64     ┆ f64           ┆ f64              ┆ f64                           │\n",
+      "╞═══════╪═════════╪═══════════════╪══════════════════╪═══════════════════════════════╡\n",
+      "│ 10    ┆ 1       ┆ null          ┆ 10.0             ┆ -1.064405                     │\n",
+      "│ 10    ┆ 10      ┆ null          ┆ 1.0              ┆ -1.064405                     │\n",
+      "│ 20    ┆ 50      ┆ 13.333333     ┆ 0.4              ┆ -0.483821                     │\n",
+      "│ 40    ┆ 100     ┆ 23.333333     ┆ 0.4              ┆ 0.677349                      │\n",
+      "│ 40    ┆ 200     ┆ 33.333333     ┆ 0.2              ┆ 0.677349                      │\n",
+      "│ 50    ┆ 400     ┆ 43.333333     ┆ 0.125            ┆ 1.257934                      │\n",
+      "└───────┴─────────┴───────────────┴──────────────────┴───────────────────────────────┘\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 8.1.0 (20230707.0739)\n",
+       " -->\n",
+       "<!-- Pages: 1 -->\n",
+       "<svg width=\"532pt\" height=\"404pt\"\n",
+       " viewBox=\"0.00 0.00 531.77 404.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 400)\">\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-400 527.77,-400 527.77,4 -4,4\"/>\n",
+       "<!-- base_df -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>base_df</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"172.97\" cy=\"-306\" rx=\"39.58\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"172.97\" y=\"-300.95\" font-family=\"Times,serif\" font-size=\"14.00\">base_df</text>\n",
+       "</g>\n",
+       "<!-- signups -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>signups</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"128.97\" cy=\"-234\" rx=\"39.07\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"128.97\" y=\"-228.95\" font-family=\"Times,serif\" font-size=\"14.00\">signups</text>\n",
+       "</g>\n",
+       "<!-- base_df&#45;&gt;signups -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>base_df&#45;&gt;signups</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M162.54,-288.41C157.33,-280.13 150.92,-269.92 145.1,-260.66\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"147.6,-259.07 139.32,-252.47 141.68,-262.8 147.6,-259.07\"/>\n",
+       "</g>\n",
+       "<!-- spend -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>spend</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"225.97\" cy=\"-234\" rx=\"32.41\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"225.97\" y=\"-228.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend</text>\n",
+       "</g>\n",
+       "<!-- base_df&#45;&gt;spend -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>base_df&#45;&gt;spend</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M185.26,-288.76C191.75,-280.19 199.85,-269.49 207.11,-259.9\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"210.49,-262.23 213.74,-252.15 204.91,-258.01 210.49,-262.23\"/>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean_unit_variance -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>spend_zero_mean_unit_variance</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"264.97\" cy=\"-18\" rx=\"132.73\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"264.97\" y=\"-12.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_zero_mean_unit_variance</text>\n",
+       "</g>\n",
+       "<!-- base_df_location -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>base_df_location</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" cx=\"172.97\" cy=\"-378\" rx=\"98.44\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"172.97\" y=\"-372.95\" font-family=\"Times,serif\" font-size=\"14.00\">Input: base_df_location</text>\n",
+       "</g>\n",
+       "<!-- base_df_location&#45;&gt;base_df -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>base_df_location&#45;&gt;base_df</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M172.97,-359.7C172.97,-352.24 172.97,-343.32 172.97,-334.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"176.47,-335.1 172.97,-325.1 169.47,-335.1 176.47,-335.1\"/>\n",
+       "</g>\n",
+       "<!-- spend_std_dev -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>spend_std_dev</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"183.97\" cy=\"-90\" rx=\"65.68\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"183.97\" y=\"-84.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_std_dev</text>\n",
+       "</g>\n",
+       "<!-- spend_std_dev&#45;&gt;spend_zero_mean_unit_variance -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>spend_std_dev&#45;&gt;spend_zero_mean_unit_variance</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M203.16,-72.41C213.23,-63.71 225.75,-52.89 236.88,-43.27\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"238.78,-45.39 244.06,-36.2 234.21,-40.09 238.78,-45.39\"/>\n",
+       "</g>\n",
+       "<!-- spend_per_signup -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>spend_per_signup</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"77.97\" cy=\"-162\" rx=\"77.97\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"77.97\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_per_signup</text>\n",
+       "</g>\n",
+       "<!-- signups&#45;&gt;spend_per_signup -->\n",
+       "<g id=\"edge12\" class=\"edge\">\n",
+       "<title>signups&#45;&gt;spend_per_signup</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M116.88,-216.41C110.87,-208.16 103.47,-198.01 96.75,-188.78\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"99.04,-186.98 90.32,-180.96 93.38,-191.1 99.04,-186.98\"/>\n",
+       "</g>\n",
+       "<!-- spend_mean -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>spend_mean</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"268.97\" cy=\"-162\" rx=\"57.49\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"268.97\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_mean</text>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>spend_zero_mean</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"345.97\" cy=\"-90\" rx=\"77.97\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"345.97\" y=\"-84.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_zero_mean</text>\n",
+       "</g>\n",
+       "<!-- spend_mean&#45;&gt;spend_zero_mean -->\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
+       "<title>spend_mean&#45;&gt;spend_zero_mean</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M286.82,-144.76C296.52,-135.95 308.71,-124.87 319.49,-115.07\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"321.35,-118.19 326.4,-108.88 316.65,-113.02 321.35,-118.19\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_std_dev -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_std_dev</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M217.62,-216.15C212.81,-205.89 206.94,-192.42 202.97,-180 196.56,-160 191.69,-136.79 188.48,-119.08\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"191.77,-118.58 186.61,-109.33 184.87,-119.78 191.77,-118.58\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_mean -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_mean</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M236.16,-216.41C241.17,-208.25 247.33,-198.22 252.95,-189.07\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"256.3,-191.31 258.55,-180.96 250.33,-187.65 256.3,-191.31\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_zero_mean -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_zero_mean</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M256.11,-226.75C281.43,-219.83 316.37,-206.02 334.97,-180 347.41,-162.59 349.66,-138.21 349.08,-119.37\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"352.52,-119.24 348.42,-109.47 345.53,-119.66 352.52,-119.24\"/>\n",
+       "</g>\n",
+       "<!-- avg_3wk_spend -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>avg_3wk_spend</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"452.97\" cy=\"-162\" rx=\"70.8\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"452.97\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">avg_3wk_spend</text>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;avg_3wk_spend -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;avg_3wk_spend</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M253.8,-224.42C289.83,-213.31 353.38,-193.71 399.02,-179.64\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"399.81,-182.75 408.33,-176.46 397.74,-176.06 399.81,-182.75\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_per_signup -->\n",
+       "<g id=\"edge11\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_per_signup</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M201.86,-221.6C180,-211.26 147.26,-195.77 120.93,-183.32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"122.72,-179.82 112.18,-178.71 119.73,-186.15 122.72,-179.82\"/>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean&#45;&gt;spend_zero_mean_unit_variance -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>spend_zero_mean&#45;&gt;spend_zero_mean_unit_variance</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M326.77,-72.41C316.7,-63.71 304.18,-52.89 293.05,-43.27\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"295.72,-40.09 285.87,-36.2 291.15,-45.39 295.72,-40.09\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ],
+      "text/plain": [
+       "<graphviz.graphs.Digraph at 0x13149e990>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Execute the driver.\n",
+    "\n",
+    "df = dr.execute(output_columns)\n",
+    "print(df)\n",
+    "\n",
+    "# To visualize do `pip install \"sf-hamilton[visualization]\"` if you want these to work\n",
+    "dr.visualize_execution(output_columns, './polars', {\"format\": \"png\"})\n",
+    "dr.display_all_functions('./my_full_dag.dot')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This adds a Jupyter Notebook example for e.g., data scientists to read instead of the Python code. The notebook emulates the `examples/polars/my_script.py` module.

## Changes
Adds Jupyter Notebook to the `examples/polars` directory.

## How I tested this
Successfully ran all unit tests locally using the following command in the root directory: `pytest tests/`

## Notes
This is a work in progress. I intend to add a table of contents and headings to make it a little easier to read.

## Checklist
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
