### PR TITLE
Supports "Any" in loader types

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -509,6 +509,10 @@ class SimplePythonGraphAdapter(SimplePythonDataFrameGraphAdapter):
 
     This executes the Hamilton dataflow locally on a machine in a single threaded, single process fashion. It allows\
     you to specify a ResultBuilder to control the return type of what ``execute()`` returns.
+
+    Currently this extends SimplePythonDataFrameGraphAdapter, although that's largely for legacy reasons (and can probably be changed).
+
+    TODO -- change this to extend the right class.
     """
 
     def __init__(self, result_builder: ResultMixin = None):
@@ -523,6 +527,9 @@ class SimplePythonGraphAdapter(SimplePythonDataFrameGraphAdapter):
     def build_result(self, **outputs: Dict[str, Any]) -> Any:
         """Delegates to the result builder function supplied."""
         return self.result_builder.build_result(**outputs)
+
+    def output_type(self) -> Type:
+        return self.result_builder.output_type()
 
 
 class DefaultAdapter(SimplePythonGraphAdapter):

--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -104,7 +104,14 @@ def resolve_adapter_class(
     :return: The loader class to use.
     """
     applicable_adapters: List[Type[AdapterCommon]] = []
+    loaders_with_any = []
     for loader_cls in reversed(loader_classes):
+        # We do this here, rather than in applies_to, as its a bit of a special case
+        # Any should always get last priority, as its very non-specific and should be able to
+        # This is partially for backwards compatibility as we haven't always supported these -- including it now
+        # would potentially use the wrong loader for production cases
+        if Any in loader_cls.applicable_types():
+            loaders_with_any.append(loader_cls)
         if loader_cls.applies_to(type_):
             applicable_adapters.append(loader_cls)
     if len(applicable_adapters) > 0:
@@ -114,6 +121,8 @@ def resolve_adapter_class(
                 f"Using the last one registered {applicable_adapters[0]}."
             )
         return applicable_adapters[0]
+    if loaders_with_any:
+        return loaders_with_any[0]
     return None
 
 

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -86,7 +86,7 @@ class PickleLoader(DataLoader):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [object]
+        return [object, Any]
 
     @classmethod
     def name(cls) -> str:

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -211,6 +211,22 @@ class StringDataLoader(DataLoader):
 
 
 @dataclasses.dataclass
+class AnyDataLoader(DataLoader):
+    value: Any
+
+    def load_data(self, type_: Type) -> Tuple[Any, Dict[str, Any]]:
+        return self.value, {"loader": "any_data_loader"}
+
+    @classmethod
+    def name(cls) -> str:
+        return "dummy"
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [Any]
+
+
+@dataclasses.dataclass
 class IntDataLoader(DataLoader):
     def load_data(self, type_: Type) -> Tuple[int, Dict[str, Any]]:
         return 1, {"loader": "int_data_loader"}
@@ -301,6 +317,8 @@ def test_validate_selects_correct_type():
         (str, [IntDataLoader], None),
         (dict, [IntDataLoader], None),
         (dict, [IntDataLoader, StringDataLoader], None),
+        (str, [AnyDataLoader, StringDataLoader], StringDataLoader),
+        (dict, [AnyDataLoader, StringDataLoader], AnyDataLoader),
     ],
 )
 def test_resolve_correct_loader_class(


### PR DESCRIPTION
There are certain cases where the loader can load any datatype , E.G. pickle-type loaders. Before this didn't work. The "proper" solution would be to change custom_subclass_check, but that has the possibility of breaking some cases of materialization as we have not always been consistent here. In this case, it *just* uses a loader with `Any` if another has not been specified. While this might casue the order to be slightly counter-intuitive, it will ensure full backwrads compatibility.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
