### PR TITLE
Fixed typo: `import dataflow` -> `import dataflows`

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -52,11 +52,11 @@ Here we dynamically download the dataflow from the internet and execute it. This
 iterating in a notebook and pulling in just the dataflow you need.
 
 ```python
-from hamilton import dataflow, driver
+from hamilton import dataflows, driver
 
 # downloads into ~/.hamilton/dataflows and loads the module -- WARNING: ensure you know what code you're importing!
-# NAME_OF_DATAFLOW = dataflow.import_module("NAME_OF_DATAFLOW") # if using official DAGWorks dataflow
-NAME_OF_DATAFLOW = dataflow.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
+# NAME_OF_DATAFLOW = dataflows.import_module("NAME_OF_DATAFLOW") # if using official DAGWorks dataflow
+NAME_OF_DATAFLOW = dataflows.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
 dr = (
   driver.Builder()
   .with_config({})  # replace with configuration as appropriate
@@ -78,14 +78,14 @@ you to easily modify the dataflow as you see fit.
 
 Run this in a notebook or python script to copy the dataflow to a directory of your choosing.
 ```python
-from hamilton import dataflow
+from hamilton import dataflows
 
 # dynamically pull and then copy
-NAME_OF_DATAFLOW = dataflow.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
-dataflow.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
+NAME_OF_DATAFLOW = dataflows.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
+dataflows.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
 # copy from the installed library
 from hamilton.contrib.user.NAME_OF_USER import NAME_OF_DATAFLOW
-dataflow.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
+dataflows.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
 ```
 You can then modify/import the code as you see fit. See [copy()](https://hamilton.dagworks.io/en/latest/reference/dataflows/copy/)
 for more details.

--- a/contrib/docs/docs/README.md
+++ b/contrib/docs/docs/README.md
@@ -72,11 +72,11 @@ Here we dynamically download the dataflow from the internet and execute it. This
 iterating in a notebook and pulling in just the dataflow you need.
 
 ```python
-from hamilton import dataflow, driver
+from hamilton import dataflows, driver
 
 # download into ~/.hamilton/dataflows and load the module -- WARNING: ensure you know what code you're importing!
-# NAME_OF_DATAFLOW = dataflow.import_module("NAME_OF_DATAFLOW") # if official dataflow
-NAME_OF_DATAFLOW = dataflow.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
+# NAME_OF_DATAFLOW = dataflows.import_module("NAME_OF_DATAFLOW") # if official dataflow
+NAME_OF_DATAFLOW = dataflows.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
 dr = (
   driver.Builder()
   .with_config({})  # replace with configuration as appropriate
@@ -97,14 +97,14 @@ you to easily modify the dataflow as you see fit.
 
 Run this in a notebook or python script to copy the dataflow to a directory of your choosing.
 ```python
-from hamilton import dataflow
+from hamilton import dataflows
 
 # dynamically pull and then copy
-NAME_OF_DATAFLOW = dataflow.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
-dataflow.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
+NAME_OF_DATAFLOW = dataflows.import_module("NAME_OF_DATAFLOW", "NAME_OF_USER")
+dataflows.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
 # copy from the installed library
 from hamilton.contrib.user.NAME_OF_USER import NAME_OF_DATAFLOW
-dataflow.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
+dataflows.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
 ```
 You can then modify/import the code as you see fit. See [copy()](https://hamilton.dagworks.io/en/latest/reference/dataflows/copy/)
 for more details.

--- a/docs/reference/dataflows/index.rst
+++ b/docs/reference/dataflows/index.rst
@@ -2,7 +2,7 @@
 Dataflows
 ==============
 
-Here lies reference documentation for `dataflow` module functions that
+Here lies reference documentation for `dataflows` module functions that
 integrate with the `hub.dagworks.io <https://hub.dagworks.io>`_ so you can pull off-the-shelf dataflows
 and get started quickly with Hamilton.
 


### PR DESCRIPTION
I tried following the contrib instructions and realized that `import dataflow` wasn't working. I fixed the documentation where I could find it:
- The Hub documentation README
- The contrib package README
- The Hamilton docs page on `dataflows`