### PR TITLE
Fixes doc example in h_pandera.check_output

### DIFF
--- a/hamilton/plugins/h_pandera.py
+++ b/hamilton/plugins/h_pandera.py
@@ -51,7 +51,14 @@ class check_output(BaseDataValidationDecorator):
 
             from hamilton import function_modifiers
 
-            @function_modifiers.check_output(schema=MySchema)
+            schema = pa.DataFrameSchema({
+                "a": pa.Column(pa.Int),
+                "b": pa.Column(pa.Float),
+                "c": pa.Column(pa.String, nullable=True),
+                "d": pa.Column(pa.Float),
+            })
+
+            @function_modifiers.check_output(schema=schema)
             def foo() -> pd.DataFrame:
                 return pd.DataFrame() # will fail
 


### PR DESCRIPTION
It was incorrect.

## Changes
- h_pandera.check_output doc string.

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
