### PR TITLE
Lifecycle validators

### DIFF
--- a/docs/reference/lifecycle-hooks/EdgeConnectionHook.rst
+++ b/docs/reference/lifecycle-hooks/EdgeConnectionHook.rst
@@ -1,0 +1,9 @@
+================================
+lifecycle.api.EdgeConnectionHook
+================================
+
+
+.. autoclass:: hamilton.lifecycle.api.EdgeConnectionHook
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/GraphExecutionHook.rst
+++ b/docs/reference/lifecycle-hooks/GraphExecutionHook.rst
@@ -1,0 +1,9 @@
+================================
+lifecycle.api.GraphExecutionHook
+================================
+
+
+.. autoclass:: hamilton.lifecycle.api.GraphExecutionHook
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/NodeExecutionMethod.rst
+++ b/docs/reference/lifecycle-hooks/NodeExecutionMethod.rst
@@ -1,0 +1,9 @@
+=================================
+lifecycle.api.NodeExecutionMethod
+=================================
+
+
+.. autoclass:: hamilton.lifecycle.api.NodeExecutionMethod
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/StaticValidator.rst
+++ b/docs/reference/lifecycle-hooks/StaticValidator.rst
@@ -1,0 +1,9 @@
+=============================
+lifecycle.api.StaticValidator
+=============================
+
+
+.. autoclass:: hamilton.lifecycle.api.StaticValidator
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/index.rst
+++ b/docs/reference/lifecycle-hooks/index.rst
@@ -12,6 +12,10 @@ Reference
 .. toctree::
    lifecycle-customizations
    ResultBuilder
+   LegacyResultMixin
    GraphAdapter
    NodeExecutionHook
-   LegacyResultMixin
+   GraphExecutionHook
+   EdgeConnectionHook
+   NodeExecutionMethod
+   StaticValidator

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -11,15 +11,17 @@ import numpy as np
 import pandas as pd
 from pandas.core.indexes import extension as pd_extension
 
+from hamilton.lifecycle import api as lifecycle_api
+
 try:
-    from . import htypes, lifecycle, node
+    from . import htypes, node
 except ImportError:
     import node
 
 logger = logging.getLogger(__name__)
 
 
-class ResultMixin(lifecycle.LegacyResultMixin):
+class ResultMixin(lifecycle_api.LegacyResultMixin):
     """Legacy result builder -- see lifecycle methods for more information."""
 
     pass
@@ -383,7 +385,7 @@ class NumpyMatrixResult(ResultMixin):
         return pd.DataFrame
 
 
-class HamiltonGraphAdapter(lifecycle.GraphAdapter, abc.ABC):
+class HamiltonGraphAdapter(lifecycle_api.GraphAdapter, abc.ABC):
     """Legacy graph adapter -- see lifecycle methods for more information."""
 
     pass

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -8,14 +8,13 @@ import time
 # required if we want to run this code stand alone.
 import typing
 import uuid
-from dataclasses import dataclass, field
 from datetime import datetime
 from types import ModuleType
 from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, Union
 
 import pandas as pd
 
-from hamilton import common, htypes
+from hamilton import common, graph_types, htypes
 from hamilton.execution import executors, graph_functions, grouping, state
 from hamilton.io import materialization
 from hamilton.io.materialization import ExtractorFactory, MaterializerFactory
@@ -69,34 +68,9 @@ def capture_function_usage(call_fn: Callable) -> Callable:
     return wrapped_fn
 
 
