### PR TITLE
adding the PandasXml Reader and Writer Class

### DIFF
--- a/examples/pandas/materialization/my_script.py
+++ b/examples/pandas/materialization/my_script.py
@@ -46,6 +46,12 @@ materializers = [
         filepath_or_buffer="./df.json",
         combine=df_builder,
     ),
+    to.xml(
+        dependencies=output_columns,
+        id="df_to_xml",
+        filepath_or_buffer="./df.xml",
+        combine=df_builder,
+    ),
 ]
 # Visualize what is happening
 dr.visualize_materialization(
@@ -61,9 +67,11 @@ materialization_results, additional_outputs = dr.materialize(
     additional_vars=[
         "df_to_pickle_build_result",
         "df_to_json_build_result",
+        "df_to_xml_build_result",
     ],  # because combine is used, we can get that result here.
     inputs=initial_columns,
 )
 print(materialization_results)
 print(additional_outputs["df_to_pickle_build_result"])
 print(additional_outputs["df_to_json_build_result"])
+print(additional_outputs["df_to_xml_build_result"])

--- a/examples/pandas/materialization/notebook.ipynb
+++ b/examples/pandas/materialization/notebook.ipynb
@@ -2,14 +2,26 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.094340Z",
      "start_time": "2023-09-15T06:12:54.077090Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'hamilton'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mimport\u001b[39;00m \u001b[39mpandas\u001b[39;00m \u001b[39mas\u001b[39;00m \u001b[39mpd\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[39mimport\u001b[39;00m \u001b[39mhamilton\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[39m#from hamilton import base, driver\u001b[39;00m\n\u001b[1;32m      4\u001b[0m \u001b[39m#from hamilton.io.materialization import to\u001b[39;00m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'hamilton'"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -19,26 +31,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 4,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.095446Z",
      "start_time": "2023-09-15T06:12:54.083089Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We use the autoreload extension that comes with ipython to automatically reload modules when\n",
     "# the code in them changes.\n",
@@ -51,14 +54,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.172281Z",
      "start_time": "2023-09-15T06:12:54.089798Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
    "outputs": [
@@ -66,7 +69,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Overwriting spend_calculations.py\n"
+      "Writing spend_calculations.py\n"
      ]
     }
    ],
@@ -112,14 +115,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.174815Z",
      "start_time": "2023-09-15T06:12:54.097253Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -133,17 +136,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.176684Z",
      "start_time": "2023-09-15T06:12:54.107160Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'spending_functions'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m get_ipython()\u001b[39m.\u001b[39;49mrun_line_magic(\u001b[39m'\u001b[39;49m\u001b[39maimport\u001b[39;49m\u001b[39m'\u001b[39;49m, \u001b[39m'\u001b[39;49m\u001b[39mspending_functions\u001b[39;49m\u001b[39m'\u001b[39;49m)\n\u001b[1;32m      3\u001b[0m df_builder \u001b[39m=\u001b[39m base\u001b[39m.\u001b[39mPandasDataFrameResult()\n\u001b[1;32m      4\u001b[0m dr \u001b[39m=\u001b[39m driver\u001b[39m.\u001b[39mDriver({}, spending_functions)  \u001b[39m# can pass in multiple modules\u001b[39;00m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/IPython/core/interactiveshell.py:2432\u001b[0m, in \u001b[0;36mInteractiveShell.run_line_magic\u001b[0;34m(self, magic_name, line, _stack_depth)\u001b[0m\n\u001b[1;32m   2430\u001b[0m     kwargs[\u001b[39m'\u001b[39m\u001b[39mlocal_ns\u001b[39m\u001b[39m'\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mget_local_scope(stack_depth)\n\u001b[1;32m   2431\u001b[0m \u001b[39mwith\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mbuiltin_trap:\n\u001b[0;32m-> 2432\u001b[0m     result \u001b[39m=\u001b[39m fn(\u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m   2434\u001b[0m \u001b[39m# The code below prevents the output from being displayed\u001b[39;00m\n\u001b[1;32m   2435\u001b[0m \u001b[39m# when using magics with decorator @output_can_be_silenced\u001b[39;00m\n\u001b[1;32m   2436\u001b[0m \u001b[39m# when the last Python token in the expression is a ';'.\u001b[39;00m\n\u001b[1;32m   2437\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mgetattr\u001b[39m(fn, magic\u001b[39m.\u001b[39mMAGIC_OUTPUT_CAN_BE_SILENCED, \u001b[39mFalse\u001b[39;00m):\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/IPython/extensions/autoreload.py:699\u001b[0m, in \u001b[0;36mAutoreloadMagics.aimport\u001b[0;34m(self, parameter_s, stream)\u001b[0m\n\u001b[1;32m    697\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_reloader\u001b[39m.\u001b[39mmark_module_skipped(_module)\n\u001b[1;32m    698\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 699\u001b[0m     top_module, top_name \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_reloader\u001b[39m.\u001b[39;49maimport_module(_module)\n\u001b[1;32m    701\u001b[0m     \u001b[39m# Inject module to user namespace\u001b[39;00m\n\u001b[1;32m    702\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mshell\u001b[39m.\u001b[39mpush({top_name: top_module})\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/IPython/extensions/autoreload.py:205\u001b[0m, in \u001b[0;36mModuleReloader.aimport_module\u001b[0;34m(self, module_name)\u001b[0m\n\u001b[1;32m    193\u001b[0m \u001b[39m\"\"\"Import a module, and mark it reloadable\u001b[39;00m\n\u001b[1;32m    194\u001b[0m \n\u001b[1;32m    195\u001b[0m \u001b[39mReturns\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    201\u001b[0m \n\u001b[1;32m    202\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    203\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmark_module_reloadable(module_name)\n\u001b[0;32m--> 205\u001b[0m import_module(module_name)\n\u001b[1;32m    206\u001b[0m top_name \u001b[39m=\u001b[39m module_name\u001b[39m.\u001b[39msplit(\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39m\u001b[39m\"\u001b[39m)[\u001b[39m0\u001b[39m]\n\u001b[1;32m    207\u001b[0m top_module \u001b[39m=\u001b[39m sys\u001b[39m.\u001b[39mmodules[top_name]\n",
