### PR TITLE
GeoPandas ShapeFile Reader and Writer

### DIFF
--- a/hamilton/plugins/geopandas_extensions.py
+++ b/hamilton/plugins/geopandas_extensions.py
@@ -1,14 +1,50 @@
-from typing import Any
+import dataclasses
+import os
+from io import BufferedReader, BytesIO
+from pathlib import Path
+from typing import IO, Any, Collection, Dict, Optional, Tuple, Type, Union
+
+from pyproj import CRS
+from shapely import (
+    GeometryCollection,
+    LinearRing,
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
 
 try:
     import geopandas as gpd
 except ImportError:
     raise NotImplementedError("geopandas is not installed.")
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from hamilton import registry
+from hamilton.io import utils
+from hamilton.io.data_adapters import DataLoader, DataSaver
 
 DATAFRAME_TYPE = gpd.GeoDataFrame
 COLUMN_TYPE = gpd.GeoSeries
+
+Geometry = Optional[
+    Union[
+        Point,
+        LineString,
+        LinearRing,
+        Polygon,
+        MultiPoint,
+        MultiLineString,
+        MultiPolygon,
+        GeometryCollection,
+    ]
+]
 
 
 @registry.get_column.register(gpd.GeoDataFrame)
@@ -30,3 +66,104 @@ def register_types():
 
 
 register_types()
+
+
+@dataclasses.dataclass
+class GeopandasFileWriter(DataSaver):
+    """
+    Class that handles saving a GeoDataFrame to a file.
+    Maps to https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_file.html
+    """
+
+    filename: Union[str, os.PathLike, IO]
+    # kwargs
+    driver: Optional[str] = None
+    schema: Optional[Dict] = None
+    index: Optional[bool] = None
+    mode: str = "w"
+    crs: Optional[CRS] = None
+    engine: Literal["fiona", "pyogrio"] = None
+
+    # TODO Allow additional arguments via kwargs
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def _get_saving_kwargs(self) -> Dict[str, Any]:
+        saving_kwargs = {}
+        if self.driver is not None:
+            saving_kwargs["driver"] = self.driver
+        if self.schema is not None:
+            saving_kwargs["schema"] = self.schema
+        if self.index is not None:
+            saving_kwargs["index"] = self.index
+        if self.mode is not None:
+            saving_kwargs["mode"] = self.mode
+        if self.crs is not None:
+            saving_kwargs["crs"] = self.crs
+        if self.engine is not None:
+            saving_kwargs["engine"] = self.engine
+
+        return saving_kwargs
+
+    def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
+        data.to_file(self.filename, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.filename)
+
+    @classmethod
+    def name(cls) -> str:
+        return ["shp", "shx", "dbf"]
+
+
+@dataclasses.dataclass
+class GeopandasFileReader(DataLoader):
+    """
+    Class that handles reading files or URLs with Geopandas
+    Maps to https://geopandas.org/en/stable/docs/reference/api/geopandas.read_file.html
+    """
+
+    filename: Union[str, Path, BytesIO, BufferedReader]
+    # kwargs
+    bbox: Optional[Union[Tuple, DATAFRAME_TYPE, COLUMN_TYPE, Geometry]] = None
+    mask: Optional[Union[Dict, DATAFRAME_TYPE, COLUMN_TYPE, Geometry]] = None
+    rows: Optional[Union[int, slice]] = None
+    engine: Literal["fiona", "pyogrio"] = None
+
+    # TODO: allow additional arguments via kwargs
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [DATAFRAME_TYPE]
+
+    def _get_loading_kwargs(self) -> Dict[str, Any]:
+        loading_kwargs = {}
+
+        if self.bbox is not None:
+            loading_kwargs["bbox"] = self.bbox
+        if self.mask is not None:
+            loading_kwargs["mask"] = self.mask
+        if self.rows is not None:
+            loading_kwargs["rows"] = self.rows
+        if self.engine is not None:
+            loading_kwargs["engine"] = self.engine
+
+        return loading_kwargs
+
+    def load_data(self, type_: Type) -> Tuple[DATAFRAME_TYPE, Dict[str, Any]]:
+        gdf = gpd.read_file(self.filename, **self._get_loading_kwargs())
+        metedata = utils.get_file_metadata(self.filename)
+
+        return gdf, metedata
+
+    @classmethod
+    def name(cls) -> str:
+        return ["shp", "shx", "dbf"]
+
+
+def register_data_loaders():
+    """Function to register the data loaders for this extension."""
+    for loader in [
+        GeopandasFileReader,
+        GeopandasFileWriter,
+    ]:
+        registry.register_adapter(loader)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
+geodatasets
+geopandas
 graphviz
 lightgbm
 lxml
@@ -6,9 +8,11 @@ matplotlib
 networkx
 polars
 pyarrow
+pyproj
 pytest
 pytest-cov
 scikit-learn
+shapely
 sqlalchemy==1.4.49; python_version == '3.7.*'
 sqlalchemy; python_version >= '3.8'
 xgboost

--- a/tests/plugins/test_geopandas_extensions.py
+++ b/tests/plugins/test_geopandas_extensions.py
@@ -1,0 +1,33 @@
+import pathlib
+import geopandas as gpd 
+import geodatasets
+import sys
+from geopandas.testing import assert_geodataframe_equal
+
+from hamilton.plugins.pandas_extensions import (
+    GeopandasFileReader,
+    GeopandasFileWriter,
+)
+
+def test_geopandas_file(tmp_path: pathlib.Path) -> None:
+    # load in the example data
+    new_york_example_data = geopandas.read_file(geodatasets.get_path("nybb"))
+
+    #write the data to a shapefile
+    file_path = tmp_path / "ShapeFileTest"
+    writer = GeopandasFileWriter(filename=file_path)
+    metadata = writer.save_data(data = new_york_example_data)
+
+    #read in the multiple files that we output
+    dbf_file_path = tmp_path / "ShapeFileTest/ShapeFileTest.dbf" 
+    shp_file_path = tmp_path / "ShapeFileTest/ShapeFileTest.shp" 
+    shx_file_path = tmp_path / "ShapeFileTest/ShapeFileTest.shx"
+
+    dbf_data, dbf_metadata = GeopandasFileReader(dbf_file_path)
+    shp_data, shp_metadata = GeopandasFileReader(shp_file_path)
+    shx_data, shx_metadata = GeopandasFileReader(shx_file_path)
+
+    #check that each is the same as the original 
+    assert_geodataframe_equal(new_york_example_data, dbf_data)
+    assert_geodataframe_equal(new_york_example_data, shp_data)
+    assert_geodataframe_equal(new_york_example_data, shx_data)


### PR DESCRIPTION

WIP: Adding the GeoPandas FIle Read and Write Class to Hamilton. 

- GeopandasFileReader: https://geopandas.org/en/stable/docs/reference/api/geopandas.read_file.html
- GeopandasFileWriter:https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_file.html

## Changes
`geopandas_extensions.py` --> Adding the read and write class 
`requirements-test.txt` -> Adding additional requirements that are needed for the classes to work
`test_geopandas_extensions.py` --> Adding test for each of the files that are outputted 

## How I tested this
Added the classes and showed that they output data in a local notebook. I also wrote a single test to check that all the geodataframses that are outputted (dbf, shp, shx) which are all the memory files are the same as the original example file I used.

more info: https://en.wikipedia.org/wiki/Shapefile

## Notes
Still to do 

- [ ] Add _geopandas_ to `hamilton/function_modifiers/base.py` ??
- [ ] Add the ability to have additional arguments (kwargs) when the class is initialized
- [ ] Add a `my_functions.py` with some example functions from Geopandas
- [ ] Add a `my_script.py` which will run through all those example functions
- [ ] Create a notebook with a DAG output similar to the pandas extension 

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
