### PR TITLE
Infer visualization format from output path

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -6,6 +6,7 @@ It should only house the graph & things required to create and traverse one.
 Note: one should largely consider the code in this module to be "private".
 """
 import logging
+import pathlib
 import uuid
 from enum import Enum
 from types import ModuleType
@@ -787,8 +788,14 @@ class FunctionGraph:
             deduplicate_inputs,
             display_fields=display_fields,
         )
-        kwargs = {"view": True}
-        if render_kwargs and isinstance(render_kwargs, dict):
+        kwargs = {"view": False, "format": "png"}  # default format = png
+        if output_file_path:  # infer format from path
+            if suffix := pathlib.Path(output_file_path).suffix:
+                inferred_format = suffix.partition(".")[-1]
+                kwargs.update(format=inferred_format)
+                # remove suffix if exist because dot.render() will append the format
+                output_file_path = str(pathlib.Path(output_file_path).stem)
+        if render_kwargs and isinstance(render_kwargs, dict):  # accept explicit format
             kwargs.update(render_kwargs)
         if output_file_path:
             dot.render(output_file_path, **kwargs)

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -743,8 +743,13 @@ class FunctionGraph:
     ) -> Optional["graphviz.Digraph"]:  # noqa F821
         """Function to display the graph represented by the passed in nodes.
 
+        The output file format is determined through the following steps, each one overwriting the previous one:
+        1. if `output_file_path` has no file extension, a PNG file is generated (e.g., `/path/to/file -> /path/to/file.png`)
+        2. if `output_file_path` has a file extension, graphviz will use the specified format (e.g., `/path/to/file.svg -> /path/to/file.svg`))
+        3. if a format value is specified for `render_kwargs={"format": "pdf"}`, it overrides any other inputs (e.g., /path/to/file.svg -> /path/to/file.pdf)
+
         :param nodes: the set of nodes that need to be computed.
-        :param output_file_path: the path where we want to store the `dot` file + pdf picture. Pass in None to not save.
+        :param output_file_path: the path where we want to store the `dot` file + png picture. Pass in None to not save.
         :param render_kwargs: kwargs to be passed to the render function to visualize.
         :param graphviz_kwargs: kwargs to be passed to the graphviz graph object to configure it.
             e.g. dict(graph_attr={'ratio': '1'}) will set the aspect ratio to be equal of the produced image.
@@ -790,7 +795,8 @@ class FunctionGraph:
         )
         kwargs = {"view": False, "format": "png"}  # default format = png
         if output_file_path:  # infer format from path
-            if suffix := pathlib.Path(output_file_path).suffix:
+            suffix = pathlib.Path(output_file_path).suffix
+            if suffix != "":
                 inferred_format = suffix.partition(".")[-1]
                 kwargs.update(format=inferred_format)
                 # remove suffix if exist because dot.render() will append the format

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -686,7 +686,7 @@ def test_function_graph_has_cycles_false():
 
 def test_function_graph_display(tmp_path: pathlib.Path):
     """Tests that display saves a file"""
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
     node_modifiers = {"B": {graph.VisualizationNodeModifiers.IS_OUTPUT}}
     all_nodes = set()
@@ -733,7 +733,7 @@ def test_function_graph_display(tmp_path: pathlib.Path):
 
 
 def test_function_graph_display_no_dot_output(tmp_path: pathlib.Path):
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
     fg.display(set(fg.get_nodes()), output_file_path=None)
@@ -743,7 +743,7 @@ def test_function_graph_display_no_dot_output(tmp_path: pathlib.Path):
 
 @pytest.mark.parametrize("show_legend", [(True), (False)])
 def test_function_graph_display_legend(show_legend: bool, tmp_path: pathlib.Path):
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
     fg.display(
@@ -760,7 +760,7 @@ def test_function_graph_display_legend(show_legend: bool, tmp_path: pathlib.Path
 
 @pytest.mark.parametrize("orient", [("LR"), ("TB"), ("RL"), ("BT")])
 def test_function_graph_display_orient(orient: str, tmp_path: pathlib.Path):
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
     fg.display(
@@ -777,7 +777,7 @@ def test_function_graph_display_orient(orient: str, tmp_path: pathlib.Path):
 
 @pytest.mark.parametrize("hide_inputs", [(True,), (False,)])
 def test_function_graph_display_inputs(hide_inputs: bool, tmp_path: pathlib.Path):
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={"b": 1, "c": 2})
 
     fg.display(
@@ -810,7 +810,7 @@ def test_function_graph_display_without_saving():
 
 @pytest.mark.parametrize("display_fields", [(True,), (False,)])
 def test_function_graph_display_fields(display_fields: bool, tmp_path: pathlib.Path):
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
 
     @schema.output(("foo", "int"), ("bar", "float"), ("baz", "str"))
     def df_with_schema() -> pd.DataFrame:
@@ -840,7 +840,7 @@ def test_function_graph_display_fields(display_fields: bool, tmp_path: pathlib.P
 
 def test_function_graph_display_fields_shared_schema(tmp_path: pathlib.Path):
     # This ensures an edge case where they end up getting dropped if there are duplicates
-    dot_file_path = tmp_path / "dag.dot"
+    dot_file_path = tmp_path / "dag"
 
     SCHEMA = (("foo", "int"), ("bar", "float"), ("baz", "str"))
 


### PR DESCRIPTION
Previously, visualizations functions needed an argument `output_file_path="/path/to/my_viz"` and the format was specified via `viz_func(render_kwargs=dict(format="png"))`. 

## Motivation
- for the path `/path/to/my_viz``, `my_viz` actually specifies the file name even though it doesn't have an extension. Graphviz render engine would append the format to the file name. It leads to unintuitive behavior where `/path/to/my_viz.png` would get appended another format `/path/to/my_viz.png.pdf`
- the default is `pdf` which unlikely to be the most used format
- you really need to dig around to figure out how to specify `render_kwargs=dict(format="png"))` and it decreases readability of visualization function calls.

## Changes
- added a default `kwargs` value to have `png` as the default format instead of `pdf`
- added a step to infer the file format from the `output_file_path`. This will overwrite the default `png`. Then, the `render_kwargs=dict(format=...))` value will overwrite the value again if specified (backward compatibility)
- if a file format is inferred (e.g., `svg` for `/path/to/my_viz.svg`), the `.svg` suffix is removed from the `output_file_path` to allow the graphviz render engine to add it back (prevent `/path/to/my_viz.svg.svg`)

## How I tested this
- needed to change a few tests that inspected the DOT file from `dag.DOT` to `dag`
- ran the test suite successfully
- I manually tested using the default png, the inferred, and the explicit formats, but didn't add tests for it

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
