### PR TITLE
Fixes parallel case with empty list

### DIFF
--- a/hamilton/execution/state.py
+++ b/hamilton/execution/state.py
@@ -459,6 +459,9 @@ class ExecutionState:
             for dependency_base, dependencies in task.realized_dependencies.copy().items():
                 # We know that if one has the collector node, they all will
                 # As that's how we run it
+                if len(dependencies) == 0:
+                    # This is a parameterized task, so we'll just end up passing an empty array, and not computing anything from it
+                    continue
                 produces_collector_arg = self.task_pool[dependencies[0]].produces(collector_arg)
                 if produces_collector_arg:
                     for dependency in dependencies:

--- a/tests/execution/test_executors.py
+++ b/tests/execution/test_executors.py
@@ -330,3 +330,17 @@ def test_parallel_end_to_end_with_collect_multiple_inputs():
         "double": ITERS,
         "summed": 1,
     }
+
+
+def test_parallel_end_to_end_with_empty_list():
+    dr = (
+        driver.Builder()
+        .with_modules(parallel_linear_basic)
+        .enable_dynamic_execution(allow_experimental_mode=True)
+        .with_remote_executor(SynchronousLocalTaskExecutor())
+        .with_adapter(base.DefaultAdapter())
+        .build()
+    )
+    parallel_collect_multiple_arguments._reset_counter()
+    res = dr.execute(["final"], overrides={"number_of_steps": 0})
+    assert res["final"] == parallel_linear_basic._calc(0)

--- a/tests/resources/dynamic_parallelism/parallel_linear_basic.py
+++ b/tests/resources/dynamic_parallelism/parallel_linear_basic.py
@@ -38,9 +38,8 @@ def final(sum_step_squared_plus_step_cubed: int) -> int:
     return sum_step_squared_plus_step_cubed
 
 
-def _calc():
-    number_of_steps_ = number_of_steps()
-    steps_ = steps(number_of_steps_)
+def _calc(number_of_steps: int = number_of_steps()) -> int:
+    steps_ = steps(number_of_steps)
     to_sum = []
     for step_ in steps_:
         step_squared_ = step_squared(step_)

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -100,7 +100,7 @@ def test_driver_has_cycles_true(driver_factory):
         # TODO -- fix erroring out when we try to run a driver with cycles
         # should display a better error
         # (lambda: Builder()
-        #     .enabble_parallelizable_type(allow_experimental_mode=True)
+        #     .enable_parallelizable_type(allow_experimental_mode=True)
         #     .with_modules(tests.resources.cyclic_functions)
         #     .with_remote_executor(executors.SynchronousLocalTaskExecutor())
         #     .with_adapter(base.DefaultAdapter())


### PR DESCRIPTION
This was broken as we assumed the list was not empty. This special-cases it. We should probably be breaking this into functions so we can add more unit tests, but given the experimental nature of this I'm not worried. Don't want to over-engineer. The fix will work nicely for now.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
