### PR TITLE
Fixes schema viz so it doesn't drop duplicates

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -487,7 +487,10 @@ def create_graphviz_graph(
                 c.attr(**cluster_node_style)
                 cols = _create_equal_length_cols(n.tags.get(schema.INTERNAL_SCHEMA_OUTPUT_KEY))
                 for i in range(len(cols)):
-                    c.node(cols[i], **field_node_style)
+                    # We may want to change the name. We have a different name than label,
+                    # as it crowds out the global namespace
+                    # For now, however, this should be unique
+                    c.node(n.name + ":" + cols[i], **field_node_style, label=cols[i])
                 c.node(n.name)
 
     # create edges


### PR DESCRIPTION
See #637. This was a bug in which we were reusing the global namespace for columns. This fixes it by prepending with a unique name.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