+      "File \u001b[0;32m/usr/lib/python3.10/importlib/__init__.py:126\u001b[0m, in \u001b[0;36mimport_module\u001b[0;34m(name, package)\u001b[0m\n\u001b[1;32m    124\u001b[0m             \u001b[39mbreak\u001b[39;00m\n\u001b[1;32m    125\u001b[0m         level \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39m1\u001b[39m\n\u001b[0;32m--> 126\u001b[0m \u001b[39mreturn\u001b[39;00m _bootstrap\u001b[39m.\u001b[39;49m_gcd_import(name[level:], package, level)\n",
+      "File \u001b[0;32m<frozen importlib._bootstrap>:1050\u001b[0m, in \u001b[0;36m_gcd_import\u001b[0;34m(name, package, level)\u001b[0m\n",
+      "File \u001b[0;32m<frozen importlib._bootstrap>:1027\u001b[0m, in \u001b[0;36m_find_and_load\u001b[0;34m(name, import_)\u001b[0m\n",
+      "File \u001b[0;32m<frozen importlib._bootstrap>:1004\u001b[0m, in \u001b[0;36m_find_and_load_unlocked\u001b[0;34m(name, import_)\u001b[0m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'spending_functions'"
+     ]
+    }
+   ],
    "source": [
     "%aimport spending_functions\n",
     "\n",
@@ -153,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.189802Z",
@@ -174,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.328399Z",
@@ -184,8 +206,221 @@
    "outputs": [
     {
      "data": {
-      "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 8.1.0 (20230707.0739)\n -->\n<!-- Pages: 1 -->\n<svg width=\"578pt\" height=\"404pt\"\n viewBox=\"0.00 0.00 578.46 404.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 400)\">\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-400 574.46,-400 574.46,4 -4,4\"/>\n<!-- df_to_pickle_build_result -->\n<g id=\"node1\" class=\"node\">\n<title>df_to_pickle_build_result</title>\n<ellipse fill=\"none\" stroke=\"black\" cx=\"106.11\" cy=\"-90\" rx=\"106.11\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"106.11\" y=\"-84.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_pickle_build_result</text>\n</g>\n<!-- df_to_pickle -->\n<g id=\"node8\" class=\"node\">\n<title>df_to_pickle</title>\n<polygon fill=\"none\" stroke=\"black\" points=\"148.24,-36 63.99,-36 63.99,0 148.24,0 148.24,-36\"/>\n<text text-anchor=\"middle\" x=\"106.11\" y=\"-12.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_pickle</text>\n</g>\n<!-- df_to_pickle_build_result&#45;&gt;df_to_pickle -->\n<g id=\"edge19\" class=\"edge\">\n<title>df_to_pickle_build_result&#45;&gt;df_to_pickle</title>\n<path fill=\"none\" stroke=\"black\" d=\"M106.11,-71.7C106.11,-64.24 106.11,-55.32 106.11,-46.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"109.61,-47.1 106.11,-37.1 102.61,-47.1 109.61,-47.1\"/>\n</g>\n<!-- spend_zero_mean -->\n<g id=\"node2\" class=\"node\">\n<title>spend_zero_mean</title>\n<ellipse fill=\"none\" stroke=\"black\" cx=\"368.11\" cy=\"-234\" rx=\"77.97\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"368.11\" y=\"-228.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_zero_mean</text>\n</g>\n<!-- spend_zero_mean_unit_variance -->\n<g id=\"node7\" class=\"node\">\n<title>spend_zero_mean_unit_variance</title>\n<polygon fill=\"none\" stroke=\"black\" points=\"420.36,-180 225.86,-180 225.86,-144 420.36,-144 420.36,-180\"/>\n<text text-anchor=\"middle\" x=\"323.11\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_zero_mean_unit_variance</text>\n</g>\n<!-- spend_zero_mean&#45;&gt;spend_zero_mean_unit_variance -->\n<g id=\"edge17\" class=\"edge\">\n<title>spend_zero_mean&#45;&gt;spend_zero_mean_unit_variance</title>\n<path fill=\"none\" stroke=\"black\" d=\"M356.99,-215.7C351.87,-207.73 345.68,-198.1 340,-189.26\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"342.46,-187.62 334.11,-181.1 336.57,-191.41 342.46,-187.62\"/>\n</g>\n<!-- spend_mean -->\n<g id=\"node3\" class=\"node\">\n<title>spend_mean</title>\n<ellipse fill=\"none\" stroke=\"black\" cx=\"367.11\" cy=\"-306\" rx=\"57.49\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"367.11\" y=\"-300.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_mean</text>\n</g>\n<!-- spend_mean&#45;&gt;spend_zero_mean -->\n<g id=\"edge7\" class=\"edge\">\n<title>spend_mean&#45;&gt;spend_zero_mean</title>\n<path fill=\"none\" stroke=\"black\" d=\"M367.36,-287.7C367.47,-280.24 367.6,-271.32 367.72,-262.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"371.23,-263.15 367.87,-253.1 364.23,-263.05 371.23,-263.15\"/>\n</g>\n<!-- spend_std_dev -->\n<g id=\"node4\" class=\"node\">\n<title>spend_std_dev</title>\n<ellipse fill=\"none\" stroke=\"black\" cx=\"226.11\" cy=\"-306\" rx=\"65.68\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"226.11\" y=\"-300.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_std_dev</text>\n</g>\n<!-- spend_std_dev&#45;&gt;spend_zero_mean_unit_variance -->\n<g id=\"edge18\" class=\"edge\">\n<title>spend_std_dev&#45;&gt;spend_zero_mean_unit_variance</title>\n<path fill=\"none\" stroke=\"black\" d=\"M235.88,-287.89C246.46,-269.69 264.11,-240.24 281.11,-216 287.52,-206.87 294.96,-197.22 301.77,-188.69\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"305.02,-191.25 308.59,-181.27 299.58,-186.84 305.02,-191.25\"/>\n</g>\n<!-- spend_per_signup -->\n<g id=\"node5\" class=\"node\">\n<title>spend_per_signup</title>\n<polygon fill=\"none\" stroke=\"black\" points=\"170.24,-180 55.99,-180 55.99,-144 170.24,-144 170.24,-180\"/>\n<text text-anchor=\"middle\" x=\"113.11\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_per_signup</text>\n</g>\n<!-- spend_per_signup&#45;&gt;df_to_pickle_build_result -->\n<g id=\"edge4\" class=\"edge\">\n<title>spend_per_signup&#45;&gt;df_to_pickle_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M111.38,-143.7C110.64,-136.24 109.75,-127.32 108.91,-118.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"112.3,-118.71 107.83,-109.1 105.34,-119.4 112.3,-118.71\"/>\n</g>\n<!-- df_to_json_build_result -->\n<g id=\"node6\" class=\"node\">\n<title>df_to_json_build_result</title>\n<ellipse fill=\"none\" stroke=\"black\" cx=\"329.11\" cy=\"-90\" rx=\"98.95\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"329.11\" y=\"-84.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_json_build_result</text>\n</g>\n<!-- spend_per_signup&#45;&gt;df_to_json_build_result -->\n<g id=\"edge15\" class=\"edge\">\n<title>spend_per_signup&#45;&gt;df_to_json_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M167.06,-143.52C198.97,-133.18 239.36,-120.09 271.84,-109.56\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"272.65,-112.65 281.08,-106.24 270.49,-106 272.65,-112.65\"/>\n</g>\n<!-- df_to_json -->\n<g id=\"node12\" class=\"node\">\n<title>df_to_json</title>\n<polygon fill=\"none\" stroke=\"black\" points=\"365.99,-36 292.24,-36 292.24,0 365.99,0 365.99,-36\"/>\n<text text-anchor=\"middle\" x=\"329.11\" y=\"-12.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_json</text>\n</g>\n<!-- df_to_json_build_result&#45;&gt;df_to_json -->\n<g id=\"edge21\" class=\"edge\">\n<title>df_to_json_build_result&#45;&gt;df_to_json</title>\n<path fill=\"none\" stroke=\"black\" d=\"M329.11,-71.7C329.11,-64.24 329.11,-55.32 329.11,-46.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"332.61,-47.1 329.11,-37.1 325.61,-47.1 332.61,-47.1\"/>\n</g>\n<!-- spend_zero_mean_unit_variance&#45;&gt;df_to_pickle_build_result -->\n<g id=\"edge5\" class=\"edge\">\n<title>spend_zero_mean_unit_variance&#45;&gt;df_to_pickle_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M268.92,-143.52C237.09,-133.25 196.85,-120.27 164.35,-109.79\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"165.68,-106.21 155.09,-106.48 163.53,-112.88 165.68,-106.21\"/>\n</g>\n<!-- spend_zero_mean_unit_variance&#45;&gt;df_to_json_build_result -->\n<g id=\"edge16\" class=\"edge\">\n<title>spend_zero_mean_unit_variance&#45;&gt;df_to_json_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M324.6,-143.7C325.24,-136.24 326,-127.32 326.72,-118.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"330.28,-119.37 327.65,-109.1 323.31,-118.77 330.28,-119.37\"/>\n</g>\n<!-- signups -->\n<g id=\"node9\" class=\"node\">\n<title>signups</title>\n<polygon fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"233.74,-252 140.49,-252 140.49,-216 233.74,-216 233.74,-252\"/>\n<text text-anchor=\"middle\" x=\"187.11\" y=\"-228.95\" font-family=\"Times,serif\" font-size=\"14.00\">Input: signups</text>\n</g>\n<!-- signups&#45;&gt;df_to_pickle_build_result -->\n<g id=\"edge2\" class=\"edge\">\n<title>signups&#45;&gt;df_to_pickle_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M140.01,-228.72C108.01,-223.07 67.87,-210.04 47.11,-180 38.02,-166.83 40.6,-158.61 47.11,-144 52.23,-132.52 61.2,-122.49 70.62,-114.34\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"72.33,-116.65 77.93,-107.66 67.94,-111.2 72.33,-116.65\"/>\n</g>\n<!-- signups&#45;&gt;spend_per_signup -->\n<g id=\"edge11\" class=\"edge\">\n<title>signups&#45;&gt;spend_per_signup</title>\n<path fill=\"none\" stroke=\"black\" d=\"M168.82,-215.7C159.93,-207.28 149.08,-197.02 139.32,-187.79\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"142.12,-185.68 132.45,-181.35 137.31,-190.76 142.12,-185.68\"/>\n</g>\n<!-- signups&#45;&gt;df_to_json_build_result -->\n<g id=\"edge13\" class=\"edge\">\n<title>signups&#45;&gt;df_to_json_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M188.91,-215.59C191.76,-196.02 199.02,-164.35 217.11,-144 230.44,-129.01 248.92,-117.91 267.03,-109.86\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"268.13,-112.77 276.01,-105.69 265.44,-106.31 268.13,-112.77\"/>\n</g>\n<!-- spend -->\n<g id=\"node10\" class=\"node\">\n<title>spend</title>\n<polygon fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"408.86,-396 325.36,-396 325.36,-360 408.86,-360 408.86,-396\"/>\n<text text-anchor=\"middle\" x=\"367.11\" y=\"-372.95\" font-family=\"Times,serif\" font-size=\"14.00\">Input: spend</text>\n</g>\n<!-- spend&#45;&gt;df_to_pickle_build_result -->\n<g id=\"edge1\" class=\"edge\">\n<title>spend&#45;&gt;df_to_pickle_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M325.02,-377.53C273.31,-376.14 185.09,-366.95 125.11,-324 64.32,-280.46 58.18,-252.03 38.11,-180 33.82,-164.59 31.09,-158.38 38.11,-144 44.02,-131.92 54.15,-121.79 64.82,-113.73\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"66.63,-116.04 72.83,-107.45 62.62,-110.3 66.63,-116.04\"/>\n</g>\n<!-- spend&#45;&gt;spend_zero_mean -->\n<g id=\"edge6\" class=\"edge\">\n<title>spend&#45;&gt;spend_zero_mean</title>\n<path fill=\"none\" stroke=\"black\" d=\"M399.52,-359.64C412.48,-350.84 426,-338.84 433.11,-324 440.03,-309.57 439.98,-302.45 433.11,-288 427.36,-275.87 417.32,-265.61 406.83,-257.44\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"409.15,-254.08 398.99,-251.07 405.06,-259.76 409.15,-254.08\"/>\n</g>\n<!-- spend&#45;&gt;spend_mean -->\n<g id=\"edge8\" class=\"edge\">\n<title>spend&#45;&gt;spend_mean</title>\n<path fill=\"none\" stroke=\"black\" d=\"M367.11,-359.7C367.11,-352.24 367.11,-343.32 367.11,-334.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"370.61,-335.1 367.11,-325.1 363.61,-335.1 370.61,-335.1\"/>\n</g>\n<!-- spend&#45;&gt;spend_std_dev -->\n<g id=\"edge9\" class=\"edge\">\n<title>spend&#45;&gt;spend_std_dev</title>\n<path fill=\"none\" stroke=\"black\" d=\"M331.9,-359.52C311.99,-349.63 287.03,-337.24 266.35,-326.97\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"268.1,-323.44 257.58,-322.13 264.98,-329.71 268.1,-323.44\"/>\n</g>\n<!-- spend&#45;&gt;spend_per_signup -->\n<g id=\"edge10\" class=\"edge\">\n<title>spend&#45;&gt;spend_per_signup</title>\n<path fill=\"none\" stroke=\"black\" d=\"M325.11,-371.77C269.51,-364.02 175.64,-347.79 151.11,-324 115.22,-289.17 110.57,-227.22 111.28,-191.17\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"114.8,-191.56 111.66,-181.44 107.8,-191.31 114.8,-191.56\"/>\n</g>\n<!-- spend&#45;&gt;df_to_json_build_result -->\n<g id=\"edge12\" class=\"edge\">\n<title>spend&#45;&gt;df_to_json_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M409.35,-362.54C430.12,-353.84 454.42,-341.1 472.11,-324 534.94,-263.29 605.25,-212.58 551.11,-144 534.86,-123.41 476.06,-109.95 423.05,-101.74\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"423.6,-98.13 413.2,-100.12 422.57,-105.06 423.6,-98.13\"/>\n</g>\n<!-- avg_3wk_spend -->\n<g id=\"node11\" class=\"node\">\n<title>avg_3wk_spend</title>\n<polygon fill=\"none\" stroke=\"black\" points=\"541.99,-180 438.24,-180 438.24,-144 541.99,-144 541.99,-180\"/>\n<text text-anchor=\"middle\" x=\"490.11\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">avg_3wk_spend</text>\n</g>\n<!-- spend&#45;&gt;avg_3wk_spend -->\n<g id=\"edge20\" class=\"edge\">\n<title>spend&#45;&gt;avg_3wk_spend</title>\n<path fill=\"none\" stroke=\"black\" d=\"M406.09,-359.72C421.56,-351.06 438.23,-339.14 449.11,-324 478,-283.81 486.58,-225.16 489.1,-190.85\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"492.64,-191.41 489.75,-181.22 485.65,-190.99 492.64,-191.41\"/>\n</g>\n<!-- avg_3wk_spend&#45;&gt;df_to_pickle_build_result -->\n<g id=\"edge3\" class=\"edge\">\n<title>avg_3wk_spend&#45;&gt;df_to_pickle_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M437.97,-146.06C434.98,-145.33 432.01,-144.64 429.11,-144 385.5,-134.37 273.67,-116.59 193.83,-104.29\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"194.7,-100.73 184.28,-102.67 193.63,-107.65 194.7,-100.73\"/>\n</g>\n<!-- avg_3wk_spend&#45;&gt;df_to_json_build_result -->\n<g id=\"edge14\" class=\"edge\">\n<title>avg_3wk_spend&#45;&gt;df_to_json_build_result</title>\n<path fill=\"none\" stroke=\"black\" d=\"M449.9,-143.52C427.51,-133.78 399.51,-121.61 376.11,-111.43\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"377.63,-107.84 367.06,-107.06 374.84,-114.26 377.63,-107.84\"/>\n</g>\n</g>\n</svg>\n",
-      "text/plain": "<graphviz.graphs.Digraph at 0x167850490>"
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 8.1.0 (20230707.0739)\n",
+       " -->\n",
+       "<!-- Pages: 1 -->\n",
+       "<svg width=\"578pt\" height=\"404pt\"\n",
+       " viewBox=\"0.00 0.00 578.46 404.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 400)\">\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-400 574.46,-400 574.46,4 -4,4\"/>\n",
+       "<!-- df_to_pickle_build_result -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>df_to_pickle_build_result</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"106.11\" cy=\"-90\" rx=\"106.11\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"106.11\" y=\"-84.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_pickle_build_result</text>\n",
+       "</g>\n",
+       "<!-- df_to_pickle -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>df_to_pickle</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"148.24,-36 63.99,-36 63.99,0 148.24,0 148.24,-36\"/>\n",
+       "<text text-anchor=\"middle\" x=\"106.11\" y=\"-12.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_pickle</text>\n",
+       "</g>\n",
+       "<!-- df_to_pickle_build_result&#45;&gt;df_to_pickle -->\n",
+       "<g id=\"edge19\" class=\"edge\">\n",
+       "<title>df_to_pickle_build_result&#45;&gt;df_to_pickle</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M106.11,-71.7C106.11,-64.24 106.11,-55.32 106.11,-46.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"109.61,-47.1 106.11,-37.1 102.61,-47.1 109.61,-47.1\"/>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>spend_zero_mean</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"368.11\" cy=\"-234\" rx=\"77.97\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"368.11\" y=\"-228.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_zero_mean</text>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean_unit_variance -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>spend_zero_mean_unit_variance</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"420.36,-180 225.86,-180 225.86,-144 420.36,-144 420.36,-180\"/>\n",
+       "<text text-anchor=\"middle\" x=\"323.11\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_zero_mean_unit_variance</text>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean&#45;&gt;spend_zero_mean_unit_variance -->\n",
+       "<g id=\"edge17\" class=\"edge\">\n",
+       "<title>spend_zero_mean&#45;&gt;spend_zero_mean_unit_variance</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M356.99,-215.7C351.87,-207.73 345.68,-198.1 340,-189.26\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"342.46,-187.62 334.11,-181.1 336.57,-191.41 342.46,-187.62\"/>\n",
+       "</g>\n",
+       "<!-- spend_mean -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>spend_mean</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"367.11\" cy=\"-306\" rx=\"57.49\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"367.11\" y=\"-300.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_mean</text>\n",
+       "</g>\n",
+       "<!-- spend_mean&#45;&gt;spend_zero_mean -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>spend_mean&#45;&gt;spend_zero_mean</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M367.36,-287.7C367.47,-280.24 367.6,-271.32 367.72,-262.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"371.23,-263.15 367.87,-253.1 364.23,-263.05 371.23,-263.15\"/>\n",
+       "</g>\n",
+       "<!-- spend_std_dev -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>spend_std_dev</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"226.11\" cy=\"-306\" rx=\"65.68\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"226.11\" y=\"-300.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_std_dev</text>\n",
+       "</g>\n",
+       "<!-- spend_std_dev&#45;&gt;spend_zero_mean_unit_variance -->\n",
+       "<g id=\"edge18\" class=\"edge\">\n",
+       "<title>spend_std_dev&#45;&gt;spend_zero_mean_unit_variance</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M235.88,-287.89C246.46,-269.69 264.11,-240.24 281.11,-216 287.52,-206.87 294.96,-197.22 301.77,-188.69\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"305.02,-191.25 308.59,-181.27 299.58,-186.84 305.02,-191.25\"/>\n",
+       "</g>\n",
+       "<!-- spend_per_signup -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>spend_per_signup</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"170.24,-180 55.99,-180 55.99,-144 170.24,-144 170.24,-180\"/>\n",
+       "<text text-anchor=\"middle\" x=\"113.11\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">spend_per_signup</text>\n",
+       "</g>\n",
+       "<!-- spend_per_signup&#45;&gt;df_to_pickle_build_result -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>spend_per_signup&#45;&gt;df_to_pickle_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M111.38,-143.7C110.64,-136.24 109.75,-127.32 108.91,-118.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"112.3,-118.71 107.83,-109.1 105.34,-119.4 112.3,-118.71\"/>\n",
+       "</g>\n",
+       "<!-- df_to_json_build_result -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>df_to_json_build_result</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"329.11\" cy=\"-90\" rx=\"98.95\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"329.11\" y=\"-84.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_json_build_result</text>\n",
+       "</g>\n",
+       "<!-- spend_per_signup&#45;&gt;df_to_json_build_result -->\n",
+       "<g id=\"edge15\" class=\"edge\">\n",
+       "<title>spend_per_signup&#45;&gt;df_to_json_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M167.06,-143.52C198.97,-133.18 239.36,-120.09 271.84,-109.56\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"272.65,-112.65 281.08,-106.24 270.49,-106 272.65,-112.65\"/>\n",
+       "</g>\n",
+       "<!-- df_to_json -->\n",
+       "<g id=\"node12\" class=\"node\">\n",
+       "<title>df_to_json</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"365.99,-36 292.24,-36 292.24,0 365.99,0 365.99,-36\"/>\n",
+       "<text text-anchor=\"middle\" x=\"329.11\" y=\"-12.95\" font-family=\"Times,serif\" font-size=\"14.00\">df_to_json</text>\n",
+       "</g>\n",
+       "<!-- df_to_json_build_result&#45;&gt;df_to_json -->\n",
+       "<g id=\"edge21\" class=\"edge\">\n",
+       "<title>df_to_json_build_result&#45;&gt;df_to_json</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M329.11,-71.7C329.11,-64.24 329.11,-55.32 329.11,-46.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"332.61,-47.1 329.11,-37.1 325.61,-47.1 332.61,-47.1\"/>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean_unit_variance&#45;&gt;df_to_pickle_build_result -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>spend_zero_mean_unit_variance&#45;&gt;df_to_pickle_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M268.92,-143.52C237.09,-133.25 196.85,-120.27 164.35,-109.79\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"165.68,-106.21 155.09,-106.48 163.53,-112.88 165.68,-106.21\"/>\n",
+       "</g>\n",
+       "<!-- spend_zero_mean_unit_variance&#45;&gt;df_to_json_build_result -->\n",
+       "<g id=\"edge16\" class=\"edge\">\n",
+       "<title>spend_zero_mean_unit_variance&#45;&gt;df_to_json_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M324.6,-143.7C325.24,-136.24 326,-127.32 326.72,-118.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"330.28,-119.37 327.65,-109.1 323.31,-118.77 330.28,-119.37\"/>\n",
+       "</g>\n",
+       "<!-- signups -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>signups</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"233.74,-252 140.49,-252 140.49,-216 233.74,-216 233.74,-252\"/>\n",
+       "<text text-anchor=\"middle\" x=\"187.11\" y=\"-228.95\" font-family=\"Times,serif\" font-size=\"14.00\">Input: signups</text>\n",
+       "</g>\n",
+       "<!-- signups&#45;&gt;df_to_pickle_build_result -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>signups&#45;&gt;df_to_pickle_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M140.01,-228.72C108.01,-223.07 67.87,-210.04 47.11,-180 38.02,-166.83 40.6,-158.61 47.11,-144 52.23,-132.52 61.2,-122.49 70.62,-114.34\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"72.33,-116.65 77.93,-107.66 67.94,-111.2 72.33,-116.65\"/>\n",
+       "</g>\n",
+       "<!-- signups&#45;&gt;spend_per_signup -->\n",
+       "<g id=\"edge11\" class=\"edge\">\n",
+       "<title>signups&#45;&gt;spend_per_signup</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M168.82,-215.7C159.93,-207.28 149.08,-197.02 139.32,-187.79\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"142.12,-185.68 132.45,-181.35 137.31,-190.76 142.12,-185.68\"/>\n",
+       "</g>\n",
+       "<!-- signups&#45;&gt;df_to_json_build_result -->\n",
+       "<g id=\"edge13\" class=\"edge\">\n",
+       "<title>signups&#45;&gt;df_to_json_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M188.91,-215.59C191.76,-196.02 199.02,-164.35 217.11,-144 230.44,-129.01 248.92,-117.91 267.03,-109.86\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"268.13,-112.77 276.01,-105.69 265.44,-106.31 268.13,-112.77\"/>\n",
+       "</g>\n",
+       "<!-- spend -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>spend</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"408.86,-396 325.36,-396 325.36,-360 408.86,-360 408.86,-396\"/>\n",
+       "<text text-anchor=\"middle\" x=\"367.11\" y=\"-372.95\" font-family=\"Times,serif\" font-size=\"14.00\">Input: spend</text>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;df_to_pickle_build_result -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;df_to_pickle_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M325.02,-377.53C273.31,-376.14 185.09,-366.95 125.11,-324 64.32,-280.46 58.18,-252.03 38.11,-180 33.82,-164.59 31.09,-158.38 38.11,-144 44.02,-131.92 54.15,-121.79 64.82,-113.73\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"66.63,-116.04 72.83,-107.45 62.62,-110.3 66.63,-116.04\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_zero_mean -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_zero_mean</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M399.52,-359.64C412.48,-350.84 426,-338.84 433.11,-324 440.03,-309.57 439.98,-302.45 433.11,-288 427.36,-275.87 417.32,-265.61 406.83,-257.44\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"409.15,-254.08 398.99,-251.07 405.06,-259.76 409.15,-254.08\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_mean -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_mean</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M367.11,-359.7C367.11,-352.24 367.11,-343.32 367.11,-334.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"370.61,-335.1 367.11,-325.1 363.61,-335.1 370.61,-335.1\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_std_dev -->\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_std_dev</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M331.9,-359.52C311.99,-349.63 287.03,-337.24 266.35,-326.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"268.1,-323.44 257.58,-322.13 264.98,-329.71 268.1,-323.44\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;spend_per_signup -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;spend_per_signup</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M325.11,-371.77C269.51,-364.02 175.64,-347.79 151.11,-324 115.22,-289.17 110.57,-227.22 111.28,-191.17\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.8,-191.56 111.66,-181.44 107.8,-191.31 114.8,-191.56\"/>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;df_to_json_build_result -->\n",
+       "<g id=\"edge12\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;df_to_json_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M409.35,-362.54C430.12,-353.84 454.42,-341.1 472.11,-324 534.94,-263.29 605.25,-212.58 551.11,-144 534.86,-123.41 476.06,-109.95 423.05,-101.74\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"423.6,-98.13 413.2,-100.12 422.57,-105.06 423.6,-98.13\"/>\n",
+       "</g>\n",
+       "<!-- avg_3wk_spend -->\n",
+       "<g id=\"node11\" class=\"node\">\n",
+       "<title>avg_3wk_spend</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"541.99,-180 438.24,-180 438.24,-144 541.99,-144 541.99,-180\"/>\n",
+       "<text text-anchor=\"middle\" x=\"490.11\" y=\"-156.95\" font-family=\"Times,serif\" font-size=\"14.00\">avg_3wk_spend</text>\n",
+       "</g>\n",
+       "<!-- spend&#45;&gt;avg_3wk_spend -->\n",
+       "<g id=\"edge20\" class=\"edge\">\n",
+       "<title>spend&#45;&gt;avg_3wk_spend</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M406.09,-359.72C421.56,-351.06 438.23,-339.14 449.11,-324 478,-283.81 486.58,-225.16 489.1,-190.85\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"492.64,-191.41 489.75,-181.22 485.65,-190.99 492.64,-191.41\"/>\n",
+       "</g>\n",
+       "<!-- avg_3wk_spend&#45;&gt;df_to_pickle_build_result -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>avg_3wk_spend&#45;&gt;df_to_pickle_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M437.97,-146.06C434.98,-145.33 432.01,-144.64 429.11,-144 385.5,-134.37 273.67,-116.59 193.83,-104.29\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"194.7,-100.73 184.28,-102.67 193.63,-107.65 194.7,-100.73\"/>\n",
+       "</g>\n",
+       "<!-- avg_3wk_spend&#45;&gt;df_to_json_build_result -->\n",
+       "<g id=\"edge14\" class=\"edge\">\n",
+       "<title>avg_3wk_spend&#45;&gt;df_to_json_build_result</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M449.9,-143.52C427.51,-133.78 399.51,-121.61 376.11,-111.43\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"377.63,-107.84 367.06,-107.06 374.84,-114.26 377.63,-107.84\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ],
+      "text/plain": [
+       "<graphviz.graphs.Digraph at 0x167850490>"
+      ]
      },
      "execution_count": 18,
      "metadata": {},
@@ -208,6 +443,13 @@
     "        filepath_or_buffer=\"./df.json\",\n",
     "        combine=df_builder,\n",
     "    ),\n",
+    "    # materialize the dataframe to a XML file\n",
+    "    to.xml(\n",
+    "        dependencies=output_columns,\n",
+    "        id=\"df_to_xml\",\n",
+    "        filepath_or_buffer=\"./df.xml\",\n",
+    "        combine=df_builder,\n",
+    "    ),\n",
     "]\n",
     "# Visualize what is happening\n",
     "dr.visualize_materialization(\n",
@@ -219,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.343892Z",
@@ -234,6 +476,7 @@
     "    additional_vars=[\n",
     "        \"df_to_pickle_build_result\",\n",
     "        \"df_to_json_build_result\",\n",
+    "        \"df_to_xml_build_result\",\n",
     "    ],  # because combine is used, we can get that result here.\n",
     "    inputs=initial_columns,\n",
     ")"
@@ -241,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.351966Z",
@@ -251,7 +494,16 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "{'df_to_pickle': {'size': 1088,\n  'path': './df.pkl',\n  'last_modified': 1694758374.3349555,\n  'timestamp': 1694772774.33507},\n 'df_to_json': {'size': 428,\n  'path': './df.json',\n  'last_modified': 1694758374.33606,\n  'timestamp': 1694772774.336193}}"
+      "text/plain": [
+       "{'df_to_pickle': {'size': 1088,\n",
+       "  'path': './df.pkl',\n",
+       "  'last_modified': 1694758374.3349555,\n",
+       "  'timestamp': 1694772774.33507},\n",
+       " 'df_to_json': {'size': 428,\n",
+       "  'path': './df.json',\n",
+       "  'last_modified': 1694758374.33606,\n",
+       "  'timestamp': 1694772774.336193}}"
+      ]
      },
      "execution_count": 20,
      "metadata": {},
@@ -264,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.369768Z",
@@ -274,8 +526,102 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "   spend  signups  avg_3wk_spend  spend_per_signup  \\\n0     10        1            NaN            10.000   \n1     10       10            NaN             1.000   \n2     20       50      13.333333             0.400   \n3     40      100      23.333333             0.400   \n4     40      200      33.333333             0.200   \n5     50      400      43.333333             0.125   \n\n   spend_zero_mean_unit_variance  \n0                      -1.064405  \n1                      -1.064405  \n2                      -0.483821  \n3                       0.677349  \n4                       0.677349  \n5                       1.257934  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>spend</th>\n      <th>signups</th>\n      <th>avg_3wk_spend</th>\n      <th>spend_per_signup</th>\n      <th>spend_zero_mean_unit_variance</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>10</td>\n      <td>1</td>\n      <td>NaN</td>\n      <td>10.000</td>\n      <td>-1.064405</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>10</td>\n      <td>10</td>\n      <td>NaN</td>\n      <td>1.000</td>\n      <td>-1.064405</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>20</td>\n      <td>50</td>\n      <td>13.333333</td>\n      <td>0.400</td>\n      <td>-0.483821</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>40</td>\n      <td>100</td>\n      <td>23.333333</td>\n      <td>0.400</td>\n      <td>0.677349</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>40</td>\n      <td>200</td>\n      <td>33.333333</td>\n      <td>0.200</td>\n      <td>0.677349</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>50</td>\n      <td>400</td>\n      <td>43.333333</td>\n      <td>0.125</td>\n      <td>1.257934</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>spend</th>\n",
+       "      <th>signups</th>\n",
+       "      <th>avg_3wk_spend</th>\n",
+       "      <th>spend_per_signup</th>\n",
+       "      <th>spend_zero_mean_unit_variance</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10</td>\n",
+       "      <td>1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10.000</td>\n",
+       "      <td>-1.064405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>-1.064405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>20</td>\n",
+       "      <td>50</td>\n",
+       "      <td>13.333333</td>\n",
+       "      <td>0.400</td>\n",
+       "      <td>-0.483821</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>40</td>\n",
+       "      <td>100</td>\n",
+       "      <td>23.333333</td>\n",
+       "      <td>0.400</td>\n",
+       "      <td>0.677349</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>40</td>\n",
+       "      <td>200</td>\n",
+       "      <td>33.333333</td>\n",
+       "      <td>0.200</td>\n",
+       "      <td>0.677349</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>50</td>\n",
+       "      <td>400</td>\n",
+       "      <td>43.333333</td>\n",
+       "      <td>0.125</td>\n",
+       "      <td>1.257934</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   spend  signups  avg_3wk_spend  spend_per_signup  \\\n",
+       "0     10        1            NaN            10.000   \n",
+       "1     10       10            NaN             1.000   \n",
+       "2     20       50      13.333333             0.400   \n",
+       "3     40      100      23.333333             0.400   \n",
+       "4     40      200      33.333333             0.200   \n",
+       "5     50      400      43.333333             0.125   \n",
+       "\n",
+       "   spend_zero_mean_unit_variance  \n",
+       "0                      -1.064405  \n",
+       "1                      -1.064405  \n",
+       "2                      -0.483821  \n",
+       "3                       0.677349  \n",
+       "4                       0.677349  \n",
+       "5                       1.257934  "
+      ]
      },
      "execution_count": 21,
      "metadata": {},