-@dataclass
-class Variable:
-    """External facing API for hamilton. Having this as a dataclass allows us
-    to hide the internals of the system but expose what the user might need.
-    Furthermore, we can always add attributes and maintain backwards compatibility."""
-
-    name: str
-    type: typing.Type
-    tags: Dict[str, str] = field(default_factory=dict)
-    is_external_input: bool = field(default=False)
-    originating_functions: Optional[Tuple[Callable, ...]] = field(default=None)
-    documentation: Optional[str] = field(default=None)
-
-    @staticmethod
-    def from_node(n: node.Node) -> "Variable":
-        """Creates a Variable from a Node.
-
-        :param n: Node to create the Variable from.
-        :return: Variable created from the Node.
-        """
-        return Variable(
-            name=n.name,
-            type=n.type,
-            tags=n.tags,
-            is_external_input=n.user_defined,
-            originating_functions=n.originating_functions,
-            documentation=n.documentation,
-        )
+# This is kept in here for backwards compatibility
+# You will want to refer to graph_types.HamiltonNode
+Variable = graph_types.HamiltonNode
 
 
 class InvalidExecutorException(Exception):

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -297,9 +297,9 @@ class Driver:
     ):
         """Utility function to perform graph validations. Static so we're not stuck with local state
 
-        @param adapter: Adapter to use for validation.
-        @param graph: Graph to validate.
-        @param graph_modules: Modules to validate.
+        :param adapter: Adapter to use for validation.
+        :param graph: Graph to validate.
+        :param graph_modules: Modules to validate.
         """
 
         if adapter.does_validation("validate_node"):
@@ -325,7 +325,6 @@ class Driver:
                         node_validation_results.items(), key=operator.itemgetter(0)
                     )
                 ]
-                errors.sort()
                 error_str = (
                     f"Node validation failed! {len(errors)} errors encountered:\n  "
                     + "\n  ".join(errors)
@@ -341,8 +340,7 @@ class Driver:
             )
             if validation_results:
                 error_delimiter = "\t"
