### PR TITLE
Added Numpy `.npy`saver/loader

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -21,6 +21,7 @@ if not registry.INITIALIZED:
     # right now. Side note: ray serializes things weirdly, so we need to do this here rather than in
     # in the other choice of hamilton/base.py.
     plugins_modules = [
+        "numpy",
         "pandas",
         "polars",
         "pyspark_pandas",

--- a/hamilton/plugins/numpy_extensions.py
+++ b/hamilton/plugins/numpy_extensions.py
@@ -39,7 +39,7 @@ class NumpyNpyWriter(DataSaver):
 
     @classmethod
     def name(cls) -> str:
-        return "file"
+        return "npy"
 
 
 @dataclasses.dataclass
@@ -71,7 +71,7 @@ class NumpyNpyReader(DataLoader):
 
     @classmethod
     def name(cls) -> str:
-        return "file"
+        return "npy"
 
 
 def register_data_loaders():

--- a/hamilton/plugins/numpy_extensions.py
+++ b/hamilton/plugins/numpy_extensions.py
@@ -1,0 +1,87 @@
+import dataclasses
+import pathlib
+from typing import IO, Any, Collection, Dict, Optional, Tuple, Type, Union
+
+try:
+    import numpy as np
+except ImportError:
+    raise NotImplementedError("Numpy is not installed.")
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+from hamilton import registry
+from hamilton.io import utils
+from hamilton.io.data_adapters import DataLoader, DataSaver
+
+
+@dataclasses.dataclass
+class NumpyNpyWriter(DataSaver):
+    """Write Numpy multidimensional arrays to custom .npy format
+    ref: https://numpy.org/doc/stable/reference/routines.io.html
+    """
+
+    path: Union[str, pathlib.Path, IO]
+    allow_pickle: Optional[bool] = None
+    fix_imports: Optional[bool] = None
+
+    def save_data(self, data: np.ndarray) -> Dict[str, Any]:
+        np.save(
+            file=self.path, arr=data, allow_pickle=self.allow_pickle, fix_imports=self.fix_imports
+        )
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [np.ndarray]
+
+    @classmethod
+    def name(cls) -> str:
+        return "file"
+
+
+@dataclasses.dataclass
+class NumpyNpyReader(DataLoader):
+    """Read Numpy multidimensional arrays from custom .npy format
+    ref: https://numpy.org/doc/stable/reference/routines.io.html
+    """
+
+    path: Union[str, pathlib.Path, IO]
+    mmap_mode: Optional[str] = None
+    allow_pickle: Optional[bool] = None
+    fix_imports: Optional[bool] = None
+    encoding: Literal["ASCII", "latin1", "bytes"] = "ASCII"
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [np.ndarray]
+
+    def load_data(self, type_: Type) -> Tuple[np.ndarray, Dict[str, Any]]:
+        array = np.load(
+            file=self.path,
+            mmap_mode=self.mmap_mode,
+            allow_pickle=self.allow_pickle,
+            fix_imports=self.fix_imports,
+            encoding=self.encoding,
+        )
+        metadata = utils.get_file_metadata(self.path)
+        return array, metadata
+
+    @classmethod
+    def name(cls) -> str:
+        return "file"
+
+
+def register_data_loaders():
+    for loader in [
+        NumpyNpyWriter,
+        NumpyNpyReader,
+    ]:
+        registry.register_adapter(loader)
+
+
+register_data_loaders()
+
+COLUMN_FRIENDLY_DF_TYPE = False

--- a/tests/plugins/test_numpy_extensions.py
+++ b/tests/plugins/test_numpy_extensions.py
@@ -1,0 +1,32 @@
+import pathlib
+
+import numpy as np
+import pytest
+
+from hamilton.plugins.numpy_extensions import NumpyNpyReader, NumpyNpyWriter
+
+
+@pytest.fixture
+def array():
+    yield np.ones((3, 3, 3))
+
+
+def test_numpy_file_writer(array: np.ndarray, tmp_path: pathlib.Path) -> None:
+    file_path = tmp_path / "array.npy"
+
+    writer = NumpyNpyWriter(path=file_path)
+    metadata = writer.save_data(array)
+
+    assert file_path.exists()
+    assert metadata["path"] == file_path
+
+
+def test_numpy_file_reader(array: np.ndarray, tmp_path: pathlib.Path) -> None:
+    file_path = tmp_path / "array.npy"
+    np.save(file_path, array)
+
+    reader = NumpyNpyReader(path=file_path)
+    loaded_array, metadata = reader.load_data(np.ndarray)
+
+    assert np.equal(array, loaded_array).all()
+    assert NumpyNpyReader.applicable_types() == [np.ndarray]


### PR DESCRIPTION
--- PR TEMPLATE INSTRUCTIONS (2) ---

Added a NumpyNpyWriter and NumpyNpyReader using the Hamilton `file` format. This custom numpy format is efficient for multidimensional arrays which aren't directly supported by parquet for instance.

## Changes

## How I tested this
Added tests to `tests/plugins/test_numpy_extensions.py` for write and read.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