@@ -288,21 +634,115 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2023-09-15T06:12:54.372414Z",
      "start_time": "2023-09-15T06:12:54.366490Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "   spend  signups  avg_3wk_spend  spend_per_signup  \\\n0     10        1            NaN            10.000   \n1     10       10            NaN             1.000   \n2     20       50      13.333333             0.400   \n3     40      100      23.333333             0.400   \n4     40      200      33.333333             0.200   \n5     50      400      43.333333             0.125   \n\n   spend_zero_mean_unit_variance  \n0                      -1.064405  \n1                      -1.064405  \n2                      -0.483821  \n3                       0.677349  \n4                       0.677349  \n5                       1.257934  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>spend</th>\n      <th>signups</th>\n      <th>avg_3wk_spend</th>\n      <th>spend_per_signup</th>\n      <th>spend_zero_mean_unit_variance</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>10</td>\n      <td>1</td>\n      <td>NaN</td>\n      <td>10.000</td>\n      <td>-1.064405</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>10</td>\n      <td>10</td>\n      <td>NaN</td>\n      <td>1.000</td>\n      <td>-1.064405</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>20</td>\n      <td>50</td>\n      <td>13.333333</td>\n      <td>0.400</td>\n      <td>-0.483821</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>40</td>\n      <td>100</td>\n      <td>23.333333</td>\n      <td>0.400</td>\n      <td>0.677349</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>40</td>\n      <td>200</td>\n      <td>33.333333</td>\n      <td>0.200</td>\n      <td>0.677349</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>50</td>\n      <td>400</td>\n      <td>43.333333</td>\n      <td>0.125</td>\n      <td>1.257934</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>spend</th>\n",
