### PR TITLE
Exposes ray init functionality

### DIFF
--- a/hamilton/plugins/h_ray.py
+++ b/hamilton/plugins/h_ray.py
@@ -209,20 +209,33 @@ class RayTaskExecutor(executors.TaskExecutor):
     This is still experimental, so the API might change.
     """
 
-    def __init__(self, num_cpus: int):
+    def __init__(
+        self,
+        num_cpus: int = None,
+        config: typing.Dict[str, typing.Any] = None,
+        skip_init: bool = False,
+    ):
         """Creates a ray task executor. Note this will likely take in more parameters. This is
         experimental, so the API will likely change, although we will do our best to make it
         backwards compatible.
 
-        :param num_cpus: Number of cores to use for initialization, passed drirectly to ray.init
+        :param num_cpus: Number of cores to use for initialization, passed directly to ray.init. Defaults to all cores.
+        :param config: General configuration to pass to ray.init. Defaults to None.
+        :param skip_init: Skips ray init if you already have Ray initialized. Default is False.
         """
         self.num_cpus = num_cpus
+        self.config = config if config else {}
+        self.skip_init = skip_init
 
     def init(self):
-        ray.init(num_cpus=self.num_cpus)
+        if not self.skip_init:
+            ray.init(num_cpus=self.num_cpus, **self.config)
 
     def finalize(self):
-        ray.shutdown()
+        if (
+            not self.skip_init
+        ):  # we assume that if we didn't init it, we don't need to shutdown either.
+            ray.shutdown()
 
     def submit_task(self, task: TaskImplementation) -> TaskFuture:
         """Submits a task, wrapping it in a TaskFuture (after getting the corresponding python


### PR DESCRIPTION
This was bothering me that we hadn't exposed a few things, this fixes that. It means that someone can now connect to a ray cluster for example.

## Changes
 - h_ray.py task executor

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
