### PR TITLE
Adds input validation to materialize execution path

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -990,6 +990,14 @@ class Driver:
             module_set = {_module.__name__ for _module in self.graph_modules}
             materializers = [m.sanitize_dependencies(module_set) for m in materializers]
             function_graph = materialization.modify_graph(self.graph, materializers)
+            # need to validate the right inputs has been provided.
+            # we do this on the modified graph.
+            nodes, user_nodes = function_graph.get_upstream_nodes(
+                final_vars + materializer_vars, inputs, overrides
+            )
+            Driver.validate_inputs(function_graph, self.adapter, user_nodes, inputs, nodes)
+            all_nodes = nodes | user_nodes
+            self.graph_executor.validate(list(all_nodes))
             raw_results = self.graph_executor.execute(
                 function_graph,
                 final_vars=final_vars + materializer_vars,

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -453,3 +453,15 @@ def test_builder_defaults_to_dict_result():
 
     result = dr.execute(["C"], inputs={"b": 1, "c": 1})
     assert result == {"C": 4}
+
+
+def test_materialize_checks_required_input(tmp_path):
+    dr = Builder().with_modules(tests.resources.dummy_functions).build()
+    from hamilton.io.materialization import to
+
+    with pytest.raises(ValueError):
+        dr.materialize(additional_vars=["C"], inputs={"c": 1})
+    with pytest.raises(ValueError):
+        dr.materialize(
+            to.pickle(id="1", path=f"{tmp_path}/foo.pkl", dependencies=["C"]), inputs={"c": 1}
+        )


### PR DESCRIPTION
It was not doing what execute does, and validating inputs before execution. This fixes that, and adds a basic test for it.

## Changes
- driver.py
- test_hamilton_driver.py

## How I tested this
- locally
- via unit tests

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