+       "      <th>signups</th>\n",
+       "      <th>avg_3wk_spend</th>\n",
+       "      <th>spend_per_signup</th>\n",
+       "      <th>spend_zero_mean_unit_variance</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10</td>\n",
+       "      <td>1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10.000</td>\n",
+       "      <td>-1.064405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>-1.064405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>20</td>\n",
+       "      <td>50</td>\n",
+       "      <td>13.333333</td>\n",
+       "      <td>0.400</td>\n",
+       "      <td>-0.483821</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>40</td>\n",
+       "      <td>100</td>\n",
+       "      <td>23.333333</td>\n",
+       "      <td>0.400</td>\n",
+       "      <td>0.677349</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>40</td>\n",
+       "      <td>200</td>\n",
+       "      <td>33.333333</td>\n",
+       "      <td>0.200</td>\n",
+       "      <td>0.677349</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>50</td>\n",
+       "      <td>400</td>\n",
+       "      <td>43.333333</td>\n",
+       "      <td>0.125</td>\n",
+       "      <td>1.257934</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   spend  signups  avg_3wk_spend  spend_per_signup  \\\n",
+       "0     10        1            NaN            10.000   \n",
+       "1     10       10            NaN             1.000   \n",
+       "2     20       50      13.333333             0.400   \n",
+       "3     40      100      23.333333             0.400   \n",
+       "4     40      200      33.333333             0.200   \n",
+       "5     50      400      43.333333             0.125   \n",
+       "\n",
+       "   spend_zero_mean_unit_variance  \n",
+       "0                      -1.064405  \n",
+       "1                      -1.064405  \n",
+       "2                      -0.483821  \n",
+       "3                       0.677349  \n",
+       "4                       0.677349  \n",
+       "5                       1.257934  "
+      ]
      },
      "execution_count": 22,
      "metadata": {},
