### PR TITLE
Removing `NotFittedError` check from XGBoostJsonWriter

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -20,7 +20,15 @@ if not registry.INITIALIZED:
     # Trigger load of extensions here because decorators are the only thing that use the registry
     # right now. Side note: ray serializes things weirdly, so we need to do this here rather than in
     # in the other choice of hamilton/base.py.
-    plugins_modules = ["pandas", "polars", "pyspark_pandas", "spark", "dask", "geopandas"]
+    plugins_modules = [
+        "pandas",
+        "polars",
+        "pyspark_pandas",
+        "spark",
+        "dask",
+        "geopandas",
+        "xgboost",
+    ]
     for plugin_module in plugins_modules:
         try:
             registry.load_extension(plugin_module)

--- a/hamilton/io/utils.py
+++ b/hamilton/io/utils.py
@@ -5,6 +5,18 @@ from typing import Any, Dict, Union
 import pandas as pd
 
 
+def get_exception_details(exception: Exception):
+    """Gives details about exception from saving or loading a file
+    This includes:
+    - the exception class name
+    - the exception message    
+    """
+    return {
+        "exception": exception.__class__.__name__,
+        "message": exception.args[0]
+    }
+
+
 def get_file_metadata(path: str) -> Dict[str, Any]:
     """Gives metadata from loading a file.
     This includes:

--- a/hamilton/io/utils.py
+++ b/hamilton/io/utils.py
@@ -9,12 +9,9 @@ def get_exception_details(exception: Exception):
     """Gives details about exception from saving or loading a file
     This includes:
     - the exception class name
