### PR TITLE
Adds examples showing printing of inputs with node error

### DIFF
--- a/hamilton/execution/graph_functions.py
+++ b/hamilton/execution/graph_functions.py
@@ -146,8 +146,20 @@ def execute_subdag(
             try:
                 value = adapter.execute_node(node_, kwargs)
             except Exception:
-                message = f"> Node {node_.name} encountered an error <"
-                border = "*" * len(message)
+                if hasattr(node_.originating_functions[0], "__original_name__"):
+                    original_func_name = node_.originating_functions[0].__original_name__
+                else:
+                    original_func_name = node_.originating_functions[0].__name__
+                module = node_.originating_functions[0].__module__
+                message = f"> {node_.name} [{module}.{original_func_name}()] encountered an error"
+                padding = " " * (80 - len(message) - 1)
+                message += padding + "<"
+                import pprint
+
+                pp = pprint.PrettyPrinter(width=80)
+                input_string = pp.pformat(kwargs)
+                message += "\n> Node inputs:\n" + input_string
+                border = "*" * 80
                 logger.exception("\n" + border + "\n" + message + "\n" + border)
                 raise
         computed[node_.name] = value

--- a/hamilton/execution/graph_functions.py
+++ b/hamilton/execution/graph_functions.py
@@ -146,11 +146,21 @@ def execute_subdag(
             try:
                 value = adapter.execute_node(node_, kwargs)
             except Exception:
-                if hasattr(node_.originating_functions[0], "__original_name__"):
-                    original_func_name = node_.originating_functions[0].__original_name__
-                else:
-                    original_func_name = node_.originating_functions[0].__name__
-                module = node_.originating_functions[0].__module__
+                # This code is coupled to how @config resolution works. Ideally it shouldn't be,
+                # so when @config resolvers are changed to return Nodes, then fn.__name__ should
+                # just work.
+                original_func_name = "unknown"
+                if node_.originating_functions:
+                    if hasattr(node_.originating_functions[0], "__original_name__"):
+                        original_func_name = node_.originating_functions[0].__original_name__
+                    else:
+                        original_func_name = node_.originating_functions[0].__name__
+                module = (
+                    node_.originating_functions[0].__module__
+                    if node_.originating_functions
+                    and hasattr(node_.originating_functions[0], "__module__")
+                    else "unknown_module"
+                )
                 message = f"> {node_.name} [{module}.{original_func_name}()] encountered an error"
                 padding = " " * (80 - len(message) - 1)
                 message += padding + "<"

--- a/hamilton/function_modifiers/configuration.py
+++ b/hamilton/function_modifiers/configuration.py
@@ -175,6 +175,7 @@ class config(base.NodeResolver):
     def resolve(self, fn, config: Dict[str, Any]) -> Callable:
         if not self.does_resolve(config):
             return None
+        fn.__original_name__ = fn.__name__
         fn.__name__ = self._get_function_name(fn)  # TODO -- copy function to not mutate it
         return fn
 

--- a/hamilton/function_modifiers/configuration.py
+++ b/hamilton/function_modifiers/configuration.py
@@ -175,6 +175,10 @@ class config(base.NodeResolver):
     def resolve(self, fn, config: Dict[str, Any]) -> Callable:
         if not self.does_resolve(config):
             return None
+        # attaches config keys used to resolve function
+        fn.__config_decorated__ = (
+            self._config_used if self._config_used is not None else ["__UNKNOWN__"]
+        )
         fn.__original_name__ = fn.__name__
         fn.__name__ = self._get_function_name(fn)  # TODO -- copy function to not mutate it
         return fn

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -278,12 +278,15 @@ class Node(object):
                     node_source = NodeType.COLLECT
                     break
         module = inspect.getmodule(fn).__name__
+        tags = {"module": module}
+        if hasattr(fn, "__config_decorated__"):
+            tags["hamilton.config"] = ",".join(fn.__config_decorated__)
         return Node(
             name,
             return_type,
             fn.__doc__ if fn.__doc__ else "",
             callabl=fn,
-            tags={"module": module},
+            tags=tags,
             node_source=node_source,
         )
 

--- a/tests/function_modifiers/test_configuration.py
+++ b/tests/function_modifiers/test_configuration.py
@@ -71,7 +71,9 @@ def test_config_name_resolution():
         pass
 
     annotation = function_modifiers.config.when(key="value")
-    assert annotation.resolve(fn__v2, {"key": "value"}).__name__ == "fn"
+    result = annotation.resolve(fn__v2, {"key": "value"})
+    assert result.__name__ == "fn"
+    assert result.__original_name__ == "fn__v2"
 
 
 def test_config_when_with_custom_name():
@@ -79,7 +81,9 @@ def test_config_when_with_custom_name():
         pass
 
     annotation = function_modifiers.config.when(key="value", name="new_function_name")
-    assert annotation.resolve(config_when_fn, {"key": "value"}).__name__ == "new_function_name"
+    result = annotation.resolve(config_when_fn, {"key": "value"})
+    assert result.__name__ == "new_function_name"
+    assert result.__original_name__ == "config_when_fn"
 
 
 def test_config_base_resolve_nodes():


### PR DESCRIPTION
So this will:

1. print the name, and the original function name
2. print the node inputs

E.g.

********************************************************************************
> spend_std_dev [my_functions.spend_std_dev()] encountered an error            <
> Node inputs:
{'spend': 0    10
1    10
2    20
3    40
4    40
5    50
dtype: int64}
********************************************************************************

This will help make it easier to debug a function failure.

I chose pprint, since it has a mode to limit the width on a best effort basis to keep things looking reasonably tidy.

## Changes
 - graph_functions
 - @ config decorator
 - configuration 
 - function_modifiers.base

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
