### PR TITLE
Adds Pandas JSON writer for off-the-shelf data saving support

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -229,6 +229,27 @@ class PandasPickleWriter(DataSaver):
         return "pickle"
 
 
+@dataclasses.dataclass
+class PandasJsonSaver(DataSaver):
+    """Data saver for JSON files using Pandas. Note that this currently does not support the wide array of
+    data saving params (e.g., orient, date_unit). We will be adding this in over time, but for now
+    you can subclass this or open up an issue if this doesn't have what you want."""
+
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
+        data.to_json(self.path)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "pandas_json"
+
+
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
     for loader in [

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -239,7 +239,7 @@ class PandasPickleWriter(DataSaver):
 
 
 @dataclasses.dataclass
-class PandasJsonSaver(DataSaver):
+class PandasJsonDataSaver(DataSaver):
     """Data saver for Pandas DataFrame to JSON file/buffer method.
 
     Disclaimer: We're exposing all the *current* params from the Pandas DataFrame.to_json method.
@@ -311,6 +311,7 @@ def register_data_loaders():
         ParquetDataLoader,
         PandasPickleReader,
         PandasPickleWriter,
+        PandasJsonDataSaver,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -231,7 +231,7 @@ class PandasPickleWriter(DataSaver):
 
 @dataclasses.dataclass
 class PandasJsonSaver(DataSaver):
-    """Data saver for JSON files using Pandas. Note that this currently does not support the wide array of
+    """Data saver for Pandas DataFrames to JSON file. Note that this currently does not support the wide array of
     data saving params (e.g., orient, date_unit). We will be adding this in over time, but for now
     you can subclass this or open up an issue if this doesn't have what you want."""
 

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,6 +1,12 @@
+import pathlib
+
 import pandas as pd
 
-from hamilton.plugins.pandas_extensions import PandasPickleReader, PandasPickleWriter
+from hamilton.plugins.pandas_extensions import (
+    PandasJsonDataSaver,
+    PandasPickleReader,
+    PandasPickleWriter,
+)
 
 
 def test_pandas_pickle(tmp_path):
@@ -23,3 +29,15 @@ def test_pandas_pickle(tmp_path):
 
     # correct number of files returned
     assert len(list(tmp_path.iterdir())) == 1, "Unexpected number of files in tmp_path directory."
+
+
+def test_pandas_json_data_saver(tmp_path: pathlib.Path) -> None:
+    data = {"foo": ["bar"]}
+    df = pd.DataFrame(data)
+    path = tmp_path / "test.json"
+    saver = PandasJsonDataSaver(filepath_or_buffer=path, indent=4)
+    kwargs = saver._get_saving_kwargs()
+    metadata = saver.save_data(df)
+    assert PandasJsonDataSaver.applicable_types() == [pd.DataFrame]
+    assert kwargs["indent"] == 4
+    assert metadata["path"] == path

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -34,10 +34,12 @@ def test_pandas_pickle(tmp_path):
 def test_pandas_json_data_saver(tmp_path: pathlib.Path) -> None:
     data = {"foo": ["bar"]}
     df = pd.DataFrame(data)
-    path = tmp_path / "test.json"
-    saver = PandasJsonDataSaver(filepath_or_buffer=path, indent=4)
+    filepath = tmp_path / "test.json"
+    saver = PandasJsonDataSaver(filepath_or_buffer=filepath, indent=4)
     kwargs = saver._get_saving_kwargs()
+    assert not filepath.exists()
     metadata = saver.save_data(df)
     assert PandasJsonDataSaver.applicable_types() == [pd.DataFrame]
     assert kwargs["indent"] == 4
-    assert metadata["path"] == path
+    assert metadata["path"] == filepath
+    assert filepath.exists()


### PR DESCRIPTION
This is an extension of the Pandas `to_json` method found ([here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html#pandas.DataFrame.to_json)).

## Changes
- `hamilton/plugins/pandas_extensions.py`
- `tests/plugins/test_pandas_extensions.py`

## How I tested this
Successfully ran unit tests locally using the following command in the root directory: `pytest tests/`

## Notes
N/A

## Checklist
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.