-    - the exception message    
+    - the exception message
     """
-    return {
-        "exception": exception.__class__.__name__,
-        "message": exception.args[0]
-    }
+    return {"exception": exception.__class__.__name__, "message": exception.args[0]}
 
 
 def get_file_metadata(path: str) -> Dict[str, Any]:

--- a/hamilton/plugins/xgboost_extensions.py
+++ b/hamilton/plugins/xgboost_extensions.py
@@ -17,8 +17,8 @@ from hamilton import registry
 from hamilton.io import utils
 from hamilton.io.data_adapters import DataLoader, DataSaver
 
-XGBOOST_MODEL_TYPES = [xgboost.XGBModel, xgboost.Booster]
-XGBOOST_MODEL_TYPES_ANNOTATION = Union[xgboost.XGBModel, xgboost.Booster]
+XGBOOST_MODEL_TYPES = [xgboost.XGBModel, xgboost.Booster, xgboost.XGBClassifier]
+XGBOOST_MODEL_TYPES_ANNOTATION = Union[xgboost.XGBModel, xgboost.Booster, xgboost.XGBClassifier]
 
 
 @dataclasses.dataclass
@@ -77,3 +77,5 @@ def register_data_loaders():
 
 
 register_data_loaders()
+
+COLUMN_FRIENDLY_DF_TYPE = False

--- a/hamilton/plugins/xgboost_extensions.py
+++ b/hamilton/plugins/xgboost_extensions.py
@@ -1,0 +1,78 @@
+import dataclasses
+from os import PathLike
+from typing import Any, Collection, Dict, Union, Tuple, Type
+
+try:
+    import xgboost
+except ImportError:
+    raise NotImplementedError("XGBoost is not installed.")
+
+try:
+    from sklearn.exceptions import NotFittedError
+except ImportError:
+    raise NotImplementedError("scikit-learn is not installed.")
+
+
+from hamilton import registry
+from hamilton.io import utils
+from hamilton.io.data_adapters import DataLoader, DataSaver
+
+
+XGBOOST_MODEL_TYPES = [xgboost.XGBModel, xgboost.Booster]
+XGBOOST_MODEL_TYPES_ANNOTATION = Union[xgboost.XGBModel, xgboost.Booster]
+
+
+@dataclasses.dataclass
+class XGBoostJsonWriter(DataSaver):
+    """Write XGBoost models and boosters to json format
+    See differences with pickle format: https://xgboost.readthedocs.io/en/stable/tutorials/saving_model.html
+    """
+    path: Union[str, PathLike]
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return XGBOOST_MODEL_TYPES
+    
+    def save_data(self, data: XGBOOST_MODEL_TYPES_ANNOTATION) -> Dict[str, Any]:
+        try:
+            data.save_model(self.path)
+        except NotFittedError as e:
+            return utils.get_exception_details(e)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "json"
+    
+
+@dataclasses.dataclass
+class XGBoostJsonReader(DataLoader):
+    """Load XGBoost models and boosters to json format
+    See differences with pickle format: https://xgboost.readthedocs.io/en/stable/tutorials/saving_model.html
+    """
+    path: Union[str, bytearray, PathLike]
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return XGBOOST_MODEL_TYPES
+    
+    def load_data(self, type_: Type) -> Tuple[XGBOOST_MODEL_TYPES_ANNOTATION, Dict[str, Any]]:
+        model = type_()
+        model.load_model(self.path)
+        metadata = utils.get_file_metadata(self.path)
+        return model, metadata
+
+    @classmethod
+    def name(cls) -> str:
+        return "json"
+    
+
+def register_data_loaders():
+    for loader in [
+        XGBoostJsonReader,
+        XGBoostJsonWriter,
+    ]:
+        registry.register_adapter(loader)
+
+
+register_data_loaders()

--- a/hamilton/plugins/xgboost_extensions.py
+++ b/hamilton/plugins/xgboost_extensions.py
@@ -17,8 +17,8 @@ from hamilton import registry
 from hamilton.io import utils
 from hamilton.io.data_adapters import DataLoader, DataSaver
 
-XGBOOST_MODEL_TYPES = [xgboost.XGBModel, xgboost.Booster, xgboost.XGBClassifier]
-XGBOOST_MODEL_TYPES_ANNOTATION = Union[xgboost.XGBModel, xgboost.Booster, xgboost.XGBClassifier]
+XGBOOST_MODEL_TYPES = [xgboost.XGBModel, xgboost.Booster]
+XGBOOST_MODEL_TYPES_ANNOTATION = Union[xgboost.XGBModel, xgboost.Booster]
 
 
 @dataclasses.dataclass

--- a/hamilton/plugins/xgboost_extensions.py
+++ b/hamilton/plugins/xgboost_extensions.py
@@ -7,11 +7,6 @@ try:
 except ImportError:
     raise NotImplementedError("XGBoost is not installed.")
 
-try:
-    from sklearn.exceptions import NotFittedError
-except ImportError:
-    raise NotImplementedError("scikit-learn is not installed.")
-
 
 from hamilton import registry
 from hamilton.io import utils
@@ -34,10 +29,7 @@ class XGBoostJsonWriter(DataSaver):
         return XGBOOST_MODEL_TYPES
 
     def save_data(self, data: XGBOOST_MODEL_TYPES_ANNOTATION) -> Dict[str, Any]:
-        try:
-            data.save_model(self.path)
-        except NotFittedError as e:
-            return utils.get_exception_details(e)
+        data.save_model(self.path)
         return utils.get_file_metadata(self.path)
 
     @classmethod

--- a/hamilton/plugins/xgboost_extensions.py
+++ b/hamilton/plugins/xgboost_extensions.py
@@ -1,6 +1,6 @@
 import dataclasses
 from os import PathLike
-from typing import Any, Collection, Dict, Union, Tuple, Type
+from typing import Any, Collection, Dict, Tuple, Type, Union
 
 try:
     import xgboost
@@ -17,7 +17,6 @@ from hamilton import registry
 from hamilton.io import utils
 from hamilton.io.data_adapters import DataLoader, DataSaver
 
-
 XGBOOST_MODEL_TYPES = [xgboost.XGBModel, xgboost.Booster]
 XGBOOST_MODEL_TYPES_ANNOTATION = Union[xgboost.XGBModel, xgboost.Booster]
 
@@ -27,12 +26,13 @@ class XGBoostJsonWriter(DataSaver):
     """Write XGBoost models and boosters to json format
     See differences with pickle format: https://xgboost.readthedocs.io/en/stable/tutorials/saving_model.html
     """
+
     path: Union[str, PathLike]
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
         return XGBOOST_MODEL_TYPES
-    
+
     def save_data(self, data: XGBOOST_MODEL_TYPES_ANNOTATION) -> Dict[str, Any]:
         try:
             data.save_model(self.path)
@@ -43,19 +43,20 @@ class XGBoostJsonWriter(DataSaver):
     @classmethod
     def name(cls) -> str:
         return "json"
-    
+
 
 @dataclasses.dataclass
 class XGBoostJsonReader(DataLoader):
     """Load XGBoost models and boosters to json format
     See differences with pickle format: https://xgboost.readthedocs.io/en/stable/tutorials/saving_model.html
     """
+
     path: Union[str, bytearray, PathLike]
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
         return XGBOOST_MODEL_TYPES
-    
+
     def load_data(self, type_: Type) -> Tuple[XGBOOST_MODEL_TYPES_ANNOTATION, Dict[str, Any]]:
         model = type_()
         model.load_model(self.path)
@@ -65,7 +66,7 @@ class XGBoostJsonReader(DataLoader):
     @classmethod
     def name(cls) -> str:
         return "json"
-    
+
 
 def register_data_loaders():
     for loader in [

--- a/hamilton/registry.py
+++ b/hamilton/registry.py
@@ -77,7 +77,9 @@ def load_extension(plugin_module: str):
     :param plugin_module: the module name sans .py. e.g. pandas, polars, pyspark_pandas.
     """
     mod = importlib.import_module(f"hamilton.plugins.{plugin_module}_extensions")
