### PR TITLE
Changes docs to build from furo main

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,11 +2,12 @@
 alabaster>=0.7,<0.8,!=0.7.5  # read the docs pins
 commonmark==0.9.1 # read the docs pins
 dask[distributed]
-furo
+# furo -- install from main for now:
+git+https://github.com/pradyunsg/furo@main
 gitpython # Required for parsing git info for generation of data-adapter docs
 grpcio-status
 mock==1.0.1 # read the docs pins
-myst-parser==0.18.1  # latest version of myst at this time
+myst-parser==2.0.0  # latest version of myst at this time
 pillow
 # required for all the plugins
 polars
@@ -15,7 +16,7 @@ pyspark
 ray
 readthedocs-sphinx-ext<2.3 # read the docs pins
 recommonmark==0.5.0  # read the docs pins
-sphinx==5.3.0  # pinned due to myst-parser
+sphinx # unpinned because myst-parser doesn't break anymore
 sphinx-autobuild
 sphinx-rtd-theme # read the docs pins
 sphinx-sitemap


### PR DESCRIPTION
This is temporary, we shouldn't install from main, but we want to get the canonical link fix.

## Changes
- requirement-docs.txt

## How I tested this
- locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
