### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,12 @@
+--- PR TEMPLATE INSTRUCTIONS (1) ---
+
 Looking to submit a Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
 * [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)
 
-Else remove this block.
+Else, if not, please remove this block of text.
 
----
+--- PR TEMPLATE INSTRUCTIONS (2) ---
+
 [Short description explaining the high-level reason for the pull request]
 
 ## Changes


### PR DESCRIPTION
So that it more clearly calls out the sf-hamilton-contrib part and that it should be removed if that is not the intent of the PR.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