-    # Non standard means we can't apply extradction like we usually do
+    # We have various plugin extensions. We default to assuming it's a dataframe extension with columns,
+    # unless it explicitly says it's not.
+    # We need to check the following if we are to enable `@extract_columns` for example.
     extractable = getattr(mod, "COLUMN_FRIENDLY_DF_TYPE", True)
     if extractable:
         assert hasattr(mod, "register_types"), "Error extension missing function register_types()"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,7 @@ polars
 pyarrow
 pytest
 pytest-cov
+scikit-learn
 sqlalchemy==1.4.49; python_version == '3.7.*'
 sqlalchemy; python_version >= '3.8'
 xgboost

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ pytest
 pytest-cov
 sqlalchemy==1.4.49; python_version == '3.7.*'
 sqlalchemy; python_version >= '3.8'
+xgboost

--- a/tests/plugins/test_xgboost_extensions.py
+++ b/tests/plugins/test_xgboost_extensions.py
@@ -17,6 +17,13 @@ def fitted_xgboost_model() -> xgboost.XGBModel:
     return model
 
 
+@pytest.fixture
+def fitted_xgboost_booster() -> xgboost.Booster:
+    dtrain = xgboost.DMatrix([[0]], label=[[0]])
+    booster = xgboost.train({"objective": "binary:logistic"}, dtrain, 1)
+    return booster
+
+
 def test_xgboost_model_json_writer(fitted_xgboost_model: xgboost.XGBModel, tmp_path: pathlib.Path) -> None:
     model_path = tmp_path / "model.json"
     writer = XGBoostJsonWriter(path=model_path)
