### PR TITLE
Adds Pandas JSON data loaders

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -229,6 +229,28 @@ class PandasPickleWriter(DataSaver):
         return "pickle"
 
 
+@dataclasses.dataclass
+class PandasJsonReader(DataLoader):
+    """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
+    data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
+    you can subclass this or open up an issue if this doesn't have what you want."""
+
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def load_data(self, type_: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
+        df = pd.read_json(self.path)
+        metadata = utils.get_file_metadata(self.path)
+        return df, metadata
+
+    @classmethod
+    def name(cls) -> str:
+        return "json"
+
+
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
     for loader in [

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -232,7 +232,7 @@ class PandasPickleWriter(DataSaver):
 @dataclasses.dataclass
 class PandasJsonLoader(DataLoader):
     """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
-    data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
+    data loading params (e.g., precise_float, encoding). We will be adding this in over time, but for now
     you can subclass this or open up an issue if this doesn't have what you want."""
 
     path: str

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -248,7 +248,7 @@ class PandasJsonLoader(DataLoader):
 
     @classmethod
     def name(cls) -> str:
-        return "json"
+        return "pandas_json"
 
 
 def register_data_loaders():

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -330,6 +330,7 @@ def register_data_loaders():
         ParquetDataLoader,
         PandasPickleReader,
         PandasPickleWriter,
+        PandasJsonLoader,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -241,7 +241,7 @@ class PandasPickleWriter(DataSaver):
 
 
 @dataclasses.dataclass
-class PandasJsonLoader(DataLoader):
+class PandasJsonDataLoader(DataLoader):
     """Data loader for JSON files using Pandas.
 
     Disclaimer: We're exposing all the *current* params from the Pandas read_json method.
@@ -330,7 +330,7 @@ def register_data_loaders():
         ParquetDataLoader,
         PandasPickleReader,
         PandasPickleWriter,
-        PandasJsonLoader,
+        PandasJsonDataLoader,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -327,7 +327,7 @@ class PandasJsonWriter(DataSaver):
     Should map to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html
     """
 
-    filepath_or_buffer: Optional[Union[str, Path, BytesIO, BufferedReader]]
+    filepath_or_buffer: Union[str, Path, BytesIO, BufferedReader]
     # kwargs
     compression: str = "infer"
     date_format: str = "epoch"

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -244,12 +244,10 @@ class PandasPickleWriter(DataSaver):
 class PandasJsonLoader(DataLoader):
     """Data loader for JSON files using Pandas.
 
-    Disclaimer: We're exposing all the *current* params from the Pandas read_json method [1].
+    Disclaimer: We're exposing all the *current* params from the Pandas read_json method.
     There's a chance some of these params may get deprecated or new params may be introduced.
     In the event that the params/kwargs below become outdated, please raise an issue or submit
     a pull request.
-
-    [1]: https://github.com/pandas-dev/pandas/blob/v2.1.0/pandas/io/json/_json.py#L500-L804
     """
 
     filepath_or_buffer: Union[FilePath, ReadBuffer[str], ReadBuffer[bytes]]

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -244,17 +244,19 @@ class PandasPickleWriter(DataSaver):
 
 
 @dataclasses.dataclass
-class PandasJsonDataLoader(DataLoader):
-    """Data loader for JSON files using Pandas.
+class PandasJsonReader(DataLoader):
+    """Class specifically to handle loading JSON files/buffers with Pandas.
 
     Disclaimer: We're exposing all the *current* params from the Pandas read_json method.
     There's a chance some of these params may get deprecated or new params may be introduced.
     In the event that the params/kwargs below become outdated, please raise an issue or submit
     a pull request.
+
+    Should map to https://pandas.pydata.org/docs/reference/api/pandas.read_json.html
     """
 
     filepath_or_buffer: Union[FilePath, ReadBuffer[str], ReadBuffer[bytes]]
-
+    # kwargs
     chunksize: Optional[int] = None
     compression: CompressionOptions = "infer"
     convert_axes: Optional[bool] = None
@@ -281,37 +283,37 @@ class PandasJsonDataLoader(DataLoader):
         kwargs = {}
         if self.chunksize is not None:
             kwargs["chunksize"] = self.chunksize
-        if self.compression != "infer":
+        if self.compression is not None:
             kwargs["compression"] = self.compression
         if self.convert_axes is not None:
             kwargs["convert_axes"] = self.convert_axes
-        if self.convert_dates is not True:
+        if self.convert_dates is not None:
             kwargs["convert_dates"] = self.convert_dates
         if self.date_unit is not None:
             kwargs["date_unit"] = self.date_unit
         if self.dtype is not None:
             kwargs["dtype"] = self.dtype
-        if self.dtype_backend != lib.no_default:
+        if self.dtype_backend is not None:
             kwargs["dtype_backend"] = self.dtype_backend
         if self.encoding is not None:
             kwargs["encoding"] = self.encoding
-        if self.encoding_errors != "strict":
+        if self.encoding_errors is not None:
             kwargs["encoding_errors"] = self.encoding_errors
         if self.engine is not None:
             kwargs["engine"] = self.engine
-        if self.keep_default_dates is not True:
+        if self.keep_default_dates is not None:
             kwargs["keep_default_dates"] = self.keep_default_dates
-        if self.lines is not False:
+        if self.lines is not None:
             kwargs["lines"] = self.lines
         if self.nrows is not None:
             kwargs["nrows"] = self.nrows
         if self.orient is not None:
             kwargs["orient"] = self.orient
-        if self.precise_float is not False:
+        if self.precise_float is not None:
             kwargs["precise_float"] = self.precise_float
         if self.storage_options is not None:
             kwargs["storage_options"] = self.storage_options
-        if self.typ != "frame":
+        if self.typ is not None:
             kwargs["typ"] = self.typ
         return kwargs
 
@@ -326,16 +328,18 @@ class PandasJsonDataLoader(DataLoader):
 
 
 @dataclasses.dataclass
-class PandasJsonDataSaver(DataSaver):
-    """Data saver for Pandas DataFrame to JSON file/buffer method.
+class PandasJsonWriter(DataSaver):
+    """Class specifically to handle saving JSON files/buffers with Pandas.
 
     Disclaimer: We're exposing all the *current* params from the Pandas DataFrame.to_json method.
     Some of these params may get deprecated or new params may be introduced. In the event that
     the params/kwargs below become outdated, please raise an issue or submit a pull request.
+
+    Should map to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html
     """
 
     filepath_or_buffer: Optional[Union[FilePath, WriteBuffer[bytes], WriteBuffer[str]]] = None
-
+    # kwargs
     compression: CompressionOptions = "infer"
     date_format: Optional[str] = None
     date_unit: TimeUnit = "ms"
@@ -355,17 +359,17 @@ class PandasJsonDataSaver(DataSaver):
 
     def _get_saving_kwargs(self):
         kwargs = {}
-        if self.compression != "infer":
+        if self.compression is not None:
             kwargs["compression"] = self.compression
         if self.date_format is not None:
             kwargs["date_format"] = self.date_format
-        if self.date_unit != "ms":
+        if self.date_unit is not None:
             kwargs["date_unit"] = self.date_unit
         if self.default_handler is not None:
             kwargs["default_handler"] = self.default_handler
-        if self.double_precision != 10:
+        if self.double_precision is not None:
             kwargs["double_precision"] = self.double_precision
-        if self.force_ascii is not True:
+        if self.force_ascii is not None:
             kwargs["force_ascii"] = self.force_ascii
         if self.index is not None:
             kwargs["index"] = self.index
@@ -373,7 +377,7 @@ class PandasJsonDataSaver(DataSaver):
             kwargs["indent"] = self.indent
         if self.lines is not False:
             kwargs["lines"] = self.lines
-        if self.mode != "w":
+        if self.mode is not None:
             kwargs["mode"] = self.mode
         if self.orient is not None:
             kwargs["orient"] = self.orient
@@ -398,8 +402,8 @@ def register_data_loaders():
         ParquetDataLoader,
         PandasPickleReader,
         PandasPickleWriter,
-        PandasJsonDataLoader,
-        PandasJsonDataSaver,
+        PandasJsonReader,
+        PandasJsonWriter,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -230,7 +230,7 @@ class PandasPickleWriter(DataSaver):
 
 
 @dataclasses.dataclass
-class PandasJsonReader(DataLoader):
+class PandasJsonLoader(DataLoader):
     """Data loader for JSON files using Pandas. Note that this currently does not support the wide array of
     data loading functionality (e.g., precise_float, encoding). We will be adding this in over time, but for now
     you can subclass this or open up an issue if this doesn't have what you want."""

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,9 +1,15 @@
+import pathlib
+
 import pandas as pd
 
-from hamilton.plugins.pandas_extensions import PandasPickleReader, PandasPickleWriter
+from hamilton.plugins.pandas_extensions import (
+    PandasJsonDataLoader,
+    PandasPickleReader,
+    PandasPickleWriter,
+)
 
 
-def test_pandas_pickle(tmp_path):
+def test_pandas_pickle(tmp_path: pathlib.Path) -> None:
     data = {
         "name": ["ladybird", "butterfly", "honeybee"],
         "num_caught": [4, 5, 6],
@@ -23,3 +29,14 @@ def test_pandas_pickle(tmp_path):
 
     # correct number of files returned
     assert len(list(tmp_path.iterdir())) == 1, "Unexpected number of files in tmp_path directory."
+
+
+def test_pandas_json_loader(tmp_path: pathlib.Path) -> None:
+    file_path = "tests/resources/data/test_load_from_data.json"
+    loader = PandasJsonDataLoader(filepath_or_buffer=file_path, encoding="utf-8")
+    kwargs = loader._get_loading_kwargs()
+    df, metadata = loader.load_data(pd.DataFrame)
+    assert PandasJsonDataLoader.applicable_types() == [pd.DataFrame]
+    assert kwargs["encoding"] == "utf-8"
+    assert df.shape == (3, 1)
+    assert metadata["path"] == file_path

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -3,8 +3,8 @@ import pathlib
 import pandas as pd
 
 from hamilton.plugins.pandas_extensions import (
-    PandasJsonDataLoader,
-    PandasJsonDataSaver,
+    PandasJsonReader,
+    PandasJsonWriter,
     PandasPickleReader,
     PandasPickleWriter,
 )
@@ -32,25 +32,24 @@ def test_pandas_pickle(tmp_path: pathlib.Path) -> None:
     assert len(list(tmp_path.iterdir())) == 1, "Unexpected number of files in tmp_path directory."
 
 
-def test_pandas_json_data_loader(tmp_path: pathlib.Path) -> None:
+def test_pandas_json_reader(tmp_path: pathlib.Path) -> None:
     file_path = "tests/resources/data/test_load_from_data.json"
-    loader = PandasJsonDataLoader(filepath_or_buffer=file_path, encoding="utf-8")
-    kwargs = loader._get_loading_kwargs()
-    df, metadata = loader.load_data(pd.DataFrame)
-    assert PandasJsonDataLoader.applicable_types() == [pd.DataFrame]
+    reader = PandasJsonReader(filepath_or_buffer=file_path, encoding="utf-8")
+    kwargs = reader._get_loading_kwargs()
+    df, metadata = reader.load_data(pd.DataFrame)
+    assert PandasJsonReader.applicable_types() == [pd.DataFrame]
     assert kwargs["encoding"] == "utf-8"
     assert df.shape == (3, 1)
     assert metadata["path"] == file_path
 
 
-def test_pandas_json_data_saver(tmp_path: pathlib.Path) -> None:
+def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
     df = pd.DataFrame({"foo": ["bar"]})
     file_path = tmp_path / "test.json"
-    saver = PandasJsonDataSaver(filepath_or_buffer=file_path, indent=4)
-    kwargs = saver._get_saving_kwargs()
-    assert not file_path.exists()
-    metadata = saver.save_data(df)
-    assert file_path.exists()
-    assert PandasJsonDataSaver.applicable_types() == [pd.DataFrame]
+    writer = PandasJsonWriter(filepath_or_buffer=file_path, indent=4)
+    kwargs = writer._get_saving_kwargs()
+    metadata = writer.save_data(df)
+    assert PandasJsonWriter.applicable_types() == [pd.DataFrame]
     assert kwargs["indent"] == 4
+    assert file_path.exists()
     assert metadata["path"] == file_path

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -31,7 +31,7 @@ def test_pandas_pickle(tmp_path: pathlib.Path) -> None:
     assert len(list(tmp_path.iterdir())) == 1, "Unexpected number of files in tmp_path directory."
 
 
-def test_pandas_json_loader(tmp_path: pathlib.Path) -> None:
+def test_pandas_json_data_loader(tmp_path: pathlib.Path) -> None:
     file_path = "tests/resources/data/test_load_from_data.json"
     loader = PandasJsonDataLoader(filepath_or_buffer=file_path, encoding="utf-8")
     kwargs = loader._get_loading_kwargs()

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -44,11 +44,10 @@ def test_pandas_json_reader(tmp_path: pathlib.Path) -> None:
 
 
 def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
-    df = pd.DataFrame({"foo": ["bar"]})
     file_path = tmp_path / "test.json"
     writer = PandasJsonWriter(filepath_or_buffer=file_path, indent=4)
     kwargs = writer._get_saving_kwargs()
-    metadata = writer.save_data(df)
+    metadata = writer.save_data(pd.DataFrame({"foo": ["bar"]}))
     assert PandasJsonWriter.applicable_types() == [pd.DataFrame]
     assert kwargs["indent"] == 4
     assert file_path.exists()

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -45,12 +45,12 @@ def test_pandas_json_data_loader(tmp_path: pathlib.Path) -> None:
 
 def test_pandas_json_data_saver(tmp_path: pathlib.Path) -> None:
     df = pd.DataFrame({"foo": ["bar"]})
-    filepath = tmp_path / "test.json"
-    saver = PandasJsonDataSaver(filepath_or_buffer=filepath, indent=4)
+    file_path = tmp_path / "test.json"
+    saver = PandasJsonDataSaver(filepath_or_buffer=file_path, indent=4)
     kwargs = saver._get_saving_kwargs()
-    assert not filepath.exists()
+    assert not file_path.exists()
     metadata = saver.save_data(df)
-    assert filepath.exists()
+    assert file_path.exists()
     assert PandasJsonDataSaver.applicable_types() == [pd.DataFrame]
     assert kwargs["indent"] == 4
-    assert metadata["path"] == filepath
+    assert metadata["path"] == file_path


### PR DESCRIPTION
This change introduces an extension of the Pandas `read_json` method found ([here](https://pandas.pydata.org/docs/reference/api/pandas.read_json.html#pandas.read_json)) and the Pandas `to_json` method found ([here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html#pandas.DataFrame.to_json)).

## Changes
- `hamilton/plugins/pandas_extensions.py`
- `tests/plugins/test_pandas_extensions.py`

## How I tested this
- Successfully ran unit tests for py3.11 locally using the following command in the root directory: `pytest tests/`
- Successfully ran unit tests for py3.7-3.10 using docker run command found [here](https://github.com/DAGWorks-Inc/hamilton/blob/main/developer_setup.md#running-tests-in-docker).

## Notes
N/A

## Checklist
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.