### PR TITLE
added Matplotlib data saver

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -21,6 +21,7 @@ if not registry.INITIALIZED:
     # right now. Side note: ray serializes things weirdly, so we need to do this here rather than in
     # in the other choice of hamilton/base.py.
     plugins_modules = [
+        "matplotlib",
         "numpy",
         "pandas",
         "polars",

--- a/hamilton/plugins/matplotlib_extensions.py
+++ b/hamilton/plugins/matplotlib_extensions.py
@@ -3,7 +3,9 @@ from os import PathLike
 from typing import IO, Any, Collection, Dict, List, Optional, Tuple, Type, Union
 
 try:
-    import matplotlib
+    from matplotlib.artist import Artist
+    from matplotlib.figure import Figure
+    from matplotlib.transforms import Bbox
 except ImportError:
     raise NotImplementedError("Matplotlib is not installed.")
 
@@ -22,7 +24,7 @@ class MatplotlibWriter(DataSaver):
     dpi: Optional[Union[float, str]] = None
     format: Optional[str] = None
     metadata: Optional[Dict] = None
-    bbox_inches: Optional[Union[str, matplotlib.transforms.Bbox]] = None
+    bbox_inches: Optional[Union[str, Bbox]] = None
     pad_inches: Optional[Union[float, str]] = None
     facecolor: Optional[Union[str, float, Tuple]] = None
     edgecolor: Optional[Union[str, float, Tuple]] = None
@@ -30,7 +32,7 @@ class MatplotlibWriter(DataSaver):
     orientation: Optional[str] = None
     papertype: Optional[str] = None
     transparent: Optional[bool] = None
-    bbox_extra_artists: Optional[List[matplotlib.artist.Artist]] = None
+    bbox_extra_artists: Optional[List[Artist]] = None
     pil_kwargs: Optional[Dict] = None
 
     def _get_saving_kwargs(self) -> dict:
@@ -62,14 +64,14 @@ class MatplotlibWriter(DataSaver):
 
         return kwargs
 
-    def save_data(self, data: matplotlib.figure.Figure) -> Dict[str, Any]:
+    def save_data(self, data: Figure) -> Dict[str, Any]:
         data.savefig(fname=self.path, **self._get_saving_kwargs())
         # TODO make utils.get_file_metadata() safer for when self.path is IO type
         return utils.get_file_metadata(self.path)
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [matplotlib.figure.Figure]
+        return [Figure]
 
     @classmethod
     def name(cls) -> str:

--- a/hamilton/plugins/matplotlib_extensions.py
+++ b/hamilton/plugins/matplotlib_extensions.py
@@ -1,0 +1,88 @@
+import dataclasses
+from os import PathLike
+from typing import IO, Any, Collection, Dict, List, Optional, Tuple, Type, Union
+
+try:
+    import matplotlib
+except ImportError:
+    raise NotImplementedError("Matplotlib is not installed.")
+
+from hamilton import registry
+from hamilton.io import utils
+from hamilton.io.data_adapters import DataSaver
+
+
+@dataclasses.dataclass
+class MatplotlibWriter(DataSaver):
+    """Write Matplotlib figure as static image format
+    ref: https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
+    """
+
+    path: Union[str, PathLike, IO]
+    dpi: Optional[Union[float, str]] = None
+    format: Optional[str] = None
+    metadata: Optional[Dict] = None
+    bbox_inches: Optional[Union[str, matplotlib.transforms.Bbox]] = None
+    pad_inches: Optional[Union[float, str]] = None
+    facecolor: Optional[Union[str, float, Tuple]] = None
+    edgecolor: Optional[Union[str, float, Tuple]] = None
+    backend: Optional[str] = None
+    orientation: Optional[str] = None
+    papertype: Optional[str] = None
+    transparent: Optional[bool] = None
+    bbox_extra_artists: Optional[List[matplotlib.artist.Artist]] = None
+    pil_kwargs: Optional[Dict] = None
+
+    def _get_saving_kwargs(self) -> dict:
+        kwargs = {}
+        if self.format is not None:
+            kwargs["format"] = self.format
+        if self.metadata is not None:
+            kwargs["metadata"] = self.metadata
+        if self.bbox_inches is not None:
+            kwargs["bbox_inches"] = self.bbox_inches
+        if self.pad_inches is not None:
+            kwargs["pad_inches"] = self.pad_inches
+        if self.facecolor is not None:
+            kwargs["facecolor"] = self.facecolor
+        if self.edgecolor is not None:
+            kwargs["edgecolor"] = self.edgecolor
+        if self.backend is not None:
+            kwargs["backend"] = self.backend
+        if self.orientation is not None:
+            kwargs["orientation"] = self.orientation
+        if self.papertype is not None:
+            kwargs["papertype"] = self.papertype
+        if self.transparent is not None:
+            kwargs["transparent"] = self.transparent
+        if self.bbox_extra_artists is not None:
+            kwargs["bbox_extra_artists"] = self.bbox_extra_artists
+        if self.pil_kwargs is not None:
+            kwargs["pil_kwargs"] = self.pil_kwargs
+
+        return kwargs
+
+    def save_data(self, data: matplotlib.figure.Figure) -> Dict[str, Any]:
+        data.savefig(fname=self.path, **self._get_saving_kwargs())
+        # TODO make utils.get_file_metadata() safer for when self.path is IO type
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [matplotlib.figure.Figure]
+
+    @classmethod
+    def name(cls) -> str:
+        return "plt"
+
+
+def register_data_savers():
+    for saver in [
+        MatplotlibWriter,
+    ]:
+        registry.register_adapter(saver)
+
+
+register_data_savers()
+
+COLUMN_FRIENDLY_DF_TYPE = False

--- a/tests/plugins/test_matplotlib_extensions.py
+++ b/tests/plugins/test_matplotlib_extensions.py
@@ -1,0 +1,30 @@
+import pathlib
+
+import matplotlib
+import matplotlib.pyplot as plt
+import pytest
+
+from hamilton.plugins.matplotlib_extensions import MatplotlibWriter
+
+
+def figure1():
+    fig = plt.figure()
+    plt.scatter([0, 1, 3], [0, 2.2, 2])
+    return fig
+
+
+def figure2():
+    fig, ax = plt.subplots()
+    ax.scatter([0, 1, 3], [0, 2.2, 2])
+    return fig
+
+
+@pytest.mark.parametrize("figure", [figure1(), figure2()])
+def test_plotly_static_writer(figure: matplotlib.figure.Figure, tmp_path: pathlib.Path) -> None:
+    file_path = tmp_path / "figure.png"
+
+    writer = MatplotlibWriter(path=file_path)
+    metadata = writer.save_data(figure)
+
+    assert file_path.exists()
+    assert metadata["path"] == file_path


### PR DESCRIPTION
Added a DataSaver to save matplotlib objects of type `matplotlib.figure.Figure`, i.e., resulting from `plt.figure()` and `plt.subplots()`.

## Changes
Added a `matplotlib_extensions.py` with the DataSaver class and added it to the registry

## How I tested this
Added a test to check the DataSaver properly writes to a file. I manually validated that the output file was correct.

## Notes
- The Matplotlib and the Plotly DataSaver accept as `path` argument objects of type `IO` (i.e., in-memory files, streams, etc.) which may fail when `hamilton.io.utils.get_file_metadata()` is called.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
