### PR TITLE
`Feature` Improved DAG visualization

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -249,7 +249,7 @@ def create_graphviz_graph(
 
         return node_style
 
-    def _get_function_modifier_style(modifier: str) -> dict[str, str]:
+    def _get_function_modifier_style(modifier: str) -> Dict[str, str]:
         """Get the style of a modifier. The dictionary returned
         is used to overwrite values of the base node style.
         Graphviz needs values to be strings.
@@ -269,7 +269,7 @@ def create_graphviz_graph(
 
         return modifier_style
 
-    def _get_edge_style(from_type: str, to_type: str) -> dict:
+    def _get_edge_style(from_type: str, to_type: str) -> Dict:
         """
 
         Graphviz needs values to be strings.

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -8,7 +8,7 @@ Note: one should largely consider the code in this module to be "private".
 import logging
 from enum import Enum
 from types import ModuleType
-from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Callable, Collection, Dict, FrozenSet, List, Optional, Set, Tuple, Type
 
 from hamilton import base, node
 from hamilton.execution import graph_functions
@@ -182,7 +182,7 @@ def create_graphviz_graph(
         type_ = n.type.__name__ if type_ is None else type_
         return f"<<b>{name}</b><br /><br /><i>{type_}</i>>"
 
-    def _get_input_label(input_nodes: frozenset[node.Node]) -> str:
+    def _get_input_label(input_nodes: FrozenSet[node.Node]) -> str:
         """Get a graphviz HTML-like node label formatted aspyer a table.
         Each row is a different input node with one column containing
         the name and the other the type.
@@ -289,7 +289,7 @@ def create_graphviz_graph(
 
         return edge_style
 
-    def _get_legend(node_types):
+    def _get_legend(node_types: Set[str]):
         """Create a visualization legend as a graphviz subgraph. The legend includes the
         node types and modifiers presente in the visualization.
         """

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -140,6 +140,7 @@ def create_graphviz_graph(
     graphviz_kwargs: dict,
     node_modifiers: Dict[str, Set[VisualizationNodeModifiers]],
     strictly_display_only_nodes_passed_in: bool,
+    show_legend: bool = True,
     orient: str = "LR",
     hide_inputs: bool = False,
     deduplicate_inputs: bool = False,
@@ -153,6 +154,7 @@ def create_graphviz_graph(
     :param node_modifiers: A dictionary of node names to dictionaries of node attributes to modify.
     :param strictly_display_only_nodes_passed_in: If True, only display the nodes passed in. Else defaults to displaying
         also what nodes a node depends on (i.e. all nodes that feed into it).
+    :param show_legend: If True, add a legend to the visualization based on the DAG's nodes.
     :param orient: `LR` stands for "left to right". Accepted values are TB, LR, BT, RL.
         `orient` will be overwridden by the value of `graphviz_kwargs['graph_attr']['rankdir']`
         see (https://graphviz.org/docs/attr-types/rankdir/)
@@ -427,7 +429,8 @@ def create_graphviz_graph(
             # create edge for input node
             digraph.edge(input_node_name, n.name)
 
-    digraph.subgraph(_get_legend(seen_node_types))
+    if show_legend:
+        digraph.subgraph(_get_legend(seen_node_types))
     return digraph
 
 

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -213,7 +213,7 @@ def create_graphviz_graph(
         else:
             return "function"
 
-    def _get_node_style(node_type: str) -> dict[str, str]:
+    def _get_node_style(node_type: str) -> Dict[str, str]:
         """Get the style of a node type.
         Graphviz needs values to be strings.
         """

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -183,7 +183,7 @@ def create_graphviz_graph(
         return f"<<b>{name}</b><br /><br /><i>{type_}</i>>"
 
     def _get_input_label(input_nodes: frozenset[node.Node]) -> str:
-        """Get a graphviz HTML-like node label formatted as a table.
+        """Get a graphviz HTML-like node label formatted aspyer a table.
         Each row is a different input node with one column containing
         the name and the other the type.
         ref: https://graphviz.org/doc/info/shapes.html#html
@@ -600,6 +600,10 @@ class FunctionGraph(object):
         graphviz_kwargs: dict = None,
         node_modifiers: Dict[str, Set[VisualizationNodeModifiers]] = None,
         strictly_display_only_passed_in_nodes: bool = False,
+        show_legend: bool = True,
+        orient: str = "LR",
+        hide_inputs: bool = False,
+        deduplicate_inputs: bool = False,
     ) -> Optional["graphviz.Digraph"]:  # noqa F821
         """Function to display the graph represented by the passed in nodes.
 
@@ -612,6 +616,13 @@ class FunctionGraph(object):
             e.g. {'node_name': {NodeModifiers.IS_USER_INPUT}} will set the node named 'node_name' to be a user input.
         :param strictly_display_only_passed_in_nodes: if True, only display the nodes passed in.  Else defaults to
             displaying also what nodes a node depends on (i.e. all nodes that feed into it).
+        :param show_legend: If True, add a legend to the visualization based on the DAG's nodes.
+        :param orient: `LR` stands for "left to right". Accepted values are TB, LR, BT, RL.
+            `orient` will be overwridden by the value of `graphviz_kwargs['graph_attr']['rankdir']`
+            see (https://graphviz.org/docs/attr-types/rankdir/)
+        :param hide_inputs: If True, no input nodes are displayed.
+        :param deduplicate_inputs: If True, remove duplicate input nodes.
+            Can improve readability depending on the specifics of the DAG.
         :return: the graphviz graph object if it was created. None if not.
         """
         # Check to see if optional dependencies have been installed.
@@ -633,6 +644,10 @@ class FunctionGraph(object):
             graphviz_kwargs,
             node_modifiers,
             strictly_display_only_passed_in_nodes,
+            show_legend,
+            orient,
+            hide_inputs,
+            deduplicate_inputs,
         )
         kwargs = {"view": True}
         if render_kwargs and isinstance(render_kwargs, dict):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,5 @@
 import inspect
+import pathlib
 import uuid
 from itertools import permutations
 
@@ -501,7 +502,7 @@ def test_function_graph_has_cycles_false():
     assert fg.has_cycles(nodes, user_nodes) is False
 
 
-def test_function_graph_display(tmp_path):
+def test_function_graph_display(tmp_path: pathlib.Path):
     """Tests that display saves a file"""
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
@@ -549,7 +550,7 @@ def test_function_graph_display(tmp_path):
     assert dot_set.issuperset(expected_set) and len(dot_set.difference(expected_set)) == 1
 
 
-def test_function_graph_display_no_dot_output(tmp_path):
+def test_function_graph_display_no_dot_output(tmp_path: pathlib.Path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
@@ -559,7 +560,7 @@ def test_function_graph_display_no_dot_output(tmp_path):
 
 
 @pytest.mark.parametrize("show_legend", [(True), (False)])
-def test_function_graph_display_legend(show_legend, tmp_path):
+def test_function_graph_display_legend(show_legend: bool, tmp_path: pathlib.Path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
@@ -576,7 +577,7 @@ def test_function_graph_display_legend(show_legend, tmp_path):
 
 
 @pytest.mark.parametrize("orient", [("LR"), ("TB"), ("RL"), ("BT")])
-def test_function_graph_display_orient(orient, tmp_path):
+def test_function_graph_display_orient(orient: str, tmp_path: pathlib.Path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
@@ -593,7 +594,7 @@ def test_function_graph_display_orient(orient, tmp_path):
 
 
 @pytest.mark.parametrize("hide_inputs", [(True), (False)])
-def test_function_graph_display_inputs(hide_inputs, tmp_path):
+def test_function_graph_display_inputs(hide_inputs: bool, tmp_path: pathlib.Path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,5 +1,4 @@
 import inspect
-import pathlib
 import uuid
 from itertools import permutations
 
@@ -502,7 +501,7 @@ def test_function_graph_has_cycles_false():
     assert fg.has_cycles(nodes, user_nodes) is False
 
 
-def test_function_graph_display(tmp_path: pathlib.Path):
+def test_function_graph_display(tmp_path):
     """Tests that display saves a file"""
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
@@ -550,7 +549,7 @@ def test_function_graph_display(tmp_path: pathlib.Path):
     assert dot_set.issuperset(expected_set) and len(dot_set.difference(expected_set)) == 1
 
 
-def test_function_graph_display_no_dot_output(tmp_path: pathlib.Path):
+def test_function_graph_display_no_dot_output(tmp_path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
@@ -560,7 +559,7 @@ def test_function_graph_display_no_dot_output(tmp_path: pathlib.Path):
 
 
 @pytest.mark.parametrize("show_legend", [(True), (False)])
-def test_function_graph_display_legend(show_legend: bool, tmp_path: pathlib.Path):
+def test_function_graph_display_legend(show_legend, tmp_path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
@@ -577,7 +576,7 @@ def test_function_graph_display_legend(show_legend: bool, tmp_path: pathlib.Path
 
 
 @pytest.mark.parametrize("orient", [("LR"), ("TB"), ("RL"), ("BT")])
-def test_function_graph_display_orient(orient: str, tmp_path: pathlib.Path):
+def test_function_graph_display_orient(orient, tmp_path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
@@ -594,7 +593,7 @@ def test_function_graph_display_orient(orient: str, tmp_path: pathlib.Path):
 
 
 @pytest.mark.parametrize("hide_inputs", [(True), (False)])
-def test_function_graph_display_inputs(hide_inputs: bool, tmp_path: pathlib.Path):
+def test_function_graph_display_inputs(hide_inputs, tmp_path):
     dot_file_path = tmp_path / "dag.dot"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 


### PR DESCRIPTION
I tried to improve the DAG visualization using the graphviz library. The visualization should be less cluttered and visually represent the expressivity of the Hamilton DAG (inputs, config, functions, materializers, overrides, etc.). I added a legend directory in the viz for better readability.

![](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/daad7e36-ea4a-428b-ba78-c3bd0e219fe1)

## Changes
All the changes are made to the function `create_graphviz_graph()`. The algorithm follows the same general structure: build nodes, then build edges. Several utility functions were created to centralized relevant definitions:
- create node label (same for all nodes except input nodes)
- get the node type (input, config, function)
- get node modifiers (override, output, collect, expand, materializer)
- create a legend based on the node types of the DAG
- added arguments to the internal function `create_graphviz_graph()` these should be wired with other user-facing visualization functions

Removed:
- no longer display "Input" or "Override" prefix to reduce space used
- the base shape for functions are rectangles / rounded rectangles, which take significantly less space than ellipses.

## How I tested this
Manually tested it with several DAGs. I included DAGs that used a maximum number of features.

## Notes
- Currently doesn't implement the Parallel/Collect special edges (but both types can now be distinguished from the node style)
- Modifiers are applied sequentially and may override each other. Currently, it is not the case because each modifier acts on a different property (shape, fillcolor, periphery color, style)
- Graph, nodes, and edges have a `style` attribute which is a comma-separated list with heterogeneous attributes. These attributes are hard to manage and overriden as a whole when updating `style`

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
