### PR TITLE
Adds collapse to the code-block for source code in the hub

### DIFF
--- a/contrib/docs/compile_docs.py
+++ b/contrib/docs/compile_docs.py
@@ -224,12 +224,13 @@ import example2 from '!!raw-loader!./example2.py';
 {README}
 
 ## Source code
-TODO: make collapsable.
 
 import MyComponentSource from '!!raw-loader!./__init__.py';
 
-<CodeBlock language="python">{{MyComponentSource}}</CodeBlock>
-
+<details>
+    <summary>__init__.py</summary>
+    <CodeBlock language="python">{{MyComponentSource}}</CodeBlock>
+</details>
 
 ## Requirements
 import requirements from '!!raw-loader!./requirements.txt';


### PR DESCRIPTION
Looking to submit a Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
* [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)

Else remove this block.

---
[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
