### PR TITLE
Docs link fixes

### DIFF
--- a/contrib/docs/docusaurus.config.js
+++ b/contrib/docs/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
             items: [
               {
                 label: 'Dataflows',
-                to: '/docs/intro',
+                to: '/docs/',
               },
             ],
           },

--- a/contrib/docs/src/pages/index.js
+++ b/contrib/docs/src/pages/index.js
@@ -17,7 +17,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/docs/">
             Integrate with your code in 5 minutes ⏱️
           </Link>
         </div>

--- a/docs/getting-started/hamilton-hub.md
+++ b/docs/getting-started/hamilton-hub.md
@@ -1,0 +1,10 @@
+# Hamilton Hub
+Want something off the shelf? or a place to build something from?
+
+In three lines of code you'll be able to run pre-built dataflows!
+
+Check out the [Hamilton Hub](https://hub.dagworks.io/?utm_source=docs) for more details.
+The "Hamilton Hub" is your place for discovering and contributing Hamilton dataflows.
+
+It's still in the early stages of being built out, so check back often
+for new dataflows!

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -27,4 +27,5 @@ The following section of the docs will teach you how to install Hamilton and get
    install
    write-first-dataflow
    run-first-dataflow
+   hamilton-hub
    next-steps

--- a/docs/reference/result-builders/Polars.rst
+++ b/docs/reference/result-builders/Polars.rst
@@ -3,5 +3,5 @@ Polars
 =======================
 
 
-.. autoclass:: hamilton.plugins.polars_implementations.PolarsDataFrameResult
+.. autoclass:: hamilton.plugins.h_polars.PolarsDataFrameResult
    :members: build_result

--- a/examples/polars/README.md
+++ b/examples/polars/README.md
@@ -26,7 +26,7 @@ Here is the graph of execution - which should look the same as the pandas exampl
 There is one major caveat with Polars to be aware of: THERE IS NO INDEX IN POLARS LIKE THERE IS WITH PANDAS.
 
 What this means is that when you tell Hamilton to execute and return a polars dataframe if you are using the
-[provided results builder](https://github.com/dagworks-inc/hamilton/blob/sf-hamilton-1.14.1/hamilton/plugins/polars_implementations.py#L8), i.e. `hamilton.plugins.polars_implementations.PolarsResultsBuilder`, then you will have to
+[provided results builder](https://github.com/dagworks-inc/hamilton/blob/sf-hamilton-1.14.1/hamilton/plugins/h_polars.py#L8), i.e. `hamilton.plugins.h_polars.PolarsResultsBuilder`, then you will have to
 ensure the row order matches the order you expect for all the outputs you request. E.g. if you do a filter, or a sort,
 or a join, or a groupby, you will have to ensure that when you ask Hamilton to materialize an output that it's in the
 order you expect.


### PR DESCRIPTION
Because they were broken/deprecated/non-existent.

## Changes
 - various docs pages.

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
