### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs) - using LiteLLM

### DIFF
--- a/contrib/hamilton/contrib/user/zilto/text_summarization/__init__.py
+++ b/contrib/hamilton/contrib/user/zilto/text_summarization/__init__.py
@@ -9,6 +9,7 @@ from hamilton import contrib
 
 with contrib.catch_import_errors(__name__, __file__, logger):
     import openai
+    import litellm
     import tiktoken
     from PyPDF2 import PdfReader
     from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -107,7 +108,7 @@ def _summarize_chunk(content: str, template_prompt: str, openai_gpt_model: str) 
     :return: the response from the openai API.
     """
     prompt = template_prompt + content
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model, messages=[{"role": "user", "content": prompt}], temperature=0
     )
     return response["choices"][0]["message"]["content"]
@@ -164,7 +165,7 @@ def summarized_text(
     :param openai_gpt_model: which openai gpt model to use.
     :return: the string response from the openai API.
     """
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model,
         messages=[
             {

--- a/examples/LLM_Workflows/knowledge_retrieval/state.py
+++ b/examples/LLM_Workflows/knowledge_retrieval/state.py
@@ -8,6 +8,7 @@ import sys
 
 import functions
 import openai
+import litellm
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from termcolor import colored
 
@@ -86,7 +87,7 @@ def chat_completion_request(messages, openai_gpt_model: str, functions=None, tem
     if functions:
         kwargs["functions"] = functions
     try:
-        response = openai.ChatCompletion.create(**kwargs)
+        response = litellm.completion(**kwargs)
         return response
     except Exception as e:
         logger.error("Unable to generate ChatCompletion response")

--- a/examples/LLM_Workflows/knowledge_retrieval/summarize_text.py
+++ b/examples/LLM_Workflows/knowledge_retrieval/summarize_text.py
@@ -5,6 +5,7 @@ from typing import Callable, Generator, List
 import openai
 import pandas as pd
 import tiktoken
+import litellm
 from PyPDF2 import PdfReader
 from scipy import spatial
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -134,7 +135,7 @@ def _summarize_chunk(content: str, template_prompt: str, openai_gpt_model: str) 
     :return: the response from the openai API.
     """
     prompt = template_prompt + content
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model, messages=[{"role": "user", "content": prompt}], temperature=0
     )
     return response["choices"][0]["message"]["content"]
@@ -199,7 +200,7 @@ def summarize_text(
     :param openai_gpt_model: which openai gpt model to use.
     :return: the string response from the openai API.
     """
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model,
         messages=[
             {

--- a/examples/LLM_Workflows/pdf_summarizer/backend/summarization.py
+++ b/examples/LLM_Workflows/pdf_summarizer/backend/summarization.py
@@ -3,6 +3,7 @@ import tempfile
 from typing import Generator, Union
 
 import openai
+import litellm
 import tiktoken
 from PyPDF2 import PdfReader
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -90,7 +91,7 @@ def _summarize_chunk(content: str, template_prompt: str, openai_gpt_model: str) 
     :return: the response from the openai API.
     """
     prompt = template_prompt + content
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model, messages=[{"role": "user", "content": prompt}], temperature=0
     )
     return response["choices"][0]["message"]["content"]
@@ -147,7 +148,7 @@ def summarized_text(
     :param openai_gpt_model: which openai gpt model to use.
     :return: the string response from the openai API.
     """
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model,
         messages=[
             {

--- a/examples/LLM_Workflows/pdf_summarizer/run_on_spark/summarization.py
+++ b/examples/LLM_Workflows/pdf_summarizer/run_on_spark/summarization.py
@@ -3,6 +3,7 @@ import tempfile
 from typing import Generator, Union
 
 import openai
+import litellm
 import tiktoken
 from PyPDF2 import PdfReader
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -98,7 +99,7 @@ def _summarize_chunk(content: str, template_prompt: str, openai_gpt_model: str) 
     """
     # NEED export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
     prompt = template_prompt + content
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model, messages=[{"role": "user", "content": prompt}], temperature=0
     )
     return response["choices"][0]["message"]["content"]
@@ -155,7 +156,7 @@ def summarized_text(
     :param openai_gpt_model: which openai gpt model to use.
     :return: the string response from the openai API.
     """
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=openai_gpt_model,
         messages=[
             {

--- a/examples/LLM_Workflows/retrieval_augmented_generation/backend/retrieval.py
+++ b/examples/LLM_Workflows/retrieval_augmented_generation/backend/retrieval.py
@@ -1,4 +1,5 @@
 import openai
+import litellm
 import weaviate
 from ingestion import _get_embeddings__openai
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -105,7 +106,7 @@ def chunk_without_summary(chunks_without_summary: list[dict]) -> Parallelizable[
 @retry(wait=wait_random_exponential(min=1, max=40), stop=stop_after_attempt(3))
 def _summarize_text__openai(prompt: str, summarize_model_name: str) -> str:
     """Use OpenAI chat API to ask a model to summarize content contained in a prompt"""
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model=summarize_model_name, messages=[{"role": "user", "content": prompt}], temperature=0
     )
     return response["choices"][0]["message"]["content"]


### PR DESCRIPTION
--- PR TEMPLATE INSTRUCTIONS (1) ---

Looking to submit a Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
* [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)

Else, if not, please remove this block of text.

--- PR TEMPLATE INSTRUCTIONS (2) ---

[Short description explaining the high-level reason for the pull request]
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```

## Changes

## How I tested this

Tested locally 

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
