### PR TITLE
Fix version check script

### DIFF
--- a/.github/workflows/contrib-auto-build-publish.yml
+++ b/.github/workflows/contrib-auto-build-publish.yml
@@ -36,7 +36,6 @@ jobs:
         # For example, use a Python script that uses the `packaging` library to compare versions
         # Set the output `version_is_greater` to `true` or `false`
         pip install requests packaging
-        pip install -e .
         python scripts/version_check.py
 
     # Install dependencies required to build

--- a/contrib/hamilton/contrib/version.py
+++ b/contrib/hamilton/contrib/version.py
@@ -1,1 +1,1 @@
-VERSION = (0, 0, 2)
+VERSION = (0, 0, 3)

--- a/contrib/scripts/version_check.py
+++ b/contrib/scripts/version_check.py
@@ -1,10 +1,14 @@
 import requests
 from packaging import version
 
-# Assume CURRENT_VERSION is extracted from your package file
-from hamilton.contrib import version as contrib_version
+VERSION = None
+with open("hamilton/contrib/version.py", "r") as f:
+    lines = f.readlines()
+    for line in lines:
+        if line.startswith("VERSION"):
+            exec(line)  # this will set VERSION to the correct tuple.
 
-CURRENT_VERSION = ".".join(map(str, contrib_version.VERSION))
+CURRENT_VERSION = ".".join(map(str, VERSION))
 
 # Replace 'your-package-name' with your actual package name on PyPI
 response = requests.get("https://pypi.org/pypi/sf-hamilton-contrib/json")


### PR DESCRIPTION
Fixes version check script

There is something funky going on. This only just suddenly started to break.
So it could be we were just lucky and now some installation non-determinism
is throwing things off, or something else changed...

Otherwise this hacks around the case of `pip install -e .` not doing the
correct thing due the package structure we've set up.

## Changes
 - script changes

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
