### PR TITLE
Fixed type hints for `parameterize_sources()`

### DIFF
--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -466,7 +466,7 @@ class parameterize_sources(parameterize):
 
     """
 
-    def __init__(self, **parameterization: Dict[str, Dict[str, str]]):
+    def __init__(self, **parameterization: Dict[str, str]):
         """Constructor for a modifier that expands a single function into n, each of which corresponds to replacing\
         some subset of the specified parameters with specific upstream nodes.
 


### PR DESCRIPTION
Changed the type hints

## Changes
Only changed the type annotation

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