@@ -38,6 +45,30 @@ def test_xgboost_model_json_reader(
     model, metadata = reader.load_data(xgboost.XGBRegressor)
 
     check_is_fitted(model)
+    assert XGBoostJsonReader.applicable_types() == [xgboost.XGBModel, xgboost.Booster]
+
+
+def test_xgboost_booster_json_writer(fitted_xgboost_booster: xgboost.Booster, tmp_path: pathlib.Path) -> None:
+    booster_path = tmp_path / "booster.json"
+    writer = XGBoostJsonWriter(path=booster_path)
+
+    metadata = writer.save_data(fitted_xgboost_booster)
+
+    assert booster_path.exists()
+    assert metadata["path"] == booster_path
+
+
+def test_xgboost_booster_json_reader(
+    fitted_xgboost_booster: xgboost.Booster,
+    tmp_path: pathlib.Path
+) -> None:
+    booster_path = tmp_path / "booster.json"
+    fitted_xgboost_booster.save_model(booster_path)
+    reader = XGBoostJsonReader(booster_path)
+
+    booster, metadata = reader.load_data(xgboost.Booster)
+
+    assert len(booster.get_dump()) > 0
     assert XGBoostJsonReader.applicable_types() == [xgboost.XGBModel, xgboost.Booster]
 
 

--- a/tests/plugins/test_xgboost_extensions.py
+++ b/tests/plugins/test_xgboost_extensions.py
@@ -1,0 +1,43 @@
+import pathlib
+
+import pytest
+import xgboost
+from sklearn.utils.validation import check_is_fitted
+
+from hamilton.plugins.xgboost_extensions import (
+    XGBoostJsonReader,
+    XGBoostJsonWriter,
+)
+
+
+@pytest.fixture
+def fitted_xgboost_model() -> xgboost.XGBModel:
+    model = xgboost.XGBRegressor()
+    model.fit([[0]], [[0]])
+    return model
+
+
+def test_xgboost_model_json_writer(fitted_xgboost_model: xgboost.XGBModel, tmp_path: pathlib.Path) -> None:
+    model_path = tmp_path / "model.json"
+    writer = XGBoostJsonWriter(path=model_path)
+
+    metadata = writer.save_data(fitted_xgboost_model)
+
+    assert model_path.exists()
+    assert metadata["path"] == model_path
+
+
+def test_xgboost_model_json_reader(
+    fitted_xgboost_model: xgboost.XGBModel,
+    tmp_path: pathlib.Path
+) -> None:
+    model_path = tmp_path / "model.json"
+    fitted_xgboost_model.save_model(model_path)
+    reader = XGBoostJsonReader(model_path)
+
+    model, metadata = reader.load_data(xgboost.XGBRegressor)
+
+    check_is_fitted(model)
+    assert XGBoostJsonReader.applicable_types() == [xgboost.XGBModel, xgboost.Booster]
+
+

--- a/tests/plugins/test_xgboost_extensions.py
+++ b/tests/plugins/test_xgboost_extensions.py
@@ -4,10 +4,7 @@ import pytest
 import xgboost
 from sklearn.utils.validation import check_is_fitted
 
-from hamilton.plugins.xgboost_extensions import (
-    XGBoostJsonReader,
-    XGBoostJsonWriter,
-)
+from hamilton.plugins.xgboost_extensions import XGBoostJsonReader, XGBoostJsonWriter
 
 
 @pytest.fixture
@@ -24,7 +21,9 @@ def fitted_xgboost_booster() -> xgboost.Booster:
     return booster
 
 
-def test_xgboost_model_json_writer(fitted_xgboost_model: xgboost.XGBModel, tmp_path: pathlib.Path) -> None:
+def test_xgboost_model_json_writer(
+    fitted_xgboost_model: xgboost.XGBModel, tmp_path: pathlib.Path
+) -> None:
     model_path = tmp_path / "model.json"
     writer = XGBoostJsonWriter(path=model_path)
 
@@ -35,8 +34,7 @@ def test_xgboost_model_json_writer(fitted_xgboost_model: xgboost.XGBModel, tmp_p
 
 
 def test_xgboost_model_json_reader(
-    fitted_xgboost_model: xgboost.XGBModel,
-    tmp_path: pathlib.Path
+    fitted_xgboost_model: xgboost.XGBModel, tmp_path: pathlib.Path
 ) -> None:
     model_path = tmp_path / "model.json"
     fitted_xgboost_model.save_model(model_path)
@@ -48,7 +46,9 @@ def test_xgboost_model_json_reader(
     assert XGBoostJsonReader.applicable_types() == [xgboost.XGBModel, xgboost.Booster]
 
 
-def test_xgboost_booster_json_writer(fitted_xgboost_booster: xgboost.Booster, tmp_path: pathlib.Path) -> None:
+def test_xgboost_booster_json_writer(
+    fitted_xgboost_booster: xgboost.Booster, tmp_path: pathlib.Path
+) -> None:
     booster_path = tmp_path / "booster.json"
     writer = XGBoostJsonWriter(path=booster_path)
 
@@ -59,8 +59,7 @@ def test_xgboost_booster_json_writer(fitted_xgboost_booster: xgboost.Booster, tm
 
 
 def test_xgboost_booster_json_reader(
-    fitted_xgboost_booster: xgboost.Booster,
-    tmp_path: pathlib.Path
+    fitted_xgboost_booster: xgboost.Booster, tmp_path: pathlib.Path
 ) -> None:
     booster_path = tmp_path / "booster.json"
     fitted_xgboost_booster.save_model(booster_path)
@@ -70,5 +69,3 @@ def test_xgboost_booster_json_reader(
 
     assert len(booster.get_dump()) > 0
     assert XGBoostJsonReader.applicable_types() == [xgboost.XGBModel, xgboost.Booster]
-
-


### PR DESCRIPTION
Follow-up to this PR: https://github.com/DAGWorks-Inc/hamilton/pull/459

XGBoostJsonWriter no longer checks for NotFittedError. This is consistent with LightGBMFileWriter and removes direct dependency with scikit-learn.

## Changes

## How I tested this

## Notes

## Checklist
All tests still pass
