### PR TITLE
Trigger hub build conditionally

### DIFF
--- a/.github/workflows/docusaurus-gh-pages.yml
+++ b/.github/workflows/docusaurus-gh-pages.yml
@@ -24,7 +24,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  branch-build:
+    if: GITHUB_REF_NAME != 'main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000
+      # 👇 Build steps
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install -e .
+      - name: Compile code to create pages
+        working-directory: contrib/docs
+        run: python compile_docs.py
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+          # The action defaults to search for the dependency file
+          # (package-lock.json or yarn.lock) in the repository root, and uses
+          # its hash as a part of the cache key.
+          # https://github.com/actions/setup-node#caching-packages-dependencies
+          cache-dependency-path: "./contrib/docs/package-lock.json"
+      - name: Install dependencies
+        working-directory: contrib/docs
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: Build
+        working-directory: contrib/docs
+        run: yarn build
+      # 👆 Build steps
   deploy:
+    if: GITHUB_REF_NAME == 'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Adds conditional jobs for hub
    
One to ensure it's always built if there are contrib changes.
    
The other is that it's only deployed once pushed to main.

## Changes
 - github hub action workflow

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
