### PR TITLE
Do not fail default NaN validation on empty series

### DIFF
--- a/hamilton/data_quality/default_validators.py
+++ b/hamilton/data_quality/default_validators.py
@@ -198,7 +198,7 @@ class MaxFractionNansValidatorPandasSeries(base.BaseDefaultValidator):
     def validate(self, data: pd.Series) -> base.ValidationResult:
         total_length = len(data)
         total_na = data.isna().sum()
-        fraction_na = total_na / total_length
+        fraction_na = total_na / total_length if total_length > 0 else 0
         passes = fraction_na <= self.max_fraction_nans
         return base.ValidationResult(
             passes=passes,

--- a/tests/test_default_data_quality.py
+++ b/tests/test_default_data_quality.py
@@ -155,6 +155,18 @@ def test_resolve_default_validators_error(output_type, kwargs, importance):
             False,
         ),
         (
+            default_validators.MaxFractionNansValidatorPandasSeries,
+            0,
+            pd.Series([]),
+            True,
+        ),
+        (
+            default_validators.MaxFractionNansValidatorPandasSeries,
+            1,
+            pd.Series([]),
+            True,
+        ),
+        (
             default_validators.DataTypeValidatorPandasSeries,
             numpy.dtype("int"),
             pd.Series([1, 2, 3]),


### PR DESCRIPTION
If the validated series is empty, then it makes sense to treat it as if 0% of the values are NaN.

## Changes

The only change is to set the nan fraction to 0 if the series is empty.

## How I tested this

Unit tests are added for the case of empty series.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
