### PR TITLE
Adds Pandas JSON reader for off-the-shelf data loading support

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -229,6 +229,28 @@ class PandasPickleWriter(DataSaver):
         return "pickle"
 
 
+@dataclasses.dataclass
+class PandasJsonReader(DataLoader):
+    """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
+    data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
+    you can subclass this or open up an issue if this doesn't have what you want."""
+
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def load_data(self, type_: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
+        df = pd.read_json(self.path)
+        metadata = utils.get_file_metadata(self.path)
+        return df, metadata
+
+    @classmethod
+    def name(cls) -> str:
+        return "json"
+
+
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
     for loader in [

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -232,7 +232,7 @@ class PandasPickleWriter(DataSaver):
 @dataclasses.dataclass
 class PandasJsonLoader(DataLoader):
     """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
-    data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
+    data loading params (e.g., precise_float, encoding). We will be adding this in over time, but for now
     you can subclass this or open up an issue if this doesn't have what you want."""
 
     path: str

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -248,7 +248,7 @@ class PandasJsonLoader(DataLoader):
 
     @classmethod
     def name(cls) -> str:
-        return "json"
+        return "pandas_json"
 
 
 def register_data_loaders():

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -330,6 +330,7 @@ def register_data_loaders():
         ParquetDataLoader,
         PandasPickleReader,
         PandasPickleWriter,
+        PandasJsonLoader,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -241,7 +241,7 @@ class PandasPickleWriter(DataSaver):
 
 
 @dataclasses.dataclass
-class PandasJsonLoader(DataLoader):
+class PandasJsonDataLoader(DataLoader):
     """Data loader for JSON files using Pandas.
 
     Disclaimer: We're exposing all the *current* params from the Pandas read_json method.
@@ -330,7 +330,7 @@ def register_data_loaders():
         ParquetDataLoader,
         PandasPickleReader,
         PandasPickleWriter,
-        PandasJsonLoader,
+        PandasJsonDataLoader,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -244,12 +244,10 @@ class PandasPickleWriter(DataSaver):
 class PandasJsonLoader(DataLoader):
     """Data loader for JSON files using Pandas.
 
-    Disclaimer: We're exposing all the *current* params from the Pandas read_json method [1].
+    Disclaimer: We're exposing all the *current* params from the Pandas read_json method.
     There's a chance some of these params may get deprecated or new params may be introduced.
     In the event that the params/kwargs below become outdated, please raise an issue or submit
     a pull request.
-
-    [1]: https://github.com/pandas-dev/pandas/blob/v2.1.0/pandas/io/json/_json.py#L500-L804
     """
 
     filepath_or_buffer: Union[FilePath, ReadBuffer[str], ReadBuffer[bytes]]

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -230,7 +230,7 @@ class PandasPickleWriter(DataSaver):
 
 
 @dataclasses.dataclass
-class PandasJsonReader(DataLoader):
+class PandasJsonLoader(DataLoader):
     """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
     data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
     you can subclass this or open up an issue if this doesn't have what you want."""

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,9 +1,15 @@
+import pathlib
+
 import pandas as pd
 
-from hamilton.plugins.pandas_extensions import PandasPickleReader, PandasPickleWriter
+from hamilton.plugins.pandas_extensions import (
+    PandasJsonDataLoader,
+    PandasPickleReader,
+    PandasPickleWriter,
+)
 
 
-def test_pandas_pickle(tmp_path):
+def test_pandas_pickle(tmp_path: pathlib.Path) -> None:
     data = {
         "name": ["ladybird", "butterfly", "honeybee"],
         "num_caught": [4, 5, 6],
@@ -23,3 +29,14 @@ def test_pandas_pickle(tmp_path):
 
     # correct number of files returned
     assert len(list(tmp_path.iterdir())) == 1, "Unexpected number of files in tmp_path directory."
+
+
+def test_pandas_json_loader(tmp_path: pathlib.Path) -> None:
+    file_path = "tests/resources/data/test_load_from_data.json"
+    loader = PandasJsonDataLoader(filepath_or_buffer=file_path, encoding="utf-8")
+    kwargs = loader._get_loading_kwargs()
+    df, metadata = loader.load_data(pd.DataFrame)
+    assert PandasJsonDataLoader.applicable_types() == [pd.DataFrame]
+    assert kwargs["encoding"] == "utf-8"
+    assert df.shape == (3, 1)
+    assert metadata["path"] == file_path

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -31,7 +31,7 @@ def test_pandas_pickle(tmp_path: pathlib.Path) -> None:
     assert len(list(tmp_path.iterdir())) == 1, "Unexpected number of files in tmp_path directory."
 
 
-def test_pandas_json_loader(tmp_path: pathlib.Path) -> None:
+def test_pandas_json_data_loader(tmp_path: pathlib.Path) -> None:
     file_path = "tests/resources/data/test_load_from_data.json"
     loader = PandasJsonDataLoader(filepath_or_buffer=file_path, encoding="utf-8")
     kwargs = loader._get_loading_kwargs()


### PR DESCRIPTION
This is an extension of the Pandas `read_json` method found ([here](https://pandas.pydata.org/docs/reference/api/pandas.read_json.html#pandas.read_json)).

## Changes
- `hamilton/plugins/pandas_extensions.py`
- `tests/plugins/test_pandas_extensions.py`

## How I tested this
Successfully ran unit tests locally using the following command in the root directory: `pytest tests/`

## Notes
N/A

## Checklist
I'm unsure where to find the project documentation, so I left it unchecked.
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
