### PR TITLE
Adds Pandas JSON writer for off-the-shelf data saving support

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -229,6 +229,28 @@ class PandasPickleWriter(DataSaver):
         return "pickle"
 
 
+@dataclasses.dataclass
+class PandasJsonReader(DataLoader):
+    """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
+    data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
+    you can subclass this or open up an issue if this doesn't have what you want."""
+
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def load_data(self, type_: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
+        df = pd.read_json(self.path)
+        metadata = utils.get_file_metadata(self.path)
+        return df, metadata
+
+    @classmethod
+    def name(cls) -> str:
+        return "json"
+
+
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
     for loader in [

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -251,6 +251,27 @@ class PandasJsonReader(DataLoader):
         return "json"
 
 
+@dataclasses.dataclass
+class PandasJsonSaver(DataSaver):
+    """Data saver for JSON files using Pandas. Note that this currently does not support the wide array of
+    data saving params (e.g., orient, date_unit). We will be adding this in over time, but for now
+    you can subclass this or open up an issue if this doesn't have what you want."""
+
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
+        data.to_json(self.path)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "pandas_json"
+
+
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
     for loader in [


### PR DESCRIPTION
This is an extension of the Pandas `to_json` method found ([here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html#pandas.DataFrame.to_json)).

## Changes
Updates `hamilton/plugins/pandas_extensions.py`

## How I tested this
Successfully ran unit tests locally using the following command in the root directory: `pytest tests/`

## Notes
I opted not to include the buffer as an option to read from vs. just a string file path (e.g., pandas pickle reader). The `utils.get_file_metadata` function and buffers do not work well together (e.g., _TypeError: stat: path should be string, bytes, os.PathLike or integer, not BytesIO_). Additionally, we could always add buffers as an option later if needed. Let me know your thoughts; I am open to all feedback!

## Checklist
This is a draft PR, so the checklist will not be completed intentionally.
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.