### PR TITLE
Truncates inputs logged when a node errors

### DIFF
--- a/hamilton/execution/graph_functions.py
+++ b/hamilton/execution/graph_functions.py
@@ -1,4 +1,5 @@
 import logging
+import pprint
 from typing import Any, Collection, Dict, List, Optional, Set, Tuple
 
 from hamilton import node
@@ -93,6 +94,29 @@ def combine_config_and_inputs(config: Dict[str, Any], inputs: Dict[str, Any]) ->
             f"mutually disjoint. {duplicated_inputs} "
         )
     return {**config, **inputs}
+
+
+def create_input_string(kwargs: dict) -> str:
+    """THis is a utility function to create a string representation of the inputs to a function.
+
+    This is useful for debugging, as it can be printed out to see what the inputs were.
+
+    :param kwargs: The inputs to the function that errored.
+    :return: The string representation of the inputs, truncated appropriately.
+    """
+    pp = pprint.PrettyPrinter(width=80)
+    inputs = {}
+    for k, v in kwargs.items():
+        item_repr = repr(v)
+        if len(item_repr) > 50:
+            item_repr = item_repr[:50] + "..."
+        else:
+            item_repr = v
+        inputs[k] = item_repr
+    input_string = pp.pformat(inputs)
+    if len(input_string) > 1000:
+        input_string = input_string[:80] + "..."
+    return input_string
 
 
 def execute_subdag(
@@ -194,10 +218,7 @@ def execute_subdag(
                 message = f"> {node_.name} [{module}.{original_func_name}()] encountered an error"
                 padding = " " * (80 - len(message) - 1)
                 message += padding + "<"
-                import pprint
-
-                pp = pprint.PrettyPrinter(width=80)
-                input_string = pp.pformat(kwargs)
+                input_string = create_input_string(kwargs)
                 message += "\n> Node inputs:\n" + input_string
                 border = "*" * 80
                 logger.exception("\n" + border + "\n" + message + "\n" + border)

--- a/hamilton/execution/graph_functions.py
+++ b/hamilton/execution/graph_functions.py
@@ -97,7 +97,7 @@ def combine_config_and_inputs(config: Dict[str, Any], inputs: Dict[str, Any]) ->
 
 
 def create_input_string(kwargs: dict) -> str:
-    """THis is a utility function to create a string representation of the inputs to a function.
+    """This is a utility function to create a string representation of the inputs to a function.
 
     This is useful for debugging, as it can be printed out to see what the inputs were.
 
@@ -115,7 +115,7 @@ def create_input_string(kwargs: dict) -> str:
         inputs[k] = item_repr
     input_string = pp.pformat(inputs)
     if len(input_string) > 1000:
-        input_string = input_string[:80] + "..."
+        input_string = input_string[:1000] + "..."
     return input_string
 
 

--- a/tests/execution/test_graph_functions.py
+++ b/tests/execution/test_graph_functions.py
@@ -168,11 +168,11 @@ def test_create_input_string_with_empty_dict():
 
 def test_create_input_string_with_large_number_of_args():
     """Tests that create_input_string truncates the output if there are too many arguments"""
-    kwargs = {f"arg{i}": i for i in range(100)}
+    kwargs = {f"arg{i}": i for i in range(1000)}
     result = create_input_string(kwargs)
     assert result.startswith("{")
     assert result.endswith("...")
-    assert len(result) == 83
+    assert len(result) == 1003
 
 
 def test_create_input_string_with_dataframes():


### PR DESCRIPTION
This was requested by a user, because we could overwhelm a log system. This should suffice for now. We can always modify tweak this later.

## Changes
- graph_functions.py error handling code

## How I tested this
 - locally

```
********************************************************************************
> spend_per_signup [my_functions.spend_per_signup()] encountered an error      <
> Node inputs:
{'signups': '0      1\n1     10\n2     50\n3    100\n4    200\n5    ...',
 'spend': '0    10\n1    10\n2    20\n3    40\n4    40\n5    50\ndt...'}
********************************************************************************
```

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
