### PR TITLE
Fixes docs typo

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -936,7 +936,7 @@ class Driver:
         """Creates a visualization of the DAG going backwards from the passed in function name(s).
 
         Note: for any "node" visualized, we will also add its parents to the visualization as well, so
-        there could be more nodes visualized than strictly what is downstream of the passed in function name(s).
+        there could be more nodes visualized than strictly what is upstream of the passed in function name(s).
 
         :param node_names: names of function(s) that are starting points for traversing the graph.
         :param output_file_path: the full URI of path + file name to save the dot file to.


### PR DESCRIPTION
It should read upstream, not downstream.

## Changes
 - doc string in driver

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
