### PR TITLE
Adds TQDM adapter to show progress

### DIFF
--- a/docs/reference/lifecycle-hooks/PDBDebugger.rst
+++ b/docs/reference/lifecycle-hooks/PDBDebugger.rst
@@ -1,0 +1,9 @@
+=====================
+lifecycle.PDBDebugger
+=====================
+
+
+.. autoclass:: hamilton.lifecycle.default.PDBDebugger
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/PrintLn.rst
+++ b/docs/reference/lifecycle-hooks/PrintLn.rst
@@ -1,0 +1,10 @@
+=================
+lifecycle.PrintLn
+=================
+
+Use this hook to print out data before/after a node's execution for debugging
+
+.. autoclass:: hamilton.lifecycle.default.PrintLn
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/ProgressBar.rst
+++ b/docs/reference/lifecycle-hooks/ProgressBar.rst
@@ -1,0 +1,13 @@
+==========================
+plugins.h_tqdm.ProgressBar
+==========================
+
+Provides a progress bar for Hamilton execution. Must have `tqdm` installed to use it:
+
+`pip install sf-hamilton[tqdm]` (use quotes if using zsh)
+
+
+.. autoclass:: hamilton.plugins.h_tqdm.ProgressBar
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/index.rst
+++ b/docs/reference/lifecycle-hooks/index.rst
@@ -1,16 +1,20 @@
-===============
-Lifecycle Hooks
-===============
+==================
+Lifecycle Adapters
+==================
 
 Currently a few of the API extensions are still experimental. Note this doesn't mean they're not well-tested or thought out -- rather that we're actively looking for feedback. More docs upcoming, but for now fish around the `experimental package <https://github.com/dagworks-inc/hamilton/tree/main/hamilton/experimental>`_, and give the extensions a try!
 
 The other extensions live within `plugins <https://github.com/dagworks-inc/hamilton/tree/main/hamilton/plugins>`_. These are fully supported and will be backwards compatible across major versions.
 
-Reference
----------
+Customization
+-------------
+
+The subsequent documents contain public-facing APIs for customizing Hamilton's
+execution. Note that the public-facing APIs are still a work in progress -- we
+will be improving the documentation. We plan for the APIs, however, to be stable
+looking forward.
 
 .. toctree::
-   lifecycle-customizations
    ResultBuilder
    LegacyResultMixin
    GraphAdapter
@@ -19,3 +23,30 @@ Reference
    EdgeConnectionHook
    NodeExecutionMethod
    StaticValidator
+
+
+Available Adapters
+-------------------
+
+In addition to the base classes for lifecycle adapters, we have a few adapters implemented and available for use.
+Note that some of these are plugins, meaning they require installing additional (external) libraries.
+
+Recall to add lifecycle adapters, you just need to call the ``with_adapters`` method of the driver:
+
+.. code-block:: python
+
+        dr = (
+            driver
+            .Builder()
+            .with_modules(...)
+            .with_adapters(
+                Adapter1(...),
+                Adapter2(...),
+                *more_adapters)
+            ...build()
+        )
+
+.. toctree::
+    PDBDebugger
+    PrintLn
+    ProgressBar

--- a/docs/reference/lifecycle-hooks/lifecycle-customizations.rst
+++ b/docs/reference/lifecycle-hooks/lifecycle-customizations.rst
@@ -1,8 +1,0 @@
-=======================
-Lifecycle Customization
-=======================
-
-The subsequent documents contain public-facing APIs for customizing Hamilton's
-execution. Note that the public-facing APIs are still a work in progress -- we
-will be improving the documentation. We plan for the APIs, however, to be stable
-looking forward.

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -13,15 +13,6 @@ from .default import PDBDebugger, PrintLn  # noqa: F401
 
 PrintLnHook = PrintLn  # for backwards compatibility -- this will be removed in 2.0
 