@@ -311,6 +751,15 @@
    ],
    "source": [
     "additional_outputs[\"df_to_json_build_result\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "additional_outputs[\"df_to_xml_build_result\"]"
    ]
   }
  ],
@@ -330,7 +779,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/examples/pandas/materialization/spend_calculations.py
+++ b/examples/pandas/materialization/spend_calculations.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+# Define your new Hamilton functions.
+# The %%writefile magic command creates a new Python module with the functions below.
+# We will import this later and pass it into our Driver.
+
+
+# Look at `my_functions` to see how these functions connect.
+def avg_3wk_spend(spend: pd.Series) -> pd.Series:
+    """Rolling 3 week average spend."""
+    return spend.rolling(3).mean()
+
+
+def spend_per_signup(spend: pd.Series, signups: pd.Series) -> pd.Series:
+    """The cost per signup in relation to spend."""
+    return spend / signups
+
+
+def spend_mean(spend: pd.Series) -> float:
+    """Shows function creating a scalar. In this case it computes the mean of the entire column."""
+    return spend.mean()
+
+
+def spend_zero_mean(spend: pd.Series, spend_mean: float) -> pd.Series:
+    """Shows function that takes a scalar. In this case to zero mean spend."""
+    return spend - spend_mean
+
+
+def spend_std_dev(spend: pd.Series) -> float:
+    """Function that computes the standard deviation of the spend column."""
+    return spend.std()
+
+
+def spend_zero_mean_unit_variance(spend_zero_mean: pd.Series, spend_std_dev: float) -> pd.Series:
+    """Function showing one way to make spend have zero mean and unit variance."""
+    return spend_zero_mean / spend_std_dev

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -398,7 +398,7 @@ class PandasXmlReader(DataLoader):
     converters: Optional[Dict[Union[int,str], Any]] = None
     parse_dates: Union[bool, List[Union[int, str,List[List],Dict[str,List[int]]]]] = False
     encoding: Optional[str] = "utf-8"
