### PR TITLE
Fixes dagworks hub contrib docs

### DIFF
--- a/contrib/docs/compile_docs.py
+++ b/contrib/docs/compile_docs.py
@@ -215,15 +215,25 @@ import example2 from '!!raw-loader!./example2.py';
 
 <CodeBlock language="python">{{example2}}</CodeBlock>
 
+### Modify for your needs
+Now if you want to modify the dataflow, you can copy it to a new folder (renaming is possible), and modify it there.
+
+<CodeBlock language="python">
+dataflows.copy({DATAFLOW_NAME}, "path/to/save/to")
+</CodeBlock>
+
+<hr/>
+
 {README}
 
 ## Source code
-TODO: make collapsable.
 
 import MyComponentSource from '!!raw-loader!./__init__.py';
 
-<CodeBlock language="python">{{MyComponentSource}}</CodeBlock>
-
+<details>
+    <summary>__init__.py</summary>
+    <CodeBlock language="python">{{MyComponentSource}}</CodeBlock>
+</details>
 
 ## Requirements
 import requirements from '!!raw-loader!./requirements.txt';


### PR DESCRIPTION
They weren't showing how to quickly modify code, etc.

## Changes
 - compile code

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
