### PR TITLE
Multiple Usability Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,6 @@ workflows:
       - test:
           requires:
             - check_for_changes
-          name: asyncio-py311
+          name: asyncio-py312
           python-version: '3.12'
           task: async

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -61,7 +61,7 @@ def capture_function_usage(call_fn: Callable) -> Callable:
                 except Exception as e:
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.error(
-                            f"Failed to send telemetry for function usage. Encountered:{e}\n"
+                            f"Failed to send telemetry for function usage. Encountered: {e}\n"
                         )
 
     return wrapped_fn
@@ -77,7 +77,8 @@ class Variable:
     type: typing.Type
     tags: Dict[str, str] = field(default_factory=dict)
     is_external_input: bool = field(default=False)
-    originating_functions: Optional[Tuple[Callable, ...]] = None
+    originating_functions: Optional[Tuple[Callable, ...]] = field(default=None)
+    documentation: Optional[str] = field(default=None)
 
     @staticmethod
     def from_node(n: node.Node) -> "Variable":
@@ -92,6 +93,7 @@ class Variable:
             tags=n.tags,
             is_external_input=n.user_defined,
             originating_functions=n.originating_functions,
+            documentation=n.documentation,
         )
 
 
@@ -366,12 +368,12 @@ class Driver:
                 user_node.type, all_inputs[user_node.name]
             ):
                 errors.append(
-                    f"Error: Type requirement mismatch. Expected {user_node.name}:{user_node.type} "
-                    f"got {all_inputs[user_node.name]}:{type(all_inputs[user_node.name])} instead."
+                    f"Error: Type requirement mismatch. Expected {user_node.name}:{user_node.type} "  # noqa: E231
+                    f"got {all_inputs[user_node.name]}:{type(all_inputs[user_node.name])} instead."  # noqa: E231
                 )
         if errors:
             errors.sort()
-            error_str = f"{len(errors)} errors encountered:\n  " + "\n  ".join(errors)
+            error_str = f"{len(errors)} errors encountered: \n  " + "\n  ".join(errors)
             raise ValueError(error_str)
 
     def execute(
@@ -462,7 +464,7 @@ class Driver:
             except Exception as e:
                 # we don't want this to fail at all!
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"Error caught in processing telemetry:\n{e}")
+                    logger.debug(f"Error caught in processing telemetry: \n{e}")
 
     def raw_execute(
         self,
@@ -849,9 +851,13 @@ class Driver:
         all_variables = {n.name: n for n in self.graph.get_nodes()}
         # ensure that the nodes exist
         if upstream_node_name not in all_variables:
-            raise ValueError(f"Upstream node {upstream_node_name} not found in graph.")
+            raise ValueError(
+                f"Upstream node {upstream_node_name} not found in graph."  # noqa: E713
+            )  # noqa: E713
         if downstream_node_name not in all_variables:
-            raise ValueError(f"Downstream node {downstream_node_name} not found in graph.")
+            raise ValueError(
+                f"Downstream node {downstream_node_name} not found in graph."  # noqa: E713
+            )  # noqa: E713
         nodes_for_path = self._get_nodes_between(upstream_node_name, downstream_node_name)
         return [Variable.from_node(n) for n in nodes_for_path]
 
@@ -918,9 +924,13 @@ class Driver:
         all_variables = {n.name: n for n in self.graph.get_nodes()}
         # ensure that the nodes exist
         if upstream_node_name not in all_variables:
-            raise ValueError(f"Upstream node {upstream_node_name} not found in graph.")
+            raise ValueError(
+                f"Upstream node {upstream_node_name} not found in graph."  # noqa: E713
+            )  # noqa: E713
         if downstream_node_name not in all_variables:
-            raise ValueError(f"Downstream node {downstream_node_name} not found in graph.")
+            raise ValueError(
+                f"Downstream node {downstream_node_name} not found in graph."  # noqa: E713
+            )  # noqa: E713
 
         # set whether the node is user input
         node_modifiers = {}

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -853,11 +853,11 @@ class Driver:
         if upstream_node_name not in all_variables:
             raise ValueError(
                 f"Upstream node {upstream_node_name} not found in graph."  # noqa: E713
-            )  # noqa: E713
+            )
         if downstream_node_name not in all_variables:
             raise ValueError(
                 f"Downstream node {downstream_node_name} not found in graph."  # noqa: E713
-            )  # noqa: E713
+            )
         nodes_for_path = self._get_nodes_between(upstream_node_name, downstream_node_name)
         return [Variable.from_node(n) for n in nodes_for_path]
 

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -256,16 +256,16 @@ class parameterize(base.NodeExpander):
                         param
                     ] = val  # We just use the standard one, nothing is getting replaced
             nodes.append(
-                node.Node(
+                node_.copy_with(
                     name=output_node,
-                    typ=node_.type,
                     doc_string=docstring,  # TODO -- change docstring
                     callabl=functools.partial(
                         replacement_function,
                         **{parameter: val.value for parameter, val in literal_dependencies.items()},
                     ),
                     input_types=new_input_types,
-                    tags=node_.tags.copy(),
+                    include_refs=False  # Include refs is here as this is earlier than compile time
+                    # TODO -- figure out why this isn't getting replaced later...
                 )
             )
         return nodes
@@ -287,7 +287,7 @@ class parameterize(base.NodeExpander):
 
         if self.RESERVED_KWARG in func_param_names:
             raise base.InvalidDecoratorException(
-                f"Error function {fn.__module__}.{fn.__name__} cannot have `{self.RESERVED_KWARG}` "
+                f"Error function {fn.__module__}.{fn.__name__} cannot have '{self.RESERVED_KWARG}'"
                 f"as a parameter it is reserved."
             )
         missing_parameters = set()
@@ -344,7 +344,7 @@ class parameterize(base.NodeExpander):
                             invalid_types.append((param, param_annotation))
             if invalid_types:
                 raise base.InvalidDecoratorException(
-                    f"Validation for fn: {fn.__qualname__} All parameters with a group() parameterization must be annotated as a list:"
+                    f"Validation for fn: {fn.__qualname__} All parameters with a group() parameterization must be annotated as a list: "
                     f"the following are not: {', '.join([f'{param} ({annotation})' for param, annotation in invalid_types])}"
                 )
 

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -282,8 +282,8 @@ class Node(object):
             doc_string=self.documentation,
             callabl=self.callable,
             node_source=self.node_role,
-            input_types=self.input_types,
-            tags=self.tags,
+            input_types=self.input_types.copy(),
+            tags=self.tags.copy(),
             originating_functions=self.originating_functions,
         )
         constructor_args.update(**overrides)

