### PR TITLE
fixed type to string for Python <=3.9

### DIFF
--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -2,7 +2,7 @@ import inspect
 import sys
 import typing
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Generator, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Generator, Optional, Tuple, Type, TypeVar
 
 import typing_inspect
 
@@ -88,6 +88,25 @@ def custom_subclass_check(requested_type: Type, param_type: Type):
                 return requested_args == param_args
         return True
     return False
+
+
+def get_type_as_string(type_: Type) -> Optional[str]:
+    """Get a string representation of a type. Returns an empty string if everything fails
+
+    The logic supports the evolution of the type system between 3.8 and 3.10.
+    """
+
+    if getattr(type_, "__name__", None):
+        type_string = type_.__name__
+    elif typing_inspect.get_origin(type_):
+        base_type = typing_inspect.get_origin(type_)
+        type_string = get_type_as_string(base_type)
+    elif getattr(type_, "__repr__", None):
+        type_string = type_.__repr__()
+    else:
+        type_string = None
+
+    return type_string
 
 
 def types_match(

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -91,9 +91,11 @@ def custom_subclass_check(requested_type: Type, param_type: Type):
 
 
 def get_type_as_string(type_: Type) -> Optional[str]:
-    """Get a string representation of a type. Returns an empty string if everything fails
+    """Get a string representation of a type.
 
     The logic supports the evolution of the type system between 3.8 and 3.10.
+    :param type_: Any Type object. Typically the node type found at Node.type.
+    :return: string representation of the type. An empty string if everything fails.
     """
 
     if getattr(type_, "__name__", None):

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -150,3 +150,46 @@ def test_validate_types_sad(type_):
 )
 def test__safe_subclass(candidate, type_, expected):
     assert htypes._safe_subclass(candidate, type_) == expected
+
+
+@pytest.mark.parametrize(
+    "type_",
+    [
+        (custom_type),
+        (typing.TypeVar("FOO")),
+        (typing.Any),
+        (int),
+        (float),
+        (typing.List[int]),
+        (typing.List),
+        (list),
+        (typing.Iterable),
+        (typing.Dict),
+        (dict),
+        (typing.Mapping),
+        (collections.Counter),
+        (typing.Tuple[str, str]),
+        (typing.Tuple[str]),
+        (typing.Tuple),
+        (typing.Union[str, str]),
+        (X),
+        (Y),
+        (typing.Any),
+        (typing.Union[X, int]),
+        (typing.Union[str, X]),
+        (typing.Union[custom_type, X]),
+        (typing.Union[float, str]),
+        (typing.Union[int, float]),
+        (typing.FrozenSet[int]),
+        (typing.Set[int]),
+        (pd.Series),
+        (htypes.column[pd.Series, int]),
+        (pd.DataFrame),
+    ],
+)
+def test_get_type_as_string(type_):
+    """Tests the custom_subclass_check"""
+    try:
+        type_string = htypes.get_type_as_string(type_)  # noqa: F841
+    except Exception as e:
+        pytest.fail(f"test get_type_as_string raised: {e}")


### PR DESCRIPTION
The recent change to `create_graphviz_graph()` in `graph.py` lead to failures for Python 3.9. More precisely, the function `_get_node_label()` was checking the `__name__` attribute of some type objects, resuling in AttributeError exceptions.

## Changes
A generic utility function `get_type_as_string` was added to `htypes.py` to get an arbitrary type as a string. The function uses different strategies to get well-formatted strings of the type otherwise return `None`.The function `create_graphviz_graph()` was changed accordingly. 

## How I tested this
A new test was added to `tests/test_type_utils.py` to check that several complex types weren't resulting in exceptions.

## Notes
- The test could check specifically for `AttributeError`
- The test covers the type to string conversion, but misshandling string and None values in `_get_node_label()` and `create_graphviz_graph()` could hypothetically lead to errors

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
