### PR TITLE
Correct the name and type annotation for default_validator_candidates

### DIFF
--- a/hamilton/function_modifiers/validation.py
+++ b/hamilton/function_modifiers/validation.py
@@ -179,7 +179,7 @@ class check_output(BaseDataValidationDecorator):
             return default_validators.resolve_default_validators(
                 node_to_validate.type,
                 importance=self.importance,
-                available_validators=self.default_decorator_candidates,
+                available_validators=self.default_validator_candidates,
                 **self.default_validator_kwargs,
             )
         except ValueError as e:
@@ -192,7 +192,7 @@ class check_output(BaseDataValidationDecorator):
     def __init__(
         self,
         importance: str = dq_base.DataValidationLevel.WARN.value,
-        default_decorator_candidates: Type[dq_base.BaseDefaultValidator] = None,
+        default_validator_candidates: List[Type[dq_base.BaseDefaultValidator]] = None,
         target_: base.TargetType = None,
         **default_validator_kwargs: Any,
     ):
@@ -204,6 +204,7 @@ class check_output(BaseDataValidationDecorator):
         TODO -- enable construction of custom validators using check_output.custom(\\*validators).
 
         :param importance: For the default validator, how important is it that this passes.
+        :param default_validator_candidates: List of validators to be considerred for this check.
         :param default_validator_kwargs: keyword arguments to be passed to the validator.
         :param target\\_: a target specifying which nodes to decorate. See the docs in check_output_custom\
         for a quick overview and the docs in function_modifiers.base.NodeTransformer for more detail.
@@ -211,7 +212,7 @@ class check_output(BaseDataValidationDecorator):
         super(check_output, self).__init__(target=target_)
         self.importance = importance
         self.default_validator_kwargs = default_validator_kwargs
-        self.default_decorator_candidates = default_decorator_candidates
+        self.default_validator_candidates = default_validator_candidates
         # We need to wait until we actually have the function in order to construct the validators
         # So, we'll just store the constructor arguments for now and check it in validation
 

--- a/tests/function_modifiers/test_validation.py
+++ b/tests/function_modifiers/test_validation.py
@@ -21,7 +21,7 @@ from tests.resources.dq_dummy_examples import (
 def test_check_output_node_transform():
     decorator = check_output(
         importance="warn",
-        default_decorator_candidates=DUMMY_VALIDATORS_FOR_TESTING,
+        default_validator_candidates=DUMMY_VALIDATORS_FOR_TESTING,
         dataset_length=1,
         dtype=np.int64,
     )


### PR DESCRIPTION
Looking to submit a Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
* [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)

Else remove this block.

---
[Short description explaining the high-level reason for the pull request]

## Changes

Updated an arg name and annotation since it doesn't match with what's expected.

## How I tested this

None.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