--- a/tests/resources/dynamic_parallelism/parallel_collect_multiple_arguments.py
+++ b/tests/resources/dynamic_parallelism/parallel_collect_multiple_arguments.py
@@ -1,0 +1,45 @@
+import collections
+import functools
+
+from hamilton.htypes import Collect, Parallelizable
+
+_fn_call_counter = collections.Counter()
+
+
+def _track_fn_call(fn) -> callable:
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        _fn_call_counter[fn.__name__] += 1
+        return fn(*args, **kwargs)
+
+    return wrapped
+
+
+def _reset_counter():
+    _fn_call_counter.clear()
+
+
+@_track_fn_call
+def not_to_repeat() -> int:
+    return -1
+
+
+@_track_fn_call
+def number_to_repeat(iterations: int) -> Parallelizable[int]:
+    for i in range(iterations):
+        yield i
+
+
+@_track_fn_call
+def something_else_not_to_repeat() -> int:
+    return -2
+
+
+@_track_fn_call
+def double(number_to_repeat: int) -> int:
+    return number_to_repeat * 2
+
+
+@_track_fn_call
+def summed(double: Collect[int], not_to_repeat: int, something_else_not_to_repeat: int) -> int:
+    return sum(double) + not_to_repeat + something_else_not_to_repeat

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -9,7 +9,7 @@ import tests.resources.dynamic_parallelism.parallel_linear_basic
 import tests.resources.tagging
 import tests.resources.test_default_args
 import tests.resources.very_simple_dag
-from hamilton import base
+from hamilton import base, node
 from hamilton.driver import (
     Builder,
     Driver,
@@ -494,3 +494,20 @@ def test_validate_materialization_sad(tmp_path):
             to.pickle(id="1", path=f"{tmp_path}/foo.pkl", dependencies=["c"]),
             inputs={},
         )
+
+
+def test_variable_from_node():
+    # Quick test for creating variables from nodes --
+    # this is simple but its nice to have
+
+    def func_to_test(a: int) -> int:
+        """This is a doctstring"""
+        return a + 1
+
+    n = node.Node.from_fn(func_to_test)
+    v = Variable.from_node(n)
+    assert v.name == n.name
+    assert v.type == n.type
+    assert v.tags == n.tags
+    assert v.documentation == n.documentation == "This is a doctstring"
+    assert v.originating_functions == n.originating_functions


### PR DESCRIPTION
Fixes:
- [ ] parameterize + Parallel
- [ ] Adds documentation to `Variable` object

We weren't copying over the node source. This is a quick fix, but the better, longer-term fix is to ensure we use `copy_with`. That'll come next, this is just to unblock an OS user.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