-    parser: str = "lmxl"
+    parser: str = "lxml"
     stylesheet: Union[str, Path, BytesIO, BufferedReader] = None
     iterparse: Optional[Dict[str,List[str]]] = None
     compression: Union[str, Dict[str, Any], None] = "infer"
@@ -476,7 +476,7 @@ class PandasXmlWriter(DataSaver):
     encoding: str = "utf-8"
     xml_declaration: bool = True
     pretty_print: bool = True
-    parser: str = "lmxl"
+    parser: str = "lxml"
     stylesheet: Optional[Union[str, Path, BytesIO, BufferedReader]] = None
     compression: Union[str, Dict[str, Any], None] = "infer"
     storage_options: Optional[Dict[str, Any]] = None

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -448,8 +448,8 @@ class PandasXmlReader(DataLoader):
     
     def load_data(self, type: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
         # Loads the data and returns the df and metadata of the xml
-        df = pd.read_xml(self.filepath_or_buffer, **self._get_loading_kwargs())
-        metadata = utils.get_file_metadata(self.filepath_or_buffer)
+        df = pd.read_xml(self.path_or_buffer, **self._get_loading_kwargs())
+        metadata = utils.get_file_metadata(self.path_or_buffer)
 
         return df, metadata
     
@@ -518,8 +518,8 @@ class PandasXmlWriter(DataSaver):
             kwargs["storage_options"] = self.storage_options
 
     def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
-        data.to_xml(self.filepath_or_buffer, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.filepath_or_buffer)
+        data.to_xml(self.path_or_buffer, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.path_or_buffer)
     
     @classmethod
     def name(cls) -> str:

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -382,25 +382,27 @@ class PandasJsonWriter(DataSaver):
     def name(cls) -> str:
         return "json"
 
+
 @dataclasses.dataclass
 class PandasXmlReader(DataLoader):
     """Class for loading/reading pickle files with Pandas.
     Maps to https://pandas.pydata.org/docs/reference/api/pandas.read_xml.html
     """
+
     path_or_buffer: Union[str, Path, BytesIO, BufferedReader]
-    #kwargs
+    # kwargs
     xpath: Optional[str] = "./*"
     namespace: Optional[Dict[str, str]] = None
     elems_only: Optional[bool] = False
-    attrs_only: Optional[bool] = False 
-    names: Optional[List[str]] = None 
+    attrs_only: Optional[bool] = False
+    names: Optional[List[str]] = None
     dtype: Optional[Dict[str, Any]] = None
-    converters: Optional[Dict[Union[int,str], Any]] = None
-    parse_dates: Union[bool, List[Union[int, str,List[List],Dict[str,List[int]]]]] = False
+    converters: Optional[Dict[Union[int, str], Any]] = None
+    parse_dates: Union[bool, List[Union[int, str, List[List], Dict[str, List[int]]]]] = False
     encoding: Optional[str] = "utf-8"
     parser: str = "lxml"
     stylesheet: Union[str, Path, BytesIO, BufferedReader] = None
-    iterparse: Optional[Dict[str,List[str]]] = None
+    iterparse: Optional[Dict[str, List[str]]] = None
     compression: Union[str, Dict[str, Any], None] = "infer"
     storage_options: Optional[Dict[str, Any]] = None
     dtype_backend: str = "numpy_nullable"
@@ -408,7 +410,7 @@ class PandasXmlReader(DataLoader):
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
         return [DATAFRAME_TYPE]
-    
+
     def _get_loading_kwargs(self) -> Dict[str, Any]:
         kwargs = {}
         if self.xpath is not None:
@@ -425,7 +427,7 @@ class PandasXmlReader(DataLoader):
             kwargs["dtype"] = self.dtype
         if self.converters is not None:
             kwargs["converters"] = self.converters
-        if self.parse_dates is not None:
+        if sys.version_info >= (3, 8) and self.parse_dates is not None:
             kwargs["parse_dates"] = self.parse_dates
         if self.encoding is not None:
             kwargs["encoding"] = self.encoding
@@ -446,25 +448,27 @@ class PandasXmlReader(DataLoader):
         if self.dtype_backend is not None:
             kwargs["dtype_backend"] = self.dtype_backend
         return kwargs
-    
+
     def load_data(self, type: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
         # Loads the data and returns the df and metadata of the xml
         df = pd.read_xml(self.path_or_buffer, **self._get_loading_kwargs())
         metadata = utils.get_file_metadata(self.path_or_buffer)
 
         return df, metadata
-    
-    @classmethod 
-    def name(cls) -> str: 
+
+    @classmethod
+    def name(cls) -> str:
         return "xml"
-    
+
+
 @dataclasses.dataclass
 class PandasXmlWriter(DataSaver):
     """Class specifically to handle saving JSON files/buffers with Pandas.
     Should map to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_xml.html
     """
+
     path_or_buffer: Union[str, Path, BytesIO, BufferedReader]
-    #kwargs 
+    # kwargs
     index: bool = True
     root_name: str = "data"
     row_name: str = "row"
@@ -484,11 +488,11 @@ class PandasXmlWriter(DataSaver):
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
         return [DATAFRAME_TYPE]
-    
+
     def _get_saving_kwargs(self):
         kwargs = {}
         if self.index is not None:
-            kwargs["index"] = self.index 
+            kwargs["index"] = self.index
         if self.root_name is not None:
             kwargs["root_name"] = self.root_name
         if self.row_name is not None:
@@ -508,7 +512,7 @@ class PandasXmlWriter(DataSaver):
         if self.xml_declaration is not None:
             kwargs["xml_declaration"] = self.xml_declaration
         if self.pretty_print is not None:
-            kwargs["pretty_print"] = self.pretty_print 
+            kwargs["pretty_print"] = self.pretty_print
         if self.parser is not None:
             kwargs["parser"] = self.parser
         if self.stylesheet is not None:
@@ -522,10 +526,11 @@ class PandasXmlWriter(DataSaver):
     def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
         data.to_xml(self.path_or_buffer, **self._get_saving_kwargs())
         return utils.get_file_metadata(self.path_or_buffer)
-    
+
     @classmethod
     def name(cls) -> str:
         return "xml"
+
 
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
@@ -538,7 +543,7 @@ def register_data_loaders():
         PandasJsonReader,
         PandasJsonWriter,
         PandasXmlReader,
-        PandasXmlWriter
+        PandasXmlWriter,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -382,6 +382,148 @@ class PandasJsonWriter(DataSaver):
     def name(cls) -> str:
         return "json"
 
+@dataclasses.dataclass
+class PandasXmlReader(DataLoader):
+    """Class for loading/reading pickle files with Pandas.
+    Maps to https://pandas.pydata.org/docs/reference/api/pandas.read_xml.html
+    """
+    path_or_buffer: Union[str, Path, BytesIO, BufferedReader]
+    #kwargs
+    xpath: Optional[str] = "./*"
+    namespace: Optional[Dict[str, str]] = None
+    elems_only: Optional[bool] = False
+    attrs_only: Optional[bool] = False 
+    names: Optional[List[str]] = None 
+    dtype: Optional[Dict[str, Any]] = None
+    converters: Optional[Dict[Union[int,str], Any]] = None
+    parse_dates: Union[bool, List[Union[int, str,List[List],Dict[str,List[int]]]]] = False
+    encoding: Optional[str] = "utf-8"
+    parser: str = "lmxl"
+    stylesheet: Union[str, Path, BytesIO, BufferedReader] = None
+    iterparse: Optional[Dict[str,List[str]]] = None
+    compression: Union[str, Dict[str, Any], None] = "infer"
+    storage_options: Optional[Dict[str, Any]] = None
+    dtype_backend: str = "numpy_nullable"
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+    
+    def _get_loading_kwargs(self) -> Dict[str, Any]:
+        kwargs = {}
+        if self.xpath is not None:
+            kwargs["xpath"] = self.xpath
+        if self.namespace is not None:
+            kwargs["namespace"] = self.namespace
+        if self.elems_only is not None:
+            kwargs["elems_only"] = self.elems_only
+        if self.attrs_only is not None:
+            kwargs["attrs_only"] = self.attrs_only
+        if self.names is not None:
+            kwargs["names"] = self.names
+        if self.dtype is not None:
+            kwargs["dtype"] = self.dtype
+        if self.converters is not None:
+            kwargs["converters"] = self.converters
+        if self.parse_dates is not None:
+            kwargs["parse_dates"] = self.parse_dates
+        if self.encoding is not None:
+            kwargs["encoding"] = self.encoding
+        if self.parser is not None:
+            kwargs["parser"] = self.parser
+        if self.encoding is not None:
+            kwargs["encoding"] = self.encoding
+        if self.parser is not None:
+            kwargs["parser"] = self.parser
+        if self.stylesheet is not None:
+            kwargs["stylesheet"] = self.stylesheet
+        if self.iterparse is not None:
+            kwargs["iterparse"] = self.iterparse
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.storage_options is not None:
+            kwargs["storage_options"] = self.storage_options
+        if self.dtype_backend is not None:
+            kwargs["dtype_backend"] = self.dtype_backend
+    
+    def load_data(self, type: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
+        # Loads the data and returns the df and metadata of the xml
+        df = pd.read_xml(self.filepath_or_buffer, **self._get_loading_kwargs())
+        metadata = utils.get_file_metadata(self.filepath_or_buffer)
+
+        return df, metadata
+    
+    @classmethod 
+    def name(cls) -> str: 
+        return "json"
+    
+@dataclasses.dataclass
+class PandasXmlWriter(DataSaver):
+    """Class specifically to handle saving JSON files/buffers with Pandas.
+    Should map to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_xml.html
+    """
+    path_or_buffer: Union[str, Path, BytesIO, BufferedReader]
+    #kwargs 
+    index: bool = True,
+    root_name: str = "data"
+    row_name: str = "row"
+    na_rep: Optional[str] = None
+    attr_cols: Optional[List[str]] = None
+    elems_cols: Optional[List[str]] = None
+    namespaces: Optional[Dict[str, str]] = None
+    prefix: Optional[str] = None
+    encoding: str = "utf-8"
+    xml_declaration: bool = True
+    pretty_print: bool = True
+    parser: str = "lmxl"
+    stylesheet: Optional[Union[str, Path, BytesIO, BufferedReader]] = None
+    compression: Union[str, Dict[str, Any], None] = "infer"
+    storage_options: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+    
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.index is not None:
+            kwargs["index"] = self.index 
+        if self.root_name is not None:
+            kwargs["root_name"] = self.root_name
+        if self.row_name is not None:
+            kwargs["row_name"] = self.row_name
+        if self.na_rep is not None:
+            kwargs["na_rep"] = self.na_rep
+        if self.attr_cols is not None:
+            kwargs["attr_cols"] = self.attr_cols
+        if self.elems_cols is not None:
+            kwargs["elems_cols"] = self.elems_cols
+        if self.namespaces is not None:
+            kwargs["namespaces"] = self.namespaces
+        if self.prefix is not None:
+            kwargs["prefix"] = self.prefix
+        if self.encoding is not None:
+            kwargs["encoding"] = self.encoding
+        if self.xml_declaration is not None:
+            kwargs["xml_declaration"] = self.xml_declaration
+        if self.pretty_print is not None:
+            kwargs["pretty_print"] = self.pretty_print 
+        if self.parser is not None:
+            kwargs["parser"] = self.parser
+        if self.stylesheet is not None:
+            kwargs["stylesheet"] = self.stylesheet
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.storage_options is not None:
+            kwargs["storage_options"] = self.storage_options
+
+    def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
+        data.to_xml(self.filepath_or_buffer, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.filepath_or_buffer)
+    
+    @classmethod
+    def name(cls) -> str:
+        return "xml"
 
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
@@ -393,6 +535,8 @@ def register_data_loaders():
         PandasPickleWriter,
         PandasJsonReader,
         PandasJsonWriter,
+        PandasXmlReader,
+        PandasXmlWriter
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -445,6 +445,7 @@ class PandasXmlReader(DataLoader):
             kwargs["storage_options"] = self.storage_options
         if self.dtype_backend is not None:
             kwargs["dtype_backend"] = self.dtype_backend
+        return kwargs
     
     def load_data(self, type: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
         # Loads the data and returns the df and metadata of the xml
@@ -516,6 +517,7 @@ class PandasXmlWriter(DataSaver):
             kwargs["compression"] = self.compression
         if self.storage_options is not None:
             kwargs["storage_options"] = self.storage_options
+        return kwargs
 
     def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
         data.to_xml(self.path_or_buffer, **self._get_saving_kwargs())

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import sys
+import lxml
 from collections.abc import Hashable
 from io import BufferedReader, BytesIO
 from pathlib import Path

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -385,8 +385,10 @@ class PandasJsonWriter(DataSaver):
 
 @dataclasses.dataclass
 class PandasXmlReader(DataLoader):
-    """Class for loading/reading pickle files with Pandas.
+    """Class for loading/reading xml files with Pandas.
     Maps to https://pandas.pydata.org/docs/reference/api/pandas.read_xml.html
+
+    Requires `lxml`. See https://pandas.pydata.org/docs/getting_started/install.html#xml
     """
 
     path_or_buffer: Union[str, Path, BytesIO, BufferedReader]
@@ -463,8 +465,10 @@ class PandasXmlReader(DataLoader):
 
 @dataclasses.dataclass
 class PandasXmlWriter(DataSaver):
-    """Class specifically to handle saving JSON files/buffers with Pandas.
+    """Class specifically to handle saving xml files/buffers with Pandas.
     Should map to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_xml.html
+
+    Requires `lxml`. See https://pandas.pydata.org/docs/getting_started/install.html#xml.
     """
 
     path_or_buffer: Union[str, Path, BytesIO, BufferedReader]

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -445,7 +445,7 @@ class PandasXmlReader(DataLoader):
             kwargs["compression"] = self.compression
         if self.storage_options is not None:
             kwargs["storage_options"] = self.storage_options
-        if self.dtype_backend is not None:
+        if sys.version_info >= (3, 8) and self.dtype_backend is not None:
             kwargs["dtype_backend"] = self.dtype_backend
         return kwargs
 

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -1,7 +1,6 @@
 import abc
 import dataclasses
 import sys
-import lxml
 from collections.abc import Hashable
 from io import BufferedReader, BytesIO
 from pathlib import Path

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -466,7 +466,7 @@ class PandasXmlWriter(DataSaver):
     """
     path_or_buffer: Union[str, Path, BytesIO, BufferedReader]
     #kwargs 
-    index: bool = True,
+    index: bool = True
     root_name: str = "data"
     row_name: str = "row"
     na_rep: Optional[str] = None

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -455,7 +455,7 @@ class PandasXmlReader(DataLoader):
     
     @classmethod 
     def name(cls) -> str: 
-        return "json"
+        return "xml"
     
 @dataclasses.dataclass
 class PandasXmlWriter(DataSaver):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 graphviz
+lxml
 networkx
 pyarrow
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+lxml
 numpy
 pandas
-lxml
 typing_extensions > 4.0.0
 typing_inspect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
 pandas
+lxml
 typing_extensions > 4.0.0
 typing_inspect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-lxml
 numpy
 pandas
 typing_extensions > 4.0.0

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,6 +1,6 @@
 from importlib import metadata
 import pathlib
-
+import lmxl 
 import pandas as pd
 
 from hamilton.plugins.pandas_extensions import (
@@ -44,7 +44,6 @@ def test_pandas_json_reader(tmp_path: pathlib.Path) -> None:
     assert kwargs["encoding"] == "utf-8"
     assert df.shape == (3, 1)
     assert metadata["path"] == file_path
-
 
 def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "test.json"

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,6 +1,6 @@
 from importlib import metadata
 import pathlib
-import lmxl 
+import lxml 
 import pandas as pd
 
 from hamilton.plugins.pandas_extensions import (

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,3 +1,4 @@
+from importlib import metadata
 import pathlib
 
 import pandas as pd
@@ -7,6 +8,8 @@ from hamilton.plugins.pandas_extensions import (
     PandasJsonWriter,
     PandasPickleReader,
     PandasPickleWriter,
+    PandasXmlReader,
+    PandasXmlWriter
 )
 
 
@@ -50,5 +53,24 @@ def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
     metadata = writer.save_data(pd.DataFrame({"foo": ["bar"]}))
     assert PandasJsonWriter.applicable_types() == [pd.DataFrame]
     assert kwargs["indent"] == 4
+    assert file_path.exists()
+    assert metadata["path"] == file_path
+
+def test_pandas_xml_reader(tmp_path: pathlib.Path) -> None:
+    path_to_test = "tests/resources/data/test_load_from_data.xml"
+    reader = PandasXmlReader(path_or_buffer = path_to_test)
+    kwargs = reader._get_loading_kwargs()
+    df, metadata = reader.load_data(pd.DataFrame)
+
+    assert PandasXmlReader.applicable_types() == [pd.DataFrame]
+    assert df.shape == (5, 4)
+
+def test_pandas_xml_writer(tmp_path: pathlib.Path) -> None:
+    file_path = tmp_path / "test.xml"
+    writer = PandasXmlWriter(path_or_buffer = file_path)
+    kwargs = writer._get_saving_kwargs()
+    metadata = writer.save_data(pd.DataFrame({"foo": ["bar"]}))
+
+    assert PandasXmlWriter.applicable_types() == [pd.DataFrame]
     assert file_path.exists()
     assert metadata["path"] == file_path

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -62,7 +62,7 @@ def test_pandas_xml_reader(tmp_path: pathlib.Path) -> None:
     df, metadata = reader.load_data(pd.DataFrame)
 
     assert PandasXmlReader.applicable_types() == [pd.DataFrame]
-    assert df.shape == (5, 4)
+    assert df.shape == (4, 4)
 
 def test_pandas_xml_writer(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "test.xml"

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,6 +1,4 @@
-from importlib import metadata
 import pathlib
-import lxml 
 import pandas as pd
 
 from hamilton.plugins.pandas_extensions import (
@@ -45,6 +43,7 @@ def test_pandas_json_reader(tmp_path: pathlib.Path) -> None:
     assert df.shape == (3, 1)
     assert metadata["path"] == file_path
 
+
 def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "test.json"
     writer = PandasJsonWriter(filepath_or_buffer=file_path, indent=4)
@@ -55,19 +54,19 @@ def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
     assert file_path.exists()
     assert metadata["path"] == file_path
 
+
 def test_pandas_xml_reader(tmp_path: pathlib.Path) -> None:
     path_to_test = "tests/resources/data/test_load_from_data.xml"
     reader = PandasXmlReader(path_or_buffer = path_to_test)
-    kwargs = reader._get_loading_kwargs()
     df, metadata = reader.load_data(pd.DataFrame)
 
     assert PandasXmlReader.applicable_types() == [pd.DataFrame]
     assert df.shape == (4, 4)
 
+
 def test_pandas_xml_writer(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "test.xml"
     writer = PandasXmlWriter(path_or_buffer = file_path)
-    kwargs = writer._get_saving_kwargs()
     metadata = writer.save_data(pd.DataFrame({"foo": ["bar"]}))
 
     assert PandasXmlWriter.applicable_types() == [pd.DataFrame]

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,4 +1,5 @@
 import pathlib
+
 import pandas as pd
 
 from hamilton.plugins.pandas_extensions import (
@@ -7,7 +8,7 @@ from hamilton.plugins.pandas_extensions import (
     PandasPickleReader,
     PandasPickleWriter,
     PandasXmlReader,
-    PandasXmlWriter
+    PandasXmlWriter,
 )
 
 
@@ -57,7 +58,7 @@ def test_pandas_json_writer(tmp_path: pathlib.Path) -> None:
 
 def test_pandas_xml_reader(tmp_path: pathlib.Path) -> None:
     path_to_test = "tests/resources/data/test_load_from_data.xml"
-    reader = PandasXmlReader(path_or_buffer = path_to_test)
+    reader = PandasXmlReader(path_or_buffer=path_to_test)
     df, metadata = reader.load_data(pd.DataFrame)
 
     assert PandasXmlReader.applicable_types() == [pd.DataFrame]
@@ -66,7 +67,7 @@ def test_pandas_xml_reader(tmp_path: pathlib.Path) -> None:
 
 def test_pandas_xml_writer(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "test.xml"
-    writer = PandasXmlWriter(path_or_buffer = file_path)
+    writer = PandasXmlWriter(path_or_buffer=file_path)
     metadata = writer.save_data(pd.DataFrame({"foo": ["bar"]}))
 
     assert PandasXmlWriter.applicable_types() == [pd.DataFrame]

--- a/tests/resources/data/test_load_from_data.xml
+++ b/tests/resources/data/test_load_from_data.xml
@@ -1,0 +1,22 @@
+<data>
+    <student name="Jordan">
+        <email>jordan@notmail.com</email>
+        <grade>A</grade>
+        <age>20</age>
+    </student>
+    <student name="Alice">
+        <email>alice@notmail.com</email>
+        <grade>B</grade>
+        <age>24</age>
+    </student>
+    <student name="Becky">
+        <email>becky@notmail.com</email>
+        <grade>C</grade>
+        <age>19</age>
+    </student>
+    <student name="Montana">
+        <email>montana@notmail.com</email>
+        <grade>A</grade>
+        <age>23</age>
+    </student>
+</data>


### PR DESCRIPTION
This code is for ticket #352 where I will adding Pandas XML functionality to read and write to that file format. The methods used and kwargs are described: 

- Reader: https://pandas.pydata.org/docs/reference/api/pandas.read_xml.html
- Writer: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_xml.html

## Changes

The changes are to the following files:

- `test_pandas_extensions.py `==> I added a few tests that I will run to test the functionality of both new methods
- `pandas_extensions.py `==> added the classes for reading and writing to xml
- `test_load_from_data.xml `==> a new file with some data in XML format to test

## How I tested this

I have read the dev guidelines and contribution notes and installed to test locally. Unfortunately, I am still struggling with getting Circleci to run on my branch, and will make another attempt to test this at a later stage.

## Notes
This commit is still a work-in-progress (WIP) and has not been tested. 

When I run `circleci local execute --job=JOB_NAME` where I change `JOB_NAME` to be `run tests` according to the `confing.yml `or even `build-py37` I get the error: `Error: unknown flag: --job
`

## Checklist
- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
