### PR TITLE
fix: Driver.execute() Pylance linting issue fixed

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -11,7 +11,7 @@ import typing
 import uuid
 from datetime import datetime
 from types import ModuleType
-from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Collection, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import pandas as pd
 
@@ -504,7 +504,7 @@ class Driver:
 
     def execute(
         self,
-        final_vars: List[Union[str, Callable, Variable]],
+        final_vars: Sequence[Union[str, Callable, Variable]],
         overrides: Dict[str, Any] = None,
         display_graph: bool = False,
         inputs: Dict[str, Any] = None,


### PR DESCRIPTION
Pylance would report typing error when passing a list of strings to `Driver.execute()`, e.g., `dr.execute(final_vars=["a", "b"])`

```
Argument of type "list[str]" cannot be assigned to parameter "final_vars" of type "List[str | ((...) -> Unknown) | Variable]" in function "execute"
  "list[str]" is incompatible with "List[str | ((...) -> Unknown) | Variable]"
    Type parameter "_T@list" is invariant, but "str" is not the same as "str | ((...) -> Unknown) | Variable"
    Consider switching from "list" to "Sequence" which is covariantPylancereportGeneralTypeIssues
```

## Changes
- Changed the type annotation of `Driver.execute()` from `List[Union[str, Callable, Variable]]` to `Sequence[Union[str, Callable, Variable]]` 

## How I tested this
- Entire test suite ran successfully

## Notes
- the typing change triggered Pylance linting for internal code that used to expect `List[str]` from `List[Union[str, Callable, Variable]]`. Now, expecting `List[str]` is too narrow for allowing `Sequence[Union[str, Callable, Variable]]`. However, these linting notifications are only internal

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
