### PR TITLE
Feature/620

### DIFF
--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -370,3 +370,36 @@ class Node(object):
             return __transform(self.callable(**kwargs), kwargs)
 
         return self.copy_with(callabl=new_callable, typ=__output_type)
+
+
+def matches_query(
+    tags: Dict[str, Union[str, List[str]]], query_dict: Dict[str, Optional[Union[str, List[str]]]]
+) -> bool:
+    """Check whether a set of node tags matches the query based on tags.
+
+    An empty dict of a query matches all tags.
+
+    :param tags: the tags of the node.
+    :param query_dict: of tag to value. If value is None, we just check that the tag exists.
+    :return: True if we have tags that match all tag queries, False otherwise.
+    """
+    # it's an AND clause between each tag and value in the query dict.
+    for tag, value in query_dict.items():
+        # if tag not in node we can return False immediately.
+        if tag not in tags:
+            return False
+        # if value is None -- we don't care about the value, just that the tag exists.
+        if value is None:
+            continue
+        node_tag_value = tags[tag]
+        if not isinstance(node_tag_value, list):
+            node_tag_value = [node_tag_value]
+        if not isinstance(value, list):
+            value = [value]
+        if set(value).intersection(set(node_tag_value)):
+            # if there is some overlap, we're good.
+            continue
+        else:
+            # else, return False.
+            return False
+    return True

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -34,17 +34,24 @@ def test_tags_invalid_key(key):
     "key",
     [
         "bar.foo",
-        "foo",  # Invalid identifier
-        "foo.bar.baz",  # Invalid key, not a valid identifier
+        "foo",  # Valid
+        "foo.bar.baz",  # Valid key
     ],
 )
 def test_tags_valid_key(key):
     assert function_modifiers.tag._key_allowed(key)
 
 
-@pytest.mark.parametrize("value", [None, False, [], ["foo", "bar"]])
+@pytest.mark.parametrize(
+    "value", [None, False, [], ["foo", "bar", 1], [None], ["foo", "foo"], ["foo", ["bar"]]]
+)
 def test_tags_invalid_value(value):
     assert not function_modifiers.tag._value_allowed(value)
+
+
+@pytest.mark.parametrize("value", [["string value"], ["foo", "bar"]])
+def test_tags_valid_value(value):
+    assert function_modifiers.tag._value_allowed(value)
 
 
 def test_tag_outputs():

--- a/tests/resources/tagging.py
+++ b/tests/resources/tagging.py
@@ -12,5 +12,6 @@ def b_c(a: int) -> dict:
     return {"b": a, "c": str(a)}
 
 
+@tag(test_list=["us", "uk"])
 def d(a: int) -> int:
     return a


### PR DESCRIPTION
Implements a version of #620 .

```python
@tag( business_value=["CA", "US"] )`
def combo_node():
    ...

@tag( business_value=["US"] )`
def only_us_node():
    ...

@tag( business_value=["CA"], some_other_tag="BAR" )`
def only_ca_node():
    ...
```
then the following queries will return:
```python
# case A: returns only_ca_node() and combo_node()
dr.list_available_variables(tag_filter=dict(business_lines=["CA"]))
# case B: returns only_us_node() and combo_node()
dr.list_available_variables(tag_filter=dict(business_lines="US"))
# case C: returns all 3 nodes
dr.list_available_variables(tag_filter=dict(business_lines=["CA", "US"] ))
# case D: returns all 3 nodes
dr.list_available_variables(tag_filter=dict(business_lines=None ))
# case E: returns 0 nodes
dr.list_available_variables(tag_filter=dict(business_lines="UK" ))
# case F: returns 0 nodes
dr.list_available_variables(tag_filter=dict(business_lines="US", some_other_tag="FOO" )
# case G: returns 1 nodes
dr.list_available_variables(tag_filter=dict(business_lines="CA", some_other_tag="BAR" )
```


## Changes
 - `@tag` now can take in a list of strings
 -  `driver.list_available_variables()` now takes in a tag_filter argument
 - node.py has new function
 - tests

## How I tested this
 - locally
 - via unit tests

## Notes
 - this does not implement anything fancy with respect to query logic. We should implement more as the use case presents itself.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
