### PR TITLE
Fix list formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This paradigm makes modifications easy to build and track, ensures code is self-
 
 ## Problems Hamilton Does not Solve
 ❌ Provisioning infrastructure -- you want a macro-orchestration system (see airflow, kubeflow, sagemaker, etc...).<br/>
-❌ Doing your ML for you -- we organize youir code, BYOL (bring your own libraries).<br/>
+❌ Doing your ML for you -- we organize your code, BYOL (bring your own libraries).<br/>
 ❌ Tracking execution + associated artifacts -- Hamilton is lightweight, but if this is important to you see the [DAGWorks product](www.dagworks.io).
 
 See the table below for more specifics/how it compares to other common tooling.

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Hamilton is a novel paradigm for specifying a flow of delayed execution in pytho
 This paradigm makes modifications easy to build and track, ensures code is self-documenting, and makes it natural to unit test your data transformations. When connected together, these functions form a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (DAG), which the Hamilton framework can execute, optimize, and report on.
 
 ## Problems Hamilton Solves
-✅ Model a dataflow -- If you can model your problem as a DAG in python, Hamilton is the cleanest way to build it.  
-✅ Unmaintainable spaghetti code -- Hamilton dataflows are unit testable, self-documenting, and provide lineage.  
-✅ Long iteration/experimentation cycles -- Hamilton provides a clear, quick, and methodical path to debugging/modifying/extending your code.  
+✅ Model a dataflow -- If you can model your problem as a DAG in python, Hamilton is the cleanest way to build it.<br/>
+✅ Unmaintainable spaghetti code -- Hamilton dataflows are unit testable, self-documenting, and provide lineage.<br/>
+✅ Long iteration/experimentation cycles -- Hamilton provides a clear, quick, and methodical path to debugging/modifying/extending your code.<br/>
 ✅ Reusing code across contexts -- Hamilton encourages code that is independent of infrastructure and can run regardless of execution setting.
 
 ## Problems Hamilton Does not Solve
-❌ Provisioning infrastructure -- you want a macro-orchestration system (see airflow, kubeflow, sagemaker, etc...).  
-❌ Doing your ML for you -- we organize youir code, BYOL (bring your own libraries).  
+❌ Provisioning infrastructure -- you want a macro-orchestration system (see airflow, kubeflow, sagemaker, etc...).<br/>
+❌ Doing your ML for you -- we organize youir code, BYOL (bring your own libraries).<br/>
 ❌ Tracking execution + associated artifacts -- Hamilton is lightweight, but if this is important to you see the [DAGWorks product](www.dagworks.io).
 
 See the table below for more specifics/how it compares to other common tooling.

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Hamilton is a novel paradigm for specifying a flow of delayed execution in pytho
 This paradigm makes modifications easy to build and track, ensures code is self-documenting, and makes it natural to unit test your data transformations. When connected together, these functions form a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (DAG), which the Hamilton framework can execute, optimize, and report on.
 
 ## Problems Hamilton Solves
-✅ Model a dataflow -- If you can model your problem as a DAG in python, Hamilton is the cleanest way to build it.
-✅ Unmaintainable spaghetti code -- Hamilton dataflows are unit testable, self-documenting, and provide lineage.
-✅ Long iteration/experimentation cycles -- Hamilton provides a clear, quick, and methodical path to debugging/modifying/extending your code.
+✅ Model a dataflow -- If you can model your problem as a DAG in python, Hamilton is the cleanest way to build it.  
+✅ Unmaintainable spaghetti code -- Hamilton dataflows are unit testable, self-documenting, and provide lineage.  
+✅ Long iteration/experimentation cycles -- Hamilton provides a clear, quick, and methodical path to debugging/modifying/extending your code.  
 ✅ Reusing code across contexts -- Hamilton encourages code that is independent of infrastructure and can run regardless of execution setting.
 
 ## Problems Hamilton Does not Solve
-❌ Provisioning infrastructure -- you want a macro-orchestration system (see airflow, kubeflow, sagemaker, etc...).
-❌ Doing your ML for you -- we organize youir code, BYOL (bring your own libraries).
+❌ Provisioning infrastructure -- you want a macro-orchestration system (see airflow, kubeflow, sagemaker, etc...).  
+❌ Doing your ML for you -- we organize youir code, BYOL (bring your own libraries).  
 ❌ Tracking execution + associated artifacts -- Hamilton is lightweight, but if this is important to you see the [DAGWorks product](www.dagworks.io).
 
 See the table below for more specifics/how it compares to other common tooling.


### PR DESCRIPTION
If you check "Problems Hamilton Solves" section on current master you'll see that the list-like content is rendered on a single line. This PR fixes it.

## Changes

~Adding two trailing whitespaces to force newline break~

Linter is not happy about trailing whitespaces (even though it's a valid Markdown feature), so I replaced them with `<br/>`

## How I tested this

Preview

## Notes

~First PR where trailing whitespace is a solution and not a problem~ 😅 

Nope, still a problem

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
