### PR TITLE
type annotations edited to fix linting issue

### DIFF
--- a/hamilton/io/materialization.py
+++ b/hamilton/io/materialization.py
@@ -26,7 +26,7 @@ class materialization_meta__(type):
         clsobj.__annotations__ = {}
         return clsobj
 
-    def __getattr__(cls, item: str) -> "MaterializerFactory":
+    def __getattr__(cls, item: str) -> "_MaterializerFactoryProtocol":
         """This *just* exists to provide a more helpful error message. If you try to access
         a property that doesn't exist, we'll raise an error that tells you what properties
         are available/where to learn more."""
@@ -69,7 +69,7 @@ class extractor_meta__(type):
         clsobj.__annotations__ = {}
         return clsobj
 
-    def __getattr__(cls, item: str) -> "MaterializerFactory":
+    def __getattr__(cls, item: str) -> "_ExtractorFactoryProtocol":
         """This *just* exists to provide a more helpful error message. If you try to access
         a property that doesn't exist, we'll raise an error that tells you what properties
         are available/where to learn more."""


### PR DESCRIPTION
Pylance (VSCode linter) would underline the entirety of materializers. 

## Changes
Elijah found the bug and asked to edit the type annotations of two methods

## How I tested this
- Pylance no longer throws errors after local changes. 
- Reran the test suite (except `tests/integrations` and `tests/plugins`) successfully and