### PR TITLE
Errors out when calling create_temporary_module with functions that

### DIFF
--- a/hamilton/ad_hoc_utils.py
+++ b/hamilton/ad_hoc_utils.py
@@ -30,6 +30,8 @@ def create_temporary_module(*functions: Callable, module_name: str = None) -> Mo
     NOTE (2): that this is slightly dangerous -- we want the module to look and feel like an actual module
     so we can fully duck-type it. We thus stick it in sys.modules (checking if it already exists).
 
+    NOTE (3): If you pass in functions that start with "_" we will error out! That will just confuse you in the long run.
+
     :param functions: Functions to use
     :param module_name: Module name to use. If not provided will default to a unique one.
     :return: a "module" housing the passed in functions
@@ -43,6 +45,12 @@ def create_temporary_module(*functions: Callable, module_name: str = None) -> Mo
         if hasattr(module, fn_name):
             raise ValueError(
                 f"Duplicate/reserved function name: {fn_name} cannot be used to create a temporary module."
+            )
+        if fn_name.startswith("_"):
+            raise ValueError(
+                f"In Hamilton, functions that start with '_' are reserved as helpers, and cannot be compiled into nodes in a DAG. "
+                f"The function {fn_name} starts with '_' and would thus be pointless to include in a temprary module created"
+                f" solely for the purpose of building a Hamilton DAG."
             )
         fn.__module__ = module.__name__
         setattr(module, fn_name, fn)

--- a/tests/test_ad_hoc_utils.py
+++ b/tests/test_ad_hoc_utils.py
@@ -1,5 +1,7 @@
 import inspect
 
+import pytest
+
 from hamilton import ad_hoc_utils, function_modifiers
 
 
@@ -37,6 +39,10 @@ def test_create_temporary_module():
         """dummy function"""
         return bar + 1
 
+    def _baz(bar: int) -> int:
+        """dummy function, not to be included"""
+        return bar + 1
+
     temp_module = ad_hoc_utils.create_temporary_module(bar, foo)
     expected_members = {
         "__spec__",
@@ -52,3 +58,22 @@ def test_create_temporary_module():
     temp_module_2 = ad_hoc_utils.create_temporary_module(bar, foo, module_name="test_module")
     assert set(dict(inspect.getmembers(temp_module_2)).keys()) == expected_members
     assert temp_module_2.__name__ == "test_module"
+
+
+def test_create_temporary_module_breaks_helper():
+    """Tests that we create a module with the passed in functions."""
+
+    def bar(baz: int) -> int:
+        """dummy function"""
+        return baz + 1
+
+    def foo(bar: int) -> int:
+        """dummy function"""
+        return bar + 1
+
+    def _baz(bar: int) -> int:
+        """dummy function, not to be included"""
+        return bar + 1
+
+    with pytest.raises(ValueError):
+        ad_hoc_utils.create_temporary_module(bar, foo, _baz)


### PR DESCRIPTION
start with "_"

See https://github.com/DAGWorks-Inc/hamilton/issues/510

This is *not* backwards compatible, but this is a specific "ad-hoc" util and has an easy fix, so I'm OK not bumping versions accordingly. I would consider this previously undefined behavior, and this will make debugging easier.

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
