### PR TITLE
Fix the displayed type for input node.

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -193,7 +193,7 @@ def create_graphviz_graph(
         rows = []
         for dep in input_nodes:
             name = dep.name
-            type_string = get_type_as_string(n.type) if get_type_as_string(n.type) else ""
+            type_string = get_type_as_string(dep.type) if get_type_as_string(dep.type) else ""
             rows.append(f"<tr><td>{name}</td><td>{type_string}</td></tr>")
         return f"<<table border=\"0\">{''.join(rows)}</table>>"
 


### PR DESCRIPTION
The previous PR changed how types were displayed from `_get_node_label()` and `_get_input_label()`. The function `_get_input_label()` now referenced a variable that no longer existed in the function and it picked up values from the broader scope. The issue was fixed by renaming the variable within the scope of `_get_input_label()`.

## Changes
Changed the variable `n` (no longer existed within the context of the node) to `dep`. 

## How I tested this
When comparing before / after this change, I am able to reproduce the incorrect input node types and then fix the issue.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
