### PR TITLE
Enables the materializers to depend on functions & driver variables

### DIFF
--- a/hamilton/common/__init__.py
+++ b/hamilton/common/__init__.py
@@ -1,0 +1,58 @@
+# code in this module should no depend on much
+from typing import Any, Callable, List, Optional, Set, Tuple, Union
+
+
+def convert_output_value(
+    output_value: Union[str, Callable, Any], module_set: Set[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Converts output values that one can request into strings.
+
+    It checks that if it's a function, it's in the passed in module set.
+
+    :param output_value: the value we want to convert into a string. We don't annotate driver.Variable here for
+       import reasons.
+    :param module_set: the set of modules functions could come from.
+    :return: a tuple, (string value, string error). One or the other is returned, never both.
+    """
+    if isinstance(output_value, str):
+        return output_value, None
+    elif hasattr(output_value, "name"):
+        return output_value.name, None
+    elif isinstance(output_value, Callable):
+        if output_value.__module__ in module_set:
+            return output_value.__name__, None
+        else:
+            return None, (
+                f"Function {output_value.__module__}.{output_value.__name__} is a function not "
+                f"in a "
+                f"module given to the materializer. Valid choices are {module_set}."
+            )
+    else:
+        return None, (
+            f"Materializer dependency {output_value} is not a string, a function, or a driver.Variable."
+        )
+
+
+def convert_output_values(
+    output_values: List[Union[str, Callable, Any]], module_set: Set[str]
+) -> List[str]:
+    """Checks & converts outputs values to strings. This is used in building dependencies for the DAG.
+
+    :param output_values: the values to convert.
+    :param module_set: the modules any functions could come from.
+    :return: the final values
+    :raises ValueError: if there are values that can't be used/converted.
+    """
+    final_values = []
+    errors = []
+    for final_var in output_values:
+        _val, _error = convert_output_value(final_var, module_set)
+        if _val:
+            final_values.append(_val)
+        if _error:
+            errors.append(_error)
+    if errors:
+        errors.sort()
+        error_str = f"{len(errors)} errors encountered:\n  " + "\n  ".join(errors)
+        raise ValueError(error_str)
+    return final_values

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1001,6 +1001,9 @@ class Driver:
         """
         if additional_vars is None:
             additional_vars = []
+
+        module_set = {_module.__name__ for _module in self.graph_modules}
+        materializers = [m.sanitize_dependencies(module_set) for m in materializers]
         function_graph = materialization.modify_graph(self.graph, materializers)
         final_vars = self._create_final_vars(additional_vars)
         materializer_vars = [materializer.id for materializer in materializers]
@@ -1039,6 +1042,9 @@ class Driver:
         """
         if additional_vars is None:
             additional_vars = []
+
+        module_set = {_module.__name__ for _module in self.graph_modules}
+        materializers = [m.sanitize_dependencies(module_set) for m in materializers]
         function_graph = materialization.modify_graph(self.graph, materializers)
         _final_vars = self._create_final_vars(additional_vars) + [
             materializer.id for materializer in materializers

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, 
 
 import pandas as pd
 
+from hamilton import common
 from hamilton.execution import executors, graph_functions, grouping, state
 from hamilton.io import materialization
 
@@ -419,31 +420,8 @@ class Driver:
         :param final_vars:
         :return: list of strings in the order that final_vars was provided.
         """
-        _final_vars = []
-        errors = []
-        module_set = {_module.__name__ for _module in self.graph_modules}
-        for final_var in final_vars:
-            if isinstance(final_var, str):
-                _final_vars.append(final_var)
-            elif isinstance(final_var, Variable):
-                _final_vars.append(final_var.name)
-            elif isinstance(final_var, Callable):
-                if final_var.__module__ in module_set:
-                    _final_vars.append(final_var.__name__)
-                else:
-                    errors.append(
-                        f"Function {final_var.__module__}.{final_var.__name__} is a function not "
-                        f"in a "
-                        f"module given to the driver. Valid choices are {module_set}."
-                    )
-            else:
-                errors.append(
-                    f"Final var {final_var} is not a string, a function, or a driver.Variable."
-                )
-        if errors:
-            errors.sort()
-            error_str = f"{len(errors)} errors encountered:\n  " + "\n  ".join(errors)
-            raise ValueError(error_str)
+        _module_set = {_module.__name__ for _module in self.graph_modules}
+        _final_vars = common.convert_output_values(final_vars, _module_set)
         return _final_vars
 
     def capture_execute_telemetry(

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -997,7 +997,7 @@ class Driver:
         :param additional_vars: Additional variables to return from the graph
         :param overrides: Overrides to pass to execution
         :param inputs: Inputs to pass to execution
-        :return: Tuple[Materialization metadata, additional_vars result]
+        :return: Tuple[Materialization metadata|data, additional_vars result]
         """
         if additional_vars is None:
             additional_vars = []

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -39,15 +39,18 @@ def custom_subclass_check(requested_type: Type, param_type: Type):
 
     We will likely need to revisit this in the future (perhaps integrate with graphadapter?)
 
-    :param requested_type: Candidate subclass
-    :param param_type: Type of parameter to check
-    :return: Whether or not this is a valid subclass.
+    :param requested_type: Candidate subclass.
+    :param param_type: Type of parameter to check against.
+    :return: Whether or not requested_type is a valid subclass of param_type.
     """
     # handles case when someone is using primitives and generics
     requested_origin_type = requested_type
     param_type, _ = get_type_information(param_type)
     param_origin_type = param_type
     has_generic = False
+    if param_type == Any:
+        # any type is a valid subclass of Any.
+        return True
     if _safe_subclass(requested_type, param_type):
         return True
     if typing_inspect.is_union_type(param_type):

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -9,7 +9,7 @@ from hamilton.io.utils import get_file_metadata
 
 
 @dataclasses.dataclass
-class JSONDataAdapter(DataLoader, DataSaver):
+class JSONDataLoader(DataLoader):
     path: str
 
     @classmethod
@@ -24,6 +24,19 @@ class JSONDataAdapter(DataLoader, DataSaver):
     def name(cls) -> str:
         return "json"
 
+
+@dataclasses.dataclass
+class JSONDataSaver(DataSaver):
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [dict]
+
+    @classmethod
+    def name(cls) -> str:
+        return "json"
+
     def save_data(self, data: Any) -> Dict[str, Any]:
         with open(self.path, "w") as f:
             json.dump(data, f)
@@ -31,13 +44,27 @@ class JSONDataAdapter(DataLoader, DataSaver):
 
 
 @dataclasses.dataclass
-class RawFileDataLoader(DataLoader, DataSaver):
+class RawFileDataLoader(DataLoader):
     path: str
     encoding: str = "utf-8"
 
     def load_data(self, type_: Type) -> Tuple[str, Dict[str, Any]]:
         with open(self.path, "r", encoding=self.encoding) as f:
             return f.read(), get_file_metadata(self.path)
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [str]
+
+    @classmethod
+    def name(cls) -> str:
+        return "file"
+
+
+@dataclasses.dataclass
+class RawFileDataSaver(DataSaver):
+    path: str
+    encoding: str = "utf-8"
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
@@ -65,9 +92,22 @@ class PickleLoader(DataLoader):
     def name(cls) -> str:
         return "pickle"
 
-    def load_data(self, type_: Type[dict]) -> Tuple[str, Dict[str, Any]]:
+    def load_data(self, type_: Type[object]) -> Tuple[object, Dict[str, Any]]:
         with open(self.path, "rb") as f:
             return pickle.load(f), get_file_metadata(self.path)
+
+
+@dataclasses.dataclass
+class PickleSaver(DataSaver):
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [object]
+
+    @classmethod
+    def name(cls) -> str:
+        return "pickle"
 
     def save_data(self, data: Any) -> Dict[str, Any]:
         with open(self.path, "wb") as f:
@@ -127,10 +167,13 @@ class InMemoryResult(DataSaver):
 
 
 DATA_ADAPTERS = [
-    JSONDataAdapter,
+    JSONDataSaver,
+    JSONDataLoader,
     LiteralValueDataLoader,
     RawFileDataLoader,
+    RawFileDataSaver,
     PickleLoader,
+    PickleSaver,
     EnvVarDataLoader,
     InMemoryResult,
 ]

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -107,10 +107,30 @@ class LiteralValueDataLoader(DataLoader):
         return "literal"
 
 
+@dataclasses.dataclass
+class InMemoryResult(DataSaver):
+    """Class specifically to returning an in memory result without saving it anywhere.
+
+    Use this to get the result of a combiner easily; depends on their use.
+    """
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [Any]
+
+    def save_data(self, data: Any) -> Any:
+        return data
+
+    @classmethod
+    def name(cls) -> str:
+        return "memory"
+
+
 DATA_ADAPTERS = [
     JSONDataAdapter,
     LiteralValueDataLoader,
     RawFileDataLoader,
     PickleLoader,
     EnvVarDataLoader,
+    InMemoryResult,
 ]

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -300,6 +300,7 @@ def test_validate_selects_correct_type():
         (int, [StringDataLoader], None),
         (str, [IntDataLoader], None),
         (dict, [IntDataLoader], None),
+        (dict, [IntDataLoader, StringDataLoader], None),
     ],
 )
 def test_resolve_correct_loader_class(

--- a/tests/io/test_data_adapters.py
+++ b/tests/io/test_data_adapters.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import Any, Collection, Dict, Tuple, Type
 
-from hamilton.io.data_adapters import DataLoader
+from hamilton.io.data_adapters import DataLoader, DataSaver
 
 
 @dataclasses.dataclass
@@ -21,6 +21,87 @@ class MockDataLoader(DataLoader):
         pass
 
 
+@dataclasses.dataclass
+class MockDataLoader2(DataLoader):
+    required_param: int
+    default_param: int = 1
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [int]
+
+    def load_data(self, type_: Type) -> Tuple[int, Dict[str, Any]]:
+        pass
+
+    @classmethod
+    def name(cls) -> str:
+        pass
+
+
+@dataclasses.dataclass
+class MockDataSaver(DataSaver):
+    required_param: int
+    default_param: int = 1
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [bool]
+
+    def save_data(self, type_: Type) -> Tuple[int, Dict[str, Any]]:
+        pass
+
+    @classmethod
+    def name(cls) -> str:
+        pass
+
+
+@dataclasses.dataclass
+class MockDataSaver2(DataSaver):
+    required_param: int
+    default_param: int = 1
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [int]
+
+    def save_data(self, type_: Type) -> Tuple[int, Dict[str, Any]]:
+        pass
+
+    @classmethod
+    def name(cls) -> str:
+        pass
+
+
 def test_data_loader_get_required_params():
     assert MockDataLoader.get_required_arguments() == {"required_param": int}
     assert MockDataLoader.get_optional_arguments() == {"default_param": int}
+
+
+def test_loader_applies_to():
+    """Tests applies to is doing the right thing for a loader. i.e. A->B where A is the loader."""
+    loader = MockDataLoader(1, 2)
+    # bool -> int   -- bool is a subclass of int.
+    assert loader.applies_to(int) is True
+    # bool -> bool   -- bool is a subclass of itself
+    assert loader.applies_to(bool) is True
+
+    loader2 = MockDataLoader2(1, 2)
+    # int -> int   -- int is a subclass of int.
+    assert loader2.applies_to(int) is True
+    # int -> bool   -- bool is not a subclass of int
+    assert loader2.applies_to(bool) is False
+
+
+def test_saver_applies_to():
+    """Tests applies to is doing the right thing for a saver. i.e. A->B where B is the saver."""
+    saver = MockDataSaver(1, 2)
+    # int -> bool -- int is not a subclass of bool
+    assert saver.applies_to(int) is False
+    # bool -> bool  -- bool is a subclas of itself
+    assert saver.applies_to(bool) is True
+
+    saver2 = MockDataSaver2(1, 2)
+    # int -> int -- int is a subclass of itself
+    assert saver2.applies_to(int) is True
+    # bool -> int -- bool is a subclass of int
+    assert saver2.applies_to(bool) is True

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,60 @@
+import pytest
+
+import tests.resources.cyclic_functions
+import tests.resources.test_default_args
+from hamilton import common, driver
+
+
+class Object:
+    """Dummy class to test with."""
+
+    def __repr__(self):
+        return "'object'"
+
+
+@pytest.mark.parametrize(
+    "value_to_convert, module_set, expected_value, expected_error",
+    [
+        ("a", {"amodule"}, "a", None),
+        (
+            tests.resources.test_default_args.A,
+            {tests.resources.test_default_args.__name__},
+            "A",
+            None,
+        ),
+        (driver.Variable("A", int), {"amodule"}, "A", None),
+        (
+            Object(),
+            {"amodule"},
+            None,
+            "Materializer dependency 'object' is not a string, a function, or a driver.Variable.",
+        ),
+        (
+            tests.resources.cyclic_functions.A,
+            {tests.resources.test_default_args.__name__},
+            None,
+            "Function tests.resources.cyclic_functions.A is a function not in a module given to the materializer. Valid choices are {'tests.resources.test_default_args'}.",
+        ),
+    ],
+)
+def test_convert_output_value(value_to_convert, module_set, expected_value, expected_error):
+    actual_value, actual_error = common.convert_output_value(value_to_convert, module_set)
+    assert actual_value == expected_value
+    assert actual_error == expected_error
+
+
+def test_convert_output_values_happy():
+    """Tests that we loop as expected without issue"""
+    actual = common.convert_output_values(
+        [tests.resources.test_default_args.A, "B"], {tests.resources.test_default_args.__name__}
+    )
+    assert actual == ["A", "B"]
+
+
+def test_convert_output_values_error():
+    """Tests that we error when bad cases are encountered."""
+    with pytest.raises(ValueError):
+        common.convert_output_values(
+            [tests.resources.test_default_args.A, tests.resources.cyclic_functions.A],
+            {tests.resources.test_default_args.__name__},
+        )

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -23,6 +23,8 @@ custom_type = typing.TypeVar("FOOBAR")
     [
         (custom_type, custom_type, True),
         (custom_type, typing.TypeVar("FOO"), False),
+        (typing.Any, typing.TypeVar("FOO"), True),
+        (typing.Any, custom_type, True),
         (int, int, True),
         (int, float, False),
         (typing.List[int], typing.List, True),
@@ -47,6 +49,8 @@ custom_type = typing.TypeVar("FOOBAR")
         (X, X, True),
         (X, Y, True),
         (Y, X, False),
+        (typing.Any, Y, True),
+        (Y, typing.Any, False),
         (typing.Union[X, int], X, True),
         (typing.Union[str, X], str, True),
         (typing.Union[custom_type, X], Y, True),
@@ -59,6 +63,8 @@ custom_type = typing.TypeVar("FOOBAR")
         (typing.FrozenSet[int], typing.Set[int], False),
         (htypes.column[pd.Series, int], pd.Series, True),
         (htypes.column[pd.Series, int], int, False),
+        (typing.Any, pd.DataFrame, True),
+        (pd.DataFrame, typing.Any, False),
     ],
 )
 def test_custom_subclass_check(param_type, requested_type, expected):


### PR DESCRIPTION
.execute() enables that. The materializers should also be able to handle it.

The complication however is on who knows what and when to do it. So I made the decision to make the driver sanitize the materializers given the context that it has. New objects are returned so we don't modify the underlying materializer object -- that way if someone is reusing a materializer definition they can do so in other driver runs/etc.

## Changes
 - driver.py
 - materialization.py
 - common
 - adapters

## How I tested this
 - locally in a notebook
 - unit tests

## Notes
 - Ready for review.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep) [there is scope creep but it's in each commit]
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
