### PR TITLE
Extends Pandera validator to handle more DF types

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -27,6 +27,7 @@ fi
 
 if [[ ${TASK} == "integrations" ]]; then
     pip install -e '.[pandera]'
+    pip install dask
     pytest tests/integrations
     exit 0
 fi


### PR DESCRIPTION
We were assuming only pandas annotated functions. This changes that and ensure that functions annotated with a dask datatype will work.

Note, added pyspark without adding a test.

## Changes
 - pandera validator

## How I tested this
 - locally via unit tests

## Notes
 - this uses the registered dataframe and column types from registry filtering on an explicit list that pandera supports.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
