### PR TITLE
Allows for dynamic registration of materializer types

### DIFF
--- a/docs/reference/io/available-data-adapters.rst
+++ b/docs/reference/io/available-data-adapters.rst
@@ -43,6 +43,10 @@ If you want to extend these, see :doc:`/reference/io/available-data-adapters` fo
 and `the example <https://github.com/DAGWorks-Inc/hamilton/blob/main/examples/materialization/README.md>`_
 in the repository for an example of how to do so.
 
+Note that you will need to call `registry.register_adapters` (or import a module that does that)
+prior to dynamically referring to these in the code -- otherwise we won't know about them, and
+won't be able to access that key!
+
 =============
 Data Loaders
 =============

--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -468,8 +468,8 @@ class save_to__meta__(type):
             return super().__getattribute__(item)
         except AttributeError as e:
             raise AttributeError(
-                "No saver named: {item} available for {cls.__name__}. "
-                "Available data savers are: {list(SAVER_REGISTRY.keys())}. "
+                f"No saver named: {item} available for {cls.__name__}. "
+                f"Available data savers are: {list(SAVER_REGISTRY.keys())}. "
                 "If you've gotten to this point, you either (1) spelled the "
                 "loader name wrong, (2) are trying to use a saver that does"
                 "not exist (yet). For a list of available savers, see "


### PR DESCRIPTION
Before we were just registering once. Now we synchrionize all konwn types if we detect a missing type -- a type that is in the registry but not in the associated class. Note that we could actually just go to the saver registry directly, but we like to add to it dynamically so we can refer to it, say, in a jupyter notebook. If we don't add it dynamically, we'll never know the available set.

## Changes

## How I tested this

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
