### PR TITLE
Add missing import to fix test

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -15,6 +15,7 @@ from hamilton.io.materialization import from_, to
 import tests.resources.data_quality
 import tests.resources.dynamic_config
 import tests.resources.overrides
+import tests.resources.test_for_materialization
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When running the tests locally I needed to add one import to get all tests running.
