### PR TITLE
Fixes inconsistency in new builder API

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1195,11 +1195,13 @@ class Builder:
         """Builds the driver -- note that this can return a different class, so you'll likely
         want to have a sense of what it returns.
 
+        Note: this defaults to a dictionary adapter if no adapter is set.
+
         :return: The driver you specified.
         """
         adapter = self.adapter if self.adapter is not None else base.DefaultAdapter()
         if not self.v2_executor:
-            return Driver(self.config, *self.modules, adapter=self.adapter)
+            return Driver(self.config, *self.modules, adapter=adapter)
         execution_manager = self.execution_manager
         if execution_manager is None:
             local_executor = self.local_executor or executors.SynchronousLocalTaskExecutor()

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import tests.resources.cyclic_functions
+import tests.resources.dummy_functions
 import tests.resources.dynamic_parallelism.parallel_linear_basic
 import tests.resources.tagging
 import tests.resources.test_default_args
@@ -445,3 +446,10 @@ def test_executor_validates_happy_parallel_executor():
 
     nodes, user_nodes = dr.graph.get_upstream_nodes(["final"])
     dr.graph_executor.validate(nodes | user_nodes)
+
+
+def test_builder_defaults_to_dict_result():
+    dr = Builder().with_modules(tests.resources.dummy_functions).build()
+
+    result = dr.execute(["C"], inputs={"b": 1, "c": 1})
+    assert result == {"C": 4}


### PR DESCRIPTION
The default should be a dictionary adapter. In the case that you were not using the "V2" functionality there was a typo and it would not set the adapter to the dictionary one, instead passing in None, and therefore defaulting to the dataframe adapter.

## Changes
 - driver.py
 - test_hamilton_driver.py

## How I tested this
 - locally ran unit tests

## Notes
 - AFAICT nothing assumed this bug as a feature.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