-                errors = [result.error for result in validation_results]
-                errors.sort()
+                errors = sorted([result.error for result in validation_results])
                 error_str = (
                     f"Graph validation failed! {len(errors)} errors encountered:{error_delimiter}"
                     + error_delimiter.join(errors)
@@ -398,7 +396,6 @@ class Driver:
         finally:
             # TODO -- update this to use the lifecycle methods
             self.capture_constructor_telemetry(error, modules, config, adapter)
-
 
     def capture_constructor_telemetry(
         self,

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -399,6 +399,7 @@ class Driver:
             # TODO -- update this to use the lifecycle methods
             self.capture_constructor_telemetry(error, modules, config, adapter)
 
+
     def capture_constructor_telemetry(
         self,
         error: Optional[str],

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -11,14 +11,13 @@ from enum import Enum
 from types import ModuleType
 from typing import Any, Callable, Collection, Dict, FrozenSet, List, Optional, Set, Tuple, Type
 
-from hamilton import base, node
+import hamilton.lifecycle.base as lifecycle_base
+from hamilton import node
 from hamilton.execution import graph_functions
-from hamilton.execution.graph_functions import combine_config_and_inputs, execute_subdag
 from hamilton.function_modifiers import base as fm_base
 from hamilton.function_modifiers.metadata import schema
 from hamilton.graph_utils import find_functions
 from hamilton.htypes import get_type_as_string, types_match
-from hamilton.lifecycle.base import LifecycleAdapterSet
 from hamilton.node import Node
 
 logger = logging.getLogger(__name__)
@@ -39,7 +38,7 @@ def add_dependency(
     nodes: Dict[str, node.Node],
     param_name: str,
     param_type: Type,
-    adapter_group: LifecycleAdapterSet,
+    adapter: lifecycle_base.LifecycleAdapterSet,
 ):
     """Adds dependencies to the node objects.
 
@@ -52,12 +51,12 @@ def add_dependency(
     :param param_type: the type of the parameter.
     :param adapter: The adapter that adapts our node type checking based on the context.
     """
-    adapter_checks_types = adapter_group.does_method("do_check_edge_types_match", is_async=False)
+    adapter_checks_types = adapter.does_method("do_check_edge_types_match", is_async=False)
     if param_name in nodes:
         # validate types match
         required_node: Node = nodes[param_name]
         types_do_match = types_match(param_type, required_node.type)
-        types_do_match |= adapter_checks_types and adapter_group.call_lifecycle_method_sync(
+        types_do_match |= adapter_checks_types and adapter.call_lifecycle_method_sync(
             "do_check_edge_types_match", type_from=param_type, type_to=required_node.type
         )
         if not types_do_match and required_node.user_defined:
@@ -65,11 +64,8 @@ def add_dependency(
             # this could be the case when one is a union and the other is a subset of that union
             # which is fine for inputs. If they are not compatible, we raise an error.
             types_are_compatible = types_match(required_node.type, param_type)
-            types_are_compatible |= (
-                adapter_checks_types
-                and adapter_group.call_lifecycle_method_sync(
-                    "do_check_edge_types_match", type_from=param_type, type_to=required_node.type
-                )
+            types_are_compatible |= adapter_checks_types and adapter.call_lifecycle_method_sync(
+                "do_check_edge_types_match", type_from=param_type, type_to=required_node.type
             )
             if not types_are_compatible:
                 raise ValueError(
@@ -111,7 +107,7 @@ def add_dependency(
 
 def update_dependencies(
     nodes: Dict[str, node.Node],
-    adapter_group: LifecycleAdapterSet,
+    adapter: lifecycle_base.LifecycleAdapterSet,
     reset_dependencies: bool = True,
 ):
     """Adds dependencies to a dictionary of nodes. If in_place is False,
@@ -133,14 +129,14 @@ def update_dependencies(
         nodes = {k: v.copy(include_refs=False) for k, v in nodes.items()}
     for node_name, n in list(nodes.items()):
         for param_name, (param_type, _) in n.input_types.items():
-            add_dependency(n, node_name, nodes, param_name, param_type, adapter_group)
+            add_dependency(n, node_name, nodes, param_name, param_type, adapter)
     return nodes
 
 
 def create_function_graph(
     *modules: ModuleType,
     config: Dict[str, Any],
-    adapter: LifecycleAdapterSet = None,
+    adapter: lifecycle_base.LifecycleAdapterSet = None,
     fg: Optional["FunctionGraph"] = None,
 ) -> Dict[str, node.Node]:
     """Creates a graph of all available functions & their dependencies.
@@ -152,7 +148,7 @@ def create_function_graph(
     """
     if adapter is None:
         adapter = (
-            LifecycleAdapterSet()
+            lifecycle_base.LifecycleAdapterSet()
         )  # empty one -- not provided/necessary, we can run without it
     if fg is None:
         nodes = {}  # name -> Node
@@ -584,7 +580,7 @@ class FunctionGraph:
         self,
         nodes: Dict[str, Node],
         config: Dict[str, Any],
-        adapter: LifecycleAdapterSet = None,
+        adapter: lifecycle_base.LifecycleAdapterSet = None,
     ):
         """Initializes a function graph from specified nodes. See note on `from_modules` if you
         start getting an error here because you use an internal API.
@@ -594,7 +590,7 @@ class FunctionGraph:
         :param adapter: Group of adapters, to use for node resolution.
         """
         if adapter is None:
-            adapter = LifecycleAdapterSet(base.SimplePythonDataFrameGraphAdapter())
+            adapter = lifecycle_base.LifecycleAdapterSet()
 
         self._config = config
         self.nodes = nodes
@@ -604,7 +600,7 @@ class FunctionGraph:
     def from_modules(
         *modules: ModuleType,
         config: Dict[str, Any],
-        adapter: LifecycleAdapterSet = None,
+        adapter: lifecycle_base.LifecycleAdapterSet = None,
     ):
         """Initializes a function graph from the specified modules. Note that this was the old
         way we constructed FunctionGraph -- this is not a public-facing API, so we replaced it
@@ -933,8 +929,8 @@ class FunctionGraph:
             inputs = {}
         if run_id is None:
             run_id = str(uuid.uuid4())
-        inputs = combine_config_and_inputs(self.config, inputs)
-        return execute_subdag(
+        inputs = graph_functions.combine_config_and_inputs(self.config, inputs)
+        return graph_functions.execute_subdag(
             nodes=nodes,
             inputs=inputs,
             adapter=self.adapter,

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -1,0 +1,69 @@
+"""Module for external-facing graph constructs. These help the user navigate/manage the graph as needed."""
+import typing
+from dataclasses import dataclass, field
+
+from hamilton import graph, node
+from hamilton.node import DependencyType
+
+
+@dataclass
+class HamiltonNode:
+    """External facing API for hamilton Nodes. Having this as a dataclass allows us
+    to hide the internals of the system but expose what the user might need.
+    Furthermore, we can always add attributes and maintain backwards compatibility."""
+
+    name: str
+    type: typing.Type
+    tags: typing.Dict[str, str] = field(default_factory=dict)
+    is_external_input: bool = field(default=False)
+    originating_functions: typing.Optional[typing.Tuple[typing.Callable, ...]] = field(default=None)
+    documentation: typing.Optional[str] = field(default=None)
+    required_dependencies: typing.Set[str] = field(default_factory=list)
+    optional_dependencies: typing.Set[str] = field(default_factory=list)
+
+    @staticmethod
+    def from_node(n: node.Node) -> "HamiltonNode":
+        """Creates a HamiltonNode from a Node (Hamilton's internal representation).
+
+        :param n: Node to create the Variable from.
+        :return: HamiltonNode created from the Node.
+        """
+        return HamiltonNode(
+            name=n.name,
+            type=n.type,
+            tags=n.tags,
+            is_external_input=n.user_defined,
+            originating_functions=n.originating_functions,
+            documentation=n.documentation,
+            required_dependencies={
+                item.name
+                for item in n.dependencies
+                if not n.input_types[item.name][1] == DependencyType.REQUIRED
+            },
+            optional_dependencies={
+                item.name
+                for item in n.dependencies
+                if n.input_types[item.name][1] == DependencyType.OPTIONAL
+            },
+        )
+
+
+@dataclass
+class HamiltonGraph:
+    """External facing API for Hamilton Graphs. Currently a list of nodes that
+    allow you to trace forward/backwards in the graph. Will likely be adding some more capabilities:
+        1. More metadata -- config + modules
+        2. More utility functions -- make it easy to walk/do an action at each node
+    For now, you have to implement walking on your own if you care about order.
+    """
+
+    nodes: typing.List[HamiltonNode]
+
+    @staticmethod
+    def from_graph(fn_graph: graph.FunctionGraph) -> "HamiltonGraph":
+        """Creates a HamiltonGraph from a FunctionGraph (Hamilton's internal representation).
+
+        @param fn_graph: FunctionGraph to convert
+        @return: HamiltonGraph created from the FunctionGraph
+        """
+        return HamiltonGraph(nodes=[HamiltonNode.from_node(n) for n in fn_graph.nodes.values()])

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -2,7 +2,15 @@
 import typing
 from dataclasses import dataclass
 
-from hamilton import graph, htypes, node
+from hamilton import htypes, node
+
+# This is a little ugly -- its just required for graph build, and works
+# This indicates a larger smell though -- we need to have the right level of
+# hierarchy to ensure we don't have to deal with this.
+# The larger problem is that we have a few interfaces that are referred to by
+# The core system (in defaults), and we have not managed to disentangle it yet.
+if typing.TYPE_CHECKING:
+    from hamilton import graph
 
 
 @dataclass

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -2,8 +2,13 @@
 import typing
 from dataclasses import dataclass, field
 
-from hamilton import graph, node
+from hamilton import node
 from hamilton.node import DependencyType
+
+# See note in lifecycle.api about type-checking/why we're doing this
+# We'll want to eventually move more out of base, but for now this is OK
+if typing.TYPE_CHECKING:
+    from hamilton import FunctionGraph
 
 
 @dataclass
@@ -60,7 +65,7 @@ class HamiltonGraph:
     nodes: typing.List[HamiltonNode]
 
     @staticmethod
-    def from_graph(fn_graph: graph.FunctionGraph) -> "HamiltonGraph":
+    def from_graph(fn_graph: "FunctionGraph") -> "HamiltonGraph":
         """Creates a HamiltonGraph from a FunctionGraph (Hamilton's internal representation).
 
         @param fn_graph: FunctionGraph to convert

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -1,6 +1,6 @@
 """Module for external-facing graph constructs. These help the user navigate/manage the graph as needed."""
 import typing
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from hamilton import graph, htypes, node
 
@@ -19,8 +19,6 @@ class HamiltonNode:
     documentation: typing.Optional[str]
     required_dependencies: typing.Set[str]
     optional_dependencies: typing.Set[str]
-    # Store the original node for internal use
-    _node: typing.Optional[node.Node] = field(default=None)
 
     @staticmethod
     def from_node(n: node.Node) -> "HamiltonNode":
@@ -46,7 +44,6 @@ class HamiltonNode:
                 for item in n.dependencies
                 if n.input_types[item.name][1] == node.DependencyType.OPTIONAL
             },
-            _node=n,
         )
 
     def __repr__(self):
@@ -66,7 +63,6 @@ class HamiltonGraph:
 
     nodes: typing.List[HamiltonNode]
     # store the original graph for internal use
-    _function_graph: graph.FunctionGraph
 
     @staticmethod
     def from_graph(fn_graph: "graph.FunctionGraph") -> "HamiltonGraph":
@@ -77,31 +73,4 @@ class HamiltonGraph:
         """
         return HamiltonGraph(
             nodes=[HamiltonNode.from_node(n) for n in fn_graph.nodes.values()],
-            _function_graph=fn_graph,
         )
-
-    def get_execution_nodes(
-        self,
-        inputs: typing.Dict[str, typing.Any],
-        final_vars: typing.List[str],
-        overrides: typing.Dict[str, typing.Any],
-        include_external_inputs: bool = False,
-    ) -> typing.Collection[HamiltonNode]:
-        """Gives the nodes involved in an execution of a DAG. Note that this is not an execution *plan*
-        as we have no guarentees that (a) these are in topological order and (b) that these are in the order of
-        execution. This is just the nodes that will be involved in the execution.
-
-        :param inputs: Inputs, passed at runtime
-        :param final_vars: Final variables, requested at runtime
-        :param overrides: Overrides, passed at runtime
-        :param include_external_inputs: We represents nodes that are expected to be passed in as nodes -- by default
-            we don't include this, but we do have the option to.
-        :return: A collection of HamiltonNodes that will be involved in the execution.
-        """
-        nodes_by_name = {n.name: n for n in self.nodes}
-        all_nodes, input_vars = self._function_graph.get_upstream_nodes(
-            final_vars, inputs, overrides
-        )
-        if not include_external_inputs:
-            all_nodes -= input_vars
-        return [nodes_by_name[n.name] for n in all_nodes]

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -21,7 +21,7 @@ class HamiltonNode:
 
     name: str
     type: typing.Type
-    tags: typing.Dict[str, str]
+    tags: typing.Dict[str, typing.Union[str, typing.List[str]]]
     is_external_input: bool
     originating_functions: typing.Tuple[typing.Callable, ...]
     documentation: typing.Optional[str]
@@ -76,8 +76,8 @@ class HamiltonGraph:
     def from_graph(fn_graph: "graph.FunctionGraph") -> "HamiltonGraph":
         """Creates a HamiltonGraph from a FunctionGraph (Hamilton's internal representation).
 
-        @param fn_graph: FunctionGraph to convert
-        @return: HamiltonGraph created from the FunctionGraph
+        :param fn_graph: FunctionGraph to convert
+        :return: HamiltonGraph created from the FunctionGraph
         """
         return HamiltonGraph(
             nodes=[HamiltonNode.from_node(n) for n in fn_graph.nodes.values()],

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -2,7 +2,7 @@
 import typing
 from dataclasses import dataclass, field
 
-from hamilton import graph, node
+from hamilton import graph, htypes, node
 
 
 @dataclass
@@ -48,6 +48,9 @@ class HamiltonNode:
             },
             _node=n,
         )
+
+    def __repr__(self):
+        return f"{self.name}: {htypes.get_type_as_string(self.type)}"
 
 
 @dataclass

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -2,13 +2,7 @@
 import typing
 from dataclasses import dataclass, field
 
-from hamilton import node
-from hamilton.node import DependencyType
-
-# See note in lifecycle.api about type-checking/why we're doing this
-# We'll want to eventually move more out of base, but for now this is OK
-if typing.TYPE_CHECKING:
-    from hamilton import FunctionGraph
+from hamilton import graph, node
 
 
 @dataclass
@@ -43,12 +37,12 @@ class HamiltonNode:
             required_dependencies={
                 item.name
                 for item in n.dependencies
-                if not n.input_types[item.name][1] == DependencyType.REQUIRED
+                if not n.input_types[item.name][1] == node.DependencyType.REQUIRED
             },
             optional_dependencies={
                 item.name
                 for item in n.dependencies
-                if n.input_types[item.name][1] == DependencyType.OPTIONAL
+                if n.input_types[item.name][1] == node.DependencyType.OPTIONAL
             },
         )
 
@@ -65,7 +59,7 @@ class HamiltonGraph:
     nodes: typing.List[HamiltonNode]
 
     @staticmethod
-    def from_graph(fn_graph: "FunctionGraph") -> "HamiltonGraph":
+    def from_graph(fn_graph: "graph.FunctionGraph") -> "HamiltonGraph":
         """Creates a HamiltonGraph from a FunctionGraph (Hamilton's internal representation).
 
         @param fn_graph: FunctionGraph to convert

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -6,7 +6,6 @@ from typing import Any, Generator, Optional, Tuple, Type, TypeVar
 
 import typing_inspect
 
-
 from hamilton.registry import COLUMN_TYPE, DF_TYPE_AND_COLUMN_TYPES
 
 BASE_ARGS_FOR_GENERICS = (typing.T,)

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -6,6 +6,7 @@ from typing import Any, Generator, Optional, Tuple, Type, TypeVar
 
 import typing_inspect
 
+
 from hamilton.registry import COLUMN_TYPE, DF_TYPE_AND_COLUMN_TYPES
 
 BASE_ARGS_FOR_GENERICS = (typing.T,)

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -1,9 +1,12 @@
 from .api import (
     EdgeConnectionHook,
     GraphAdapter,
+    GraphExecutionHook,
     LegacyResultMixin,
     NodeExecutionHook,
+    NodeExecutionMethod,
     ResultBuilder,
+    StaticValidator,
 )
 from .base import LifecycleAdapter
 from .default import PDBDebugger, PrintLnHook
@@ -18,4 +21,7 @@ __all__ = [
     "EdgeConnectionHook",
     "PrintLnHook",
     "PDBDebugger",
+    "GraphExecutionHook",
+    "NodeExecutionMethod",
+    "StaticValidator",
 ]

--- a/hamilton/lifecycle/api.py
+++ b/hamilton/lifecycle/api.py
@@ -1,10 +1,22 @@
 import abc
 from abc import ABC
 from types import ModuleType
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 from hamilton import graph_types, node
-from hamilton.graph import FunctionGraph
+
+# This is only here for a type-hint
+# As python types aren't real (they're determined at runtime), we can't have circular import resolved
+# These are often necessary to handle typing -- as types don't have a perfect DAG of dependencies
+# In this case, we're breaking the following loop:
+#    -> lifecycle_api depends on graph_types and FunctionGraph
+#    -> graph_types depends on hamilton.base
+#    -> hamilton.base depends on lifecycle_api, as some interfaces for graph adapters live there
+# To really fix this we should move everything user-facing out of base, which is a pretty sloppy name for a package anyway
+# And put it where it belongs. For now we're OK with the TYPE_CHECKING hack
+if TYPE_CHECKING:
+    from hamilton.graph import FunctionGraph
+
 from hamilton.graph_types import HamiltonGraph, HamiltonNode
 from hamilton.lifecycle.base import (
     BaseDoBuildResult,
@@ -239,7 +251,7 @@ class GraphExecutionHook(BasePreGraphExecute, BasePostGraphExecute):
         self,
         *,
         run_id: str,
-        graph: FunctionGraph,
+        graph: "FunctionGraph",
         success: bool,
         error: Optional[Exception],
         results: Optional[Dict[str, Any]],
@@ -252,7 +264,7 @@ class GraphExecutionHook(BasePreGraphExecute, BasePostGraphExecute):
         self,
         *,
         run_id: str,
-        graph: FunctionGraph,
+        graph: "FunctionGraph",
         final_vars: List[str],
         inputs: Dict[str, Any],
         overrides: Dict[str, Any],

--- a/hamilton/lifecycle/api.py
+++ b/hamilton/lifecycle/api.py
@@ -268,6 +268,7 @@ class GraphExecutionHook(BasePreGraphExecute, BasePostGraphExecute):
         error: Optional[Exception],
         results: Optional[Dict[str, Any]],
     ):
+        """Just delegates to the interface method, passing in the right data."""
         return self.run_after_graph_execution(
             graph=HamiltonGraph.from_graph(graph), success=success, error=error, results=results
         )
@@ -283,6 +284,9 @@ class GraphExecutionHook(BasePreGraphExecute, BasePostGraphExecute):
         inputs: Dict[str, Any],
         overrides: Dict[str, Any],
     ):
+        """Implementation of the pre_graph_execute hook. This just converts the inputs to
+        the format the user-facing hook is expecting -- performing a walk of the DAG to pass in
+        the set of nodes to execute. Delegates to the interface method."""
         all_nodes, user_defined_nodes = graph.get_upstream_nodes(final_vars, inputs, overrides)
         nodes_to_execute = set(all_nodes) - set(user_defined_nodes)
         return self.run_before_graph_execution(
@@ -330,11 +334,11 @@ class GraphExecutionHook(BasePreGraphExecute, BasePostGraphExecute):
         """This is run after graph execution. This allows you to do anything you want after the graph executes,
         knowing the results of the execution/any errors.
 
-        @param graph: Graph that is being executed
-        @param results: Results of the graph execution
-        @param error: Error that occurred, None if no error occurred
-        @param success: Whether the graph executed successfully
-        @param future_kwargs: Additional keyword arguments -- this is kept for backwards compatibility
+        :param graph: Graph that is being executed
+        :param results: Results of the graph execution
+        :param error: Error that occurred, None if no error occurred
+        :param success: Whether the graph executed successfully
+        :param future_kwargs: Additional keyword arguments -- this is kept for backwards compatibility
         """
         pass
 
@@ -430,7 +434,8 @@ class NodeExecutionMethod(BaseDoNodeExecute):
 
 
 class StaticValidator(BaseValidateGraph, BaseValidateNode):
-    """Performs static validation of the DAG. Note that this has the option to perform default validat"""
+    """Performs static validation of the DAG. Note that this has the option to perform default validation for each method --
+    this means that if you don't implement one of these it is OK."""
 
     def run_to_validate_node(
         self, *, node: HamiltonNode, **future_kwargs

--- a/hamilton/lifecycle/api.py
+++ b/hamilton/lifecycle/api.py
@@ -258,7 +258,7 @@ class EdgeConnectionHook(BaseDoCheckEdgeTypesMatch, BaseDoValidateInput, abc.ABC
         :param node_type: Type of the node that is accepting the input.
         :param input_value: Value of the input
         :param kwargs: Keyword arguments -- this is kept for future backwards compatibility.
-        :return: Whether or not the input is valid for the node type.
+        :return: Whether the input is valid for the node type.
         """
         pass
 
@@ -307,3 +307,8 @@ class NodeExecutionMethod(BaseDoNodeExecute):
         :return: The result of the node execution -- up to you to return this.
         """
         pass
+
+
+# class DAGValidator(BasePostGraphConstruct)
+#     def post_graph_construct(self, *, graph: "FunctionGraph", modules: List[ModuleType], config: Dict[str, Any]):
+#         pass

--- a/hamilton/lifecycle/api.py
+++ b/hamilton/lifecycle/api.py
@@ -429,27 +429,27 @@ class StaticValidator(BaseValidateGraph, BaseValidateNode):
     def run_to_validate_node(
         self, *, node: HamiltonNode, **future_kwargs
     ) -> Tuple[bool, Optional[str]]:
-        """Override this for Node Validations! Defaults to just returning valid.
+        """Override this to build custom node validations! Defaults to just returning that a node is valid so you don't have to implement it if you want to just implement a single method.
         Runs post node construction to validate a node. You have access to a bunch of metadata about the node, stored in the hamilton_node argument
 
         :param node: Node to validate
         :param future_kwargs: Additional keyword arguments -- this is kept for backwards compatibility
-        :return: A tuple of whether the node is valid and an error message in the case of failure. Return [True, None] for a valid node.
-        Otherwise, return a detailed error message -- this should have all context/debugging information, but does not need
-        to mention the node name (it will be aggregated with others).
+        :return: A tuple of whether the node is valid and an error
+            message in the case of failure. Return [True, None] for a valid node.Otherwise, return a detailed error message -- this should have all context/debugging information, but does not need to
+            mention the node name (it will be aggregated with others).
         """
         return True, None
 
     def run_to_validate_graph(
         self, graph: HamiltonGraph, **future_kwargs
     ) -> Tuple[bool, Optional[str]]:
-        """Override this for DAG validations! Default to just returning valid.
+        """Override this to build custom DAG validations! Default to just returning that the graph is valid, so you don't have to implement it if you want to just implement a single method.
         Runs post graph construction to validate a graph. You have access to a bunch of metadata about the graph, stored in the graph argument.
 
         :param graph: Graph to validate.
         :param future_kwargs: Additional keyword arguments -- this is kept for backwards compatibility
         :return: A tuple of whether the graph is valid and an error message in the case of failure. Return [True, None] for a valid graph.
-        Otherwise, return a detailed error message -- this should have all context/debugging information.
+            Otherwise, return a detailed error message -- this should have all context/debugging information.
         """
         return True, None
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+dask
 fsspec
 graphviz
 kaleido

--- a/tests/lifecycle/test_lifecycle_base.py
+++ b/tests/lifecycle/test_lifecycle_base.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import pytest
 
@@ -49,17 +49,22 @@ def _valid_function_self_kwargs(self, *, a: int, b: int) -> int:
 
 
 @pytest.mark.parametrize(
-    "fn, returns_value",
+    "fn,returns_value,specified_return_value",
     [
-        (_valid_function_empty, False),
-        (_valid_function_returns_value, True),
-        (_valid_function_self, False),
-        (_valid_function_self_kwargs, True),
+        (_valid_function_empty, False, None),
+        (_valid_function_returns_value, True, None),
+        (_valid_function_returns_value, True, int),
+        (_valid_function_self, False, None),
+        (_valid_function_self_kwargs, True, None),
     ],
 )
-def test__validate_lifecycle_adapter_function_success(fn, returns_value: bool):
+def test_validate_lifecycle_adapter_function_success(
+    fn, returns_value: bool, specified_return_value: Optional[Type]
+):
     """Test that the lifecycle adapter function works as expected."""
-    validate_lifecycle_adapter_function(fn, returns_value=returns_value)
+    validate_lifecycle_adapter_function(
+        fn, returns_value=returns_value, return_type=specified_return_value
+    )
 
 
 def _function_with_positional_args(a, b):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,7 +24,7 @@ class Object:
             None,
         ),
         (
-            driver.Variable("A", int, {}, False, (), None, set(), set(), None),
+            driver.Variable("A", int, {}, False, (), None, set(), set()),
             {"amodule"},
             "A",
             None,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -23,7 +23,12 @@ class Object:
             "A",
             None,
         ),
-        (driver.Variable("A", int), {"amodule"}, "A", None),
+        (
+            driver.Variable("A", int, {}, False, (), None, set(), set(), None),
+            {"amodule"},
+            "A",
+            None,
+        ),
         (
             Object(),
             {"amodule"},

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -443,12 +443,13 @@ def test_using_callables_to_execute(driver_factory):
 def test_create_final_vars():
     """Tests that the final vars are created correctly."""
     dr = Driver({"required": 1}, tests.resources.test_default_args)
+    D_node = dr.graph.nodes["D"]
     actual = dr._create_final_vars(
         [
             "C",
             tests.resources.test_default_args.B,
             tests.resources.test_default_args.A,
-            Variable("D", int, {}, False),
+            Variable.from_node(D_node),
         ]
     )
     expected = ["C", "B", "A", "D"]


### PR DESCRIPTION
Adds a lifecycle validation capability. We had two types of lifecycle customizations:
1. Methods (replaced some component)
2. Hooks (augmented some components)

Now we have validators, which return a [bool, str] result, consisting of [success, message]. These allow erroring out if conditions are not met. We add one for validating nodes, and one for validating DAGs.

We also do a bunch of repo hygiene/add a few more public-facing capabilities.

https://github.com/DAGWorks-Inc/hamilton/issues/631

## Changes

## How I tested this

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