-try:
-    from .conditional_tqdm import TQDM  # noqa: F401
-except ImportError:
-    TQDM = None
-
-optional = []
-if TQDM is not None:
-    optional.append("TQDM")
-
 # All the following types are public facing
 __all__ = [
     "LifecycleAdapter",
@@ -36,4 +27,4 @@ __all__ = [
     "GraphExecutionHook",
     "NodeExecutionMethod",
     "StaticValidator",
-] + optional
+]

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -1,4 +1,4 @@
-from .api import (
+from .api import (  # noqa: F401
     EdgeConnectionHook,
     GraphAdapter,
     GraphExecutionHook,
@@ -8,8 +8,17 @@ from .api import (
     ResultBuilder,
     StaticValidator,
 )
-from .base import LifecycleAdapter
-from .default import PDBDebugger, PrintLnHook
+from .base import LifecycleAdapter  # noqa: F401
+from .default import PDBDebugger, PrintLnHook  # noqa: F401
+
+try:
+    from .conditional_tqdm import TQDMHook  # noqa: F401
+except ImportError:
+    TQDMHook = None
+
+optional = []
+if TQDMHook is not None:
+    optional.append("TQDMHook")
 
 # All the following types are public facing
 __all__ = [
@@ -24,4 +33,4 @@ __all__ = [
     "GraphExecutionHook",
     "NodeExecutionMethod",
     "StaticValidator",
-]
+] + optional

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -9,7 +9,9 @@ from .api import (  # noqa: F401
     StaticValidator,
 )
 from .base import LifecycleAdapter  # noqa: F401
-from .default import PDBDebugger, PrintLnHook  # noqa: F401
+from .default import PDBDebugger, PrintLn  # noqa: F401
+
+PrintLnHook = PrintLn  # for backwards compatibility -- this will be removed in 2.0
 
 try:
     from .conditional_tqdm import TQDMHook  # noqa: F401
@@ -28,7 +30,8 @@ __all__ = [
     "GraphAdapter",
     "NodeExecutionHook",
     "EdgeConnectionHook",
-    "PrintLnHook",
+    "PrintLn",
+    "PrintLnHook",  # for backwards compatibility this will be removed in 2.0
     "PDBDebugger",
     "GraphExecutionHook",
     "NodeExecutionMethod",

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -14,13 +14,13 @@ from .default import PDBDebugger, PrintLn  # noqa: F401
 PrintLnHook = PrintLn  # for backwards compatibility -- this will be removed in 2.0
 
 try:
-    from .conditional_tqdm import TQDMHook  # noqa: F401
+    from .conditional_tqdm import TQDM  # noqa: F401
 except ImportError:
-    TQDMHook = None
+    TQDM = None
 
 optional = []
-if TQDMHook is not None:
-    optional.append("TQDMHook")
+if TQDM is not None:
+    optional.append("TQDM")
 
 # All the following types are public facing
 __all__ = [

--- a/hamilton/lifecycle/conditional_tqdm.py
+++ b/hamilton/lifecycle/conditional_tqdm.py
@@ -2,15 +2,13 @@ from typing import Any, Dict, List, Optional
 
 import tqdm
 
-from hamilton import graph, node
-from hamilton.lifecycle import base
+from hamilton import graph_types
+from hamilton.lifecycle import GraphExecutionHook, NodeExecutionHook
 
 
 class TQDM(
-    base.BasePreGraphExecute,
-    base.BasePreNodeExecute,
-    base.BasePostNodeExecute,
-    base.BasePostGraphExecute,
+    GraphExecutionHook,
+    NodeExecutionHook,
 ):
     """An adapter that uses tqdm to show progress bars for the graph execution.
 
@@ -33,71 +31,70 @@ class TQDM(
 
     """
 
-    def __init__(self, desc: str = "Graph execution", node_name_target_width: int = 30, **kwargs):
+    def __init__(self, desc: str = "Graph execution", max_node_name_width: int = 50, **kwargs):
         """Create a new TQDM Adatper.
 
         :param desc: The description to show in the progress bar. E.g. DAG Name is a good choice.
         :param kwargs: Additional kwargs to pass to TQDM. See TQDM docs for more info.
-        :param node_name_target_width: the target width for the node name so that the progress bar is consistent.
+        :param node_name_target_width: the target width for the node name so that the progress bar is consistent. If this is None, it will take the longest, until it hits max_node_name_width.
+
         """
         self.desc = desc
         self.kwargs = kwargs
-        self.node_name_target_width = node_name_target_width  # what we target padding for.
+        self.node_name_target_width = (
+            None  # what we target padding for -- starts at None as we adjust.
+        )
+        self.max_node_name_width = max_node_name_width  # what we cap the padding at.
+        self.progress_bar = None
 
-    def pre_graph_execute(
+    def _get_node_name_display(self, node_name: str) -> str:
+        """Gives the node name display given a max width and a node name. Max width could be DAG-dependent."""
+        out = (
+            node_name
+            if len(node_name) <= self.node_name_target_width
+            else node_name[: self.node_name_target_width - 3] + "..."
+        )
+        if len(out) < self.node_name_target_width:
+            out += " " * (self.node_name_target_width - len(out))
+        return out
+
+    def run_before_graph_execution(
         self,
         *,
-        run_id: str,
-        graph: graph.FunctionGraph,
+        graph: graph_types.HamiltonGraph,
         final_vars: List[str],
         inputs: Dict[str, Any],
         overrides: Dict[str, Any],
+        **future_kwargs: Any,
     ):
-        all, human = graph.get_upstream_nodes(final_vars)
-        total_node_to_execute = len(all) - len(human)
+        nodes_to_execute = graph.get_execution_nodes(inputs, final_vars, overrides)
+        total_node_to_execute = len(nodes_to_execute)
+        max_node_name_length = min(
+            max([len(node.name) for node in nodes_to_execute]), self.max_node_name_width
+        )
+        if self.node_name_target_width is None:
+            self.node_name_target_width = max_node_name_length
         self.progress_bar = tqdm.tqdm(
             desc=self.desc, unit="funcs", total=total_node_to_execute, **self.kwargs
         )
 
-    def pre_node_execute(
+    def run_before_node_execution(
         self,
         *,
-        run_id: str,
-        node_: node.Node,
-        kwargs: Dict[str, Any],
-        task_id: Optional[str] = None,
+        node_name: str,
+        node_tags: Dict[str, Any],
+        node_kwargs: Dict[str, Any],
+        node_return_type: type,
+        task_id: Optional[str],
+        **future_kwargs: Any,
     ):
-        # pad the node name with spaces to make it consistent in length
-        name_part = node_.name
-        if len(name_part) > self.node_name_target_width:
-            padding = ""
-        else:
-            padding = " " * (self.node_name_target_width - len(name_part))
-        self.progress_bar.set_description_str(f"{self.desc} -> {name_part + padding}")
-        self.progress_bar.set_postfix({"executing": name_part})
+        name_display = self._get_node_name_display(node_name)
+        self.progress_bar.set_description_str(f"{self.desc} -> {name_display}")
 
-    def post_node_execute(
-        self,
-        *,
-        run_id: str,
-        node_: node.Node,
-        kwargs: Dict[str, Any],
-        success: bool,
-        error: Optional[Exception],
-        result: Optional[Any],
-        task_id: Optional[str] = None,
-    ):
+    def run_after_node_execution(self, **future_kwargs):
         self.progress_bar.update(1)
 
-    def post_graph_execute(
-        self,
-        *,
-        run_id: str,
-        graph: graph.FunctionGraph,
-        success: bool,
-        error: Optional[Exception],
-        results: Optional[Dict[str, Any]],
-    ):
+    def run_after_graph_execution(self, **future_kwargs):
         name_part = "Execution Complete!"
         if len(name_part) > self.node_name_target_width:
             padding = ""

--- a/hamilton/lifecycle/conditional_tqdm.py
+++ b/hamilton/lifecycle/conditional_tqdm.py
@@ -6,13 +6,13 @@ from hamilton import graph, node
 from hamilton.lifecycle import base
 
 
-class TQDMHook(
+class TQDM(
     base.BasePreGraphExecute,
     base.BasePreNodeExecute,
     base.BasePostNodeExecute,
     base.BasePostGraphExecute,
 ):
-    """A hook that uses tqdm to show progress bars for the graph execution.
+    """An adapter that uses tqdm to show progress bars for the graph execution.
 
     Note: you need to have tqdm installed for this to work.
     If you don't have it installed, you can install it with `pip install tqdm`.
@@ -34,7 +34,7 @@ class TQDMHook(
     """
 
     def __init__(self, desc: str = "Graph execution", node_name_target_width: int = 30, **kwargs):
-        """Create a new TQDMHook.
+        """Create a new TQDM Adatper.
 
         :param desc: The description to show in the progress bar. E.g. DAG Name is a good choice.
         :param kwargs: Additional kwargs to pass to TQDM. See TQDM docs for more info.
@@ -99,7 +99,10 @@ class TQDMHook(
         results: Optional[Dict[str, Any]],
     ):
         name_part = "Execution Complete!"
-        padding = " " * (self.node_name_target_width - len(name_part))
+        if len(name_part) > self.node_name_target_width:
+            padding = ""
+        else:
+            padding = " " * (self.node_name_target_width - len(name_part))
         self.progress_bar.set_description_str(f"{self.desc} -> {name_part + padding}")
         self.progress_bar.set_postfix({})
         self.progress_bar.close()

--- a/hamilton/lifecycle/conditional_tqdm.py
+++ b/hamilton/lifecycle/conditional_tqdm.py
@@ -1,0 +1,105 @@
+from typing import Any, Dict, List, Optional
+
+import tqdm
+
+from hamilton import graph, node
+from hamilton.lifecycle import base
+
+
+class TQDMHook(
+    base.BasePreGraphExecute,
+    base.BasePreNodeExecute,
+    base.BasePostNodeExecute,
+    base.BasePostGraphExecute,
+):
+    """A hook that uses tqdm to show progress bars for the graph execution.
+
+    Note: you need to have tqdm installed for this to work.
+    If you don't have it installed, you can install it with `pip install tqdm`.
+
+    .. code-block:: python
+
+        from hamilton import lifecycle
+
+        dr = (
+            driver.Builder()
+            .with_config({})
+            .with_modules(some_modules)
+            .with_adapters(lifecycle.TQDMHook(desc="DAG-NAME"))
+            .build()
+        )
+        # and then when you call .execute() or .materialize() you'll get a progress bar!
+
+
+    """
+
+    def __init__(self, desc: str = "Graph execution", node_name_target_width: int = 30, **kwargs):
+        """Create a new TQDMHook.
+
+        :param desc: The description to show in the progress bar. E.g. DAG Name is a good choice.
+        :param kwargs: Additional kwargs to pass to TQDM. See TQDM docs for more info.
+        :param node_name_target_width: the target width for the node name so that the progress bar is consistent.
+        """
+        self.desc = desc
+        self.kwargs = kwargs
+        self.node_name_target_width = node_name_target_width  # what we target padding for.
+
+    def pre_graph_execute(
+        self,
+        *,
+        run_id: str,
+        graph: graph.FunctionGraph,
+        final_vars: List[str],
+        inputs: Dict[str, Any],
+        overrides: Dict[str, Any],
+    ):
+        all, human = graph.get_upstream_nodes(final_vars)
+        total_node_to_execute = len(all) - len(human)
+        self.progress_bar = tqdm.tqdm(
+            desc=self.desc, unit="funcs", total=total_node_to_execute, **self.kwargs
+        )
+
+    def pre_node_execute(
+        self,
+        *,
+        run_id: str,
+        node_: node.Node,
+        kwargs: Dict[str, Any],
+        task_id: Optional[str] = None,
+    ):
+        # pad the node name with spaces to make it consistent in length
+        name_part = node_.name
+        if len(name_part) > self.node_name_target_width:
+            padding = ""
+        else:
+            padding = " " * (self.node_name_target_width - len(name_part))
+        self.progress_bar.set_description_str(f"{self.desc} -> {name_part + padding}")
+        self.progress_bar.set_postfix({"executing": name_part})
+
+    def post_node_execute(
+        self,
+        *,
+        run_id: str,
+        node_: node.Node,
+        kwargs: Dict[str, Any],
+        success: bool,
+        error: Optional[Exception],
+        result: Optional[Any],
+        task_id: Optional[str] = None,
+    ):
+        self.progress_bar.update(1)
+
+    def post_graph_execute(
+        self,
+        *,
+        run_id: str,
+        graph: graph.FunctionGraph,
+        success: bool,
+        error: Optional[Exception],
+        results: Optional[Dict[str, Any]],
+    ):
+        name_part = "Execution Complete!"
+        padding = " " * (self.node_name_target_width - len(name_part))
+        self.progress_bar.set_description_str(f"{self.desc} -> {name_part + padding}")
+        self.progress_bar.set_postfix({})
+        self.progress_bar.close()

--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -160,11 +160,11 @@ class PDBDebugger(NodeExecutionHook, NodeExecutionMethod):
         after: bool = False,
     ):
         """Creates a PDB debugger. This has three possible modes:
-        1. Before -- places you in a function with (a) node information, and (b) inputs
-        2. During -- runs the node with pdb.run. Note this may not always work or give what you expect as
-            node functions are often wrapped in multiple levels of input modifications/whatnot. That said, it should give you something.
-            Also note that this is not (currently) compatible with graph adapters.
-        3. After -- places you in a function with (a) node information, (b) inputs, and (c) results
+            1. Before -- places you in a function with (a) node information, and (b) inputs
+            2. During -- runs the node with pdb.run. Note this may not always work or give what you expect as
+                node functions are often wrapped in multiple levels of input modifications/whatnot. That said, it should give you something.
+                Also note that this is not (currently) compatible with graph adapters.
+            3. After -- places you in a function with (a) node information, (b) inputs, and (c) results
 
 
         :param node_filter: A function that takes a node name and a node tags dict and returns a boolean. If the boolean is True, the node will be printed out.
@@ -188,7 +188,7 @@ class PDBDebugger(NodeExecutionHook, NodeExecutionMethod):
         **future_kwargs: Any,
     ) -> Any:
         """Executes the node with a PDB debugger. This modifies the global PDBDebugger.CONTEXT variable to contain information about the node,
-        so you can access it while debugging.
+            so you can access it while debugging.
 
 
         :param node_name: Name of the node

--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -31,7 +31,7 @@ def should_run_node(node_name: str, node_tags: Dict[str, Any], node_filter: Node
     raise ValueError(f"Invalid node filter: {node_filter}")
 
 
-class PrintLnHook(NodeExecutionHook):
+class PrintLn(NodeExecutionHook):
     """Basic hook to print out information before/after node execution."""
 
     NODE_TIME_STATE = "node_time"
@@ -74,7 +74,7 @@ class PrintLnHook(NodeExecutionHook):
         :param node_filter: A function that takes a node name and a node tags dict and returns a boolean. If the boolean is True, the node will be printed out.
             If False, it will not be printed out.
         """
-        PrintLnHook._validate_verbosity(verbosity)
+        PrintLn._validate_verbosity(verbosity)
         self.verbosity = verbosity
         self.print_fn = print_fn
         self.timer_dict = {}  # quick dict to track the time it took to execute a node

--- a/hamilton/plugins/h_tqdm.py
+++ b/hamilton/plugins/h_tqdm.py
@@ -6,29 +6,28 @@ from hamilton import graph_types
 from hamilton.lifecycle import GraphExecutionHook, NodeExecutionHook
 
 
-class TQDM(
+class ProgressBar(
     GraphExecutionHook,
     NodeExecutionHook,
 ):
     """An adapter that uses tqdm to show progress bars for the graph execution.
 
     Note: you need to have tqdm installed for this to work.
-    If you don't have it installed, you can install it with `pip install tqdm`.
+    If you don't have it installed, you can install it with `pip install tqdm`
+    (or `pip install sf-hamilton[tqdm]` -- use quotes if you're using zsh).
 
     .. code-block:: python
 
-        from hamilton import lifecycle
+        from hamilton.plugins import h_tqdm
 
         dr = (
             driver.Builder()
             .with_config({})
             .with_modules(some_modules)
-            .with_adapters(lifecycle.TQDMHook(desc="DAG-NAME"))
+            .with_adapters(h_tqdm.ProgressBar(desc="DAG-NAME"))
             .build()
         )
         # and then when you call .execute() or .materialize() you'll get a progress bar!
-
-
     """
 
     def __init__(self, desc: str = "Graph execution", max_node_name_width: int = 50, **kwargs):

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -25,4 +25,5 @@ sphinx # unpinned because myst-parser doesn't break anymore
 sphinx-autobuild
 sphinx-rtd-theme # read the docs pins
 sphinx-sitemap
+tqdm
 xgboost

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         ],  # I'm sure they'll add support soon,
         # but for now its not compatible
         "pandera": ["pandera"],
+        "tqdm": ["tqdm"],
     },
     # Relevant project URLs
     project_urls={  # Optional


### PR DESCRIPTION
This is not added by default. But something people can add to their driver. This will only work
if you have TQDM installed.

```python

from hamilton import lifecycle

dr = (
    driver.Builder()
    .with_config({})
    .with_modules(some_modules)
    .with_adapters(lifecycle.TQDM(desc="DAG-NAME"))
    .build()
)

```

## Changes
 - adds TQDM progress bar adapter

## How I tested this
 - locally

## Notes
 - this is conditionally available based on whether TQDM is installed or not.
 - [ ] need to update docs somewhere I think.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
