### PR TITLE
Tweaks error message to make it harder to miss

### DIFF
--- a/hamilton/execution/graph_functions.py
+++ b/hamilton/execution/graph_functions.py
@@ -146,7 +146,9 @@ def execute_subdag(
             try:
                 value = adapter.execute_node(node_, kwargs)
             except Exception:
-                logger.exception(f"Node {node_.name} encountered an error")
+                message = f"> Node {node_.name} encountered an error <"
+                border = "*" * len(message)
+                logger.exception("\n" + border + "\n" + message + "\n" + border)
                 raise
         computed[node_.name] = value
         # > pruning the graph


### PR DESCRIPTION
Adds a block to explicitly make it hard to not miss which node threw the error.

```
ERROR:hamilton.execution.graph_functions:
****************************************
> Node spend_mean encountered an error <
****************************************
```

## Changes
 - graph_functions.py

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
