### PR TITLE
export_json method in Driver.

### DIFF
--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -1,8 +1,10 @@
 """Module for external-facing graph constructs. These help the user navigate/manage the graph as needed."""
+import inspect
 import typing
 from dataclasses import dataclass
 
 from hamilton import htypes, node
+from hamilton.htypes import get_type_as_string
 
 # This is a little ugly -- its just required for graph build, and works
 # This indicates a larger smell though -- we need to have the right level of
@@ -27,6 +29,20 @@ class HamiltonNode:
     documentation: typing.Optional[str]
     required_dependencies: typing.Set[str]
     optional_dependencies: typing.Set[str]
+
+    def as_dict(self):
+        """Create a dictionary representation of the Node that is JSON serializable"""
+        return {
+            "name": self.name,
+            "tags": self.tags,
+            "output_type": get_type_as_string(self.type) if get_type_as_string(self.type) else "",
+            "required_dependencies": sorted(self.required_dependencies),
+            "optional_dependencies": sorted(self.optional_dependencies),
+            "source": inspect.getsource(self.originating_functions[0])
+            if self.originating_functions
+            else None,
+            "documentation": self.documentation,
+        }
 
     @staticmethod
     def from_node(n: node.Node) -> "HamiltonNode":

--- a/tests/test_driver_export.py
+++ b/tests/test_driver_export.py
@@ -1,0 +1,96 @@
+import json
+
+from hamilton import driver
+
+from tests.resources.dynamic_parallelism import no_parallel
+
+EXPECTED_JSON = {
+    "nodes": [
+        {
+            "name": "final",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": ["sum_step_squared_plus_step_cubed"],
+            "optional_dependencies": [],
+            "source": (
+                "def final(sum_step_squared_plus_step_cubed: int) -> int:\n"
+                '    print("finalizing")\n'
+                "    return sum_step_squared_plus_step_cubed\n"
+            ),
+            "documentation": "",
+        },
+        {
+            "name": "number_of_steps",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": [],
+            "optional_dependencies": [],
+            "source": "def number_of_steps() -> int:\n    return 5\n",
+            "documentation": "",
+        },
+        {
+            "name": "step_cubed",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": ["steps"],
+            "optional_dependencies": [],
+            "source": (
+                "def step_cubed(steps: int) -> int:\n"
+                '    print("cubing step {}".format(steps))\n'
+                "    return steps**3\n"
+            ),
+            "documentation": "",
+        },
+        {
+            "name": "step_squared",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": ["steps"],
+            "optional_dependencies": [],
+            "source": 'def step_squared(steps: int) -> int:\n    print("squaring step {}".format(steps))\n   '
+            " return steps**2\n",
+            "documentation": "",
+        },
+        {
+            "name": "step_squared_plus_step_cubed",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": ["step_cubed", "step_squared"],
+            "optional_dependencies": [],
+            "source": (
+                "def step_squared_plus_step_cubed(step_squared: int, step_cubed: int) -> int:\n"
+                '    print("adding step squared and step cubed")\n'
+                "    return step_squared + step_cubed\n"
+            ),
+            "documentation": "",
+        },
+        {
+            "name": "steps",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": ["number_of_steps"],
+            "optional_dependencies": [],
+            "source": "def steps(number_of_steps: int) -> int:\n    return number_of_steps\n",
+            "documentation": "",
+        },
+        {
+            "name": "sum_step_squared_plus_step_cubed",
+            "tags": {"module": "tests.resources.dynamic_parallelism.no_parallel"},
+            "output_type": "int",
+            "required_dependencies": ["step_squared_plus_step_cubed"],
+            "optional_dependencies": [],
+            "source": (
+                "def sum_step_squared_plus_step_cubed(step_squared_plus_step_cubed: int) -> int:\n"
+                '    print("summing step squared")\n'
+                "    return step_squared_plus_step_cubed\n"
+            ),
+            "documentation": "",
+        },
+    ],
+}
+
+
+def test_export_execution():
+    dr = driver.Builder().with_modules(no_parallel).build()
+    json_str = dr.export_execution(["final"])
+    assert json_str == json.dumps(EXPECTED_JSON)

--- a/tests/test_graph_types.py
+++ b/tests/test_graph_types.py
@@ -1,4 +1,9 @@
+import inspect
+import json
+
 from hamilton import graph_types, node
+
+from tests import nodes as test_nodes
 
 
 def test_create_hamilton_node():
@@ -20,3 +25,27 @@ def test_create_hamilton_node():
     assert not hamilton_node.is_external_input
     assert hamilton_node.required_dependencies == {"required_dep"}
     assert hamilton_node.optional_dependencies == {"optional_dep"}
+
+    assert hamilton_node.as_dict() == {
+        "name": "node_to_create",
+        "tags": {"tag_key": "tag_value"},
+        "output_type": "str",
+        "required_dependencies": ["required_dep"],
+        "optional_dependencies": ["optional_dep"],
+        "source": (
+            "    def node_to_create(required_dep: int, optional_dep: int = 1) -> str:\n"
+            '        """Documentation"""\n'
+            '        return f"{required_dep}_{optional_dep}"\n'
+        ),
+        "documentation": "Documentation",
+    }
+
+
+def test_json_serializable_dict():
+    for name, obj in inspect.getmembers(test_nodes):
+        if inspect.isfunction(obj) and not name.startswith("_"):
+            n = node.Node.from_fn(obj)
+            hamilton_node = graph_types.HamiltonNode.from_node(n)
+
+            # Check that json.dumps works on all nodes
+            json.dumps(hamilton_node.as_dict())


### PR DESCRIPTION
This PR creates a new method on the driver `export_json`. The method returns a JSON string representation of the graph.

The method is intended to be used by clients wishing to view and analyze their graphs with other visualizations tools. 

Idea referenced in discussion here: https://github.com/DAGWorks-Inc/hamilton/discussions/624

## Changes
 - New method `export_json` created in `driver.py`
 - New method `as_dict` created in `node.py`. This returns a JSON serializable dictionary of the Node.
 
## How I tested this
New tests created for both new methods

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
