### PR TITLE
Adds Polars Jupyter Notebook for e.g., data scientists to read

### DIFF
--- a/examples/polars/notebook.ipynb
+++ b/examples/polars/notebook.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "## 1. Mount google drive\n",
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')\n",
+    "## 2. Change directory to google drive.\n",
+    "# %cd /content/drive/MyDrive\n",
+    "## 3. Make a directory \"hamilton-tutorials\"\n",
+    "# !mkdir hamilton-tutorials\n",
+    "## 4. Change directory to it.\n",
+    "# %cd hamilton-tutorials\n",
+    "## 5. Clone this repository to your google drive\n",
+    "# !git clone https://github.com/DAGWorks-Inc/hamilton/\n",
+    "## 6. Move your current directory to the hello_world example\n",
+    "# %cd hamilton/examples/hello_world\n",
+    "## 7. Install requirements.\n",
+    "# %pip install -r requirements.txt\n",
+    "# clear_output()  # optionally clear outputs\n",
+    "# To check your current working directory you can type `!pwd` in a cell and run it."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Cell 2 - import modules to create part of the DAG from\n",
+    "# We use the autoreload extension that comes with ipython to automatically reload modules when\n",
+    "# the code in them changes.\n",
+    "\n",
+    "# import the jupyter extension\n",
+    "%load_ext autoreload\n",
+    "# set it to only reload the modules imported\n",
+    "%autoreload 1"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import polars as pl\n",
+    "\n",
+    "from hamilton import (\n",
+    "    ad_hoc_utils,\n",
+    "    base,\n",
+    "    driver,\n",
+    ")\n",
+    "from hamilton.function_modifiers import extract_columns\n",
+    "from hamilton.plugins import h_polars"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# We'll place the spend calculations into a new module\n",
+    "\n",
+    "@extract_columns(\"signups\", \"spend\")\n",
+    "def base_df(base_df_location: str) -> pl.DataFrame:\n",
+    "    \"\"\"Loads base dataframe of data.\n",
+    "\n",
+    "    :param base_df_location: just showing that we could load this from a file...\n",
+    "    :return:\n",
+    "    \"\"\"\n",
+    "    return pl.DataFrame(\n",
+    "        {\n",
+    "            \"signups\": pl.Series([1, 10, 50, 100, 200, 400]),\n",
+    "            \"spend\": pl.Series([10, 10, 20, 40, 40, 50]),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "def avg_3wk_spend(spend: pl.Series) -> pl.Series:\n",
+    "    \"\"\"Rolling 3 week average spend.\"\"\"\n",
+    "    return spend.rolling_mean(3)\n",
+    "\n",
+    "def spend_per_signup(spend: pl.Series, signups: pl.Series) -> pl.Series:\n",
+    "    \"\"\"The cost per signup in relation to spend.\"\"\"\n",
+    "    return spend / signups\n",
+    "\n",
+    "def spend_mean(spend: pl.Series) -> float:\n",
+    "    \"\"\"Shows function creating a scalar. In this case it computes the mean of the entire column.\"\"\"\n",
+    "    return spend.mean()\n",
+    "\n",
+    "def spend_zero_mean(spend: pl.Series, spend_mean: float) -> pl.Series:\n",
+    "    \"\"\"Shows function that takes a scalar. In this case to zero mean spend.\"\"\"\n",
+    "    return spend - spend_mean\n",
+    "\n",
+    "def spend_std_dev(spend: pl.Series) -> float:\n",
+    "    \"\"\"Function that computes the standard deviation of the spend column.\"\"\"\n",
+    "    return spend.std()\n",
+    "\n",
+    "def spend_zero_mean_unit_variance(spend_zero_mean: pl.Series, spend_std_dev: float) -> pl.Series:\n",
+    "    \"\"\"Function showing one way to make spend have zero mean and unit variance.\"\"\"\n",
+    "    return spend_zero_mean / spend_std_dev\n",
+    "\n",
+    "spend_calculations = ad_hoc_utils.create_temporary_module(\n",
+    "    base_df,\n",
+    "    avg_3wk_spend,\n",
+    "    spend_per_signup,\n",
+    "    spend_mean,\n",
+    "    spend_zero_mean,\n",
+    "    spend_std_dev,\n",
+    "    spend_zero_mean_unit_variance,\n",
+    "    module_name=\"spend_calculations\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Set up the driver, input and output columns\n",
+    "config = {\n",
+    "    \"base_df_location\": \"dummy_value\",\n",
+    "}\n",
+    "adapter = base.SimplePythonGraphAdapter(result_builder=h_polars.PolarsDataFrameResult())\n",
+    "dr = driver.Driver(config, spend_calculations, adapter=adapter)\n",
+    "output_columns = [\n",
+    "    \"spend\",\n",
+    "    \"signups\",\n",
+    "    \"avg_3wk_spend\",\n",
+    "    \"spend_per_signup\",\n",
+    "    \"spend_zero_mean_unit_variance\",\n",
+    "]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Execute the driver.\n",
+    "\n",
+    "df = dr.execute(output_columns)\n",
+    "print(df)\n",
+    "\n",
+    "# To visualize do `pip install \"sf-hamilton[visualization]\"` if you want these to work\n",
+    "dr.visualize_execution(output_columns, './polars', {\"format\": \"png\"})\n",
+    "dr.display_all_functions('./my_full_dag.dot')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [
+     "%% md\n",
+     "\n",
+     "Uncomment and run the cell below if you are in a Google Colab environment. It will:\n",
+     "1. Mount google drive. You will be asked to authenticate and give permissions.\n",
+     "2. Change directory to google drive.\n",
+     "3. Make a directory \"hamilton-tutorials\"\n",
+     "4. Change directory to it.\n",
+     "5. Clone this repository to your google drive\n",
+     "6. Move your current directory to the hello_world example\n",
+     "7. Install requirements.\n",
+     "\n",
+     "This means that any modifications will be saved, and you won't lose them if you close your browser.\n"
+    ],
+    "metadata": {
+     "collapsed": false
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This adds a Jupyter Notebook example for e.g., data scientists to read instead of the Python code. The notebook emulates the `examples/polars/my_script.py` module.

## Changes
Adds Jupyter Notebook to the `examples/polars` directory.

## How I tested this
Successfully ran all unit tests locally using the following command in the root directory: `pytest tests/`

## Notes
This is a work in progress. I intend to add a table of contents and headings to make it a little easier to read.

## Checklist
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
