### PR TITLE
fix: JSON materializer don't support `list[dict]`

### DIFF
--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -4,7 +4,7 @@ import json
 import os
 import pathlib
 import pickle
-from typing import Any, Collection, Dict, Tuple, Type, Union
+from typing import Any, Collection, Dict, List, Tuple, Type, Union
 
 from hamilton.io.data_adapters import DataLoader, DataSaver
 from hamilton.io.utils import get_file_metadata
@@ -16,7 +16,7 @@ class JSONDataLoader(DataLoader):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [dict]
+        return [dict, List[dict]]
 
     def load_data(self, type_: Type) -> Tuple[dict, Dict[str, Any]]:
         with open(self.path, "r") as f:
@@ -33,7 +33,7 @@ class JSONDataSaver(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [dict]
+        return [dict, List[dict]]
 
     @classmethod
     def name(cls) -> str:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,7 @@ lz4
 matplotlib
 networkx
 openpyxl  # for excel data loader
+pandera
 plotly
 polars
 pyarrow

--- a/tests/io/test_default_adapters.py
+++ b/tests/io/test_default_adapters.py
@@ -1,9 +1,16 @@
 import io
+import json
 import pathlib
+from typing import List
 
 import pytest
 
-from hamilton.io.default_data_loaders import RawFileDataSaverBytes
+from hamilton.io.utils import FILE_METADATA
+from hamilton.io.default_data_loaders import (
+    RawFileDataSaverBytes,
+    JSONDataLoader,
+    JSONDataSaver
+)
 
 
 @pytest.mark.parametrize(
@@ -24,3 +31,39 @@ def test_raw_file_adapter(data, tmp_path: pathlib.Path) -> None:
 
     data_processed = data if type(data) is bytes else data.getvalue()
     assert data_processed == data2
+
+
+@pytest.mark.parametrize(
+    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]]
+)
+def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
+    """Test that `from_.json` and `to.json` can handle JSON objects where
+    the top-level is an object `{ }` -> dict or an array `[ ]` -> list[dict]
+    """
+    data_path = tmp_path / "data.json"
+    saver = JSONDataSaver(path=data_path)
+    
+    metadata = saver.save_data(data)
+    loaded_data = json.loads(data_path.read_text())
+        
+    assert JSONDataSaver.applicable_types() == [dict, List[dict]]
+    assert data_path.exists()
+    assert metadata[FILE_METADATA]["path"] == str(data_path)
+    assert data == loaded_data
+    
+    
+@pytest.mark.parametrize(
+    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]]
+)
+def test_json_load_object_and_array(data, tmp_path: pathlib.Path):
+    """Test that `from_.json` and `to.json` can handle JSON objects where
+    the top-level is an object `{ }` -> dict or an array `[ ]` -> list[dict]
+    """
+    data_path = tmp_path / "data.json"
+    loader = JSONDataLoader(path=data_path)
+    
+    json.dump(data, data_path.open("w"))
+    loaded_data, metadata = loader.load_data(type(data))
+        
+    assert JSONDataLoader.applicable_types() == [dict, List[dict]]
+    assert data == loaded_data

--- a/tests/io/test_default_adapters.py
+++ b/tests/io/test_default_adapters.py
@@ -5,12 +5,8 @@ from typing import List
 
 import pytest
 
+from hamilton.io.default_data_loaders import JSONDataLoader, JSONDataSaver, RawFileDataSaverBytes
 from hamilton.io.utils import FILE_METADATA
-from hamilton.io.default_data_loaders import (
-    RawFileDataSaverBytes,
-    JSONDataLoader,
-    JSONDataSaver
-)
 
 
 @pytest.mark.parametrize(
@@ -33,37 +29,33 @@ def test_raw_file_adapter(data, tmp_path: pathlib.Path) -> None:
     assert data_processed == data2
 
 
-@pytest.mark.parametrize(
-    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]]
-)
+@pytest.mark.parametrize("data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]])
 def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
     the top-level is an object `{ }` -> dict or an array `[ ]` -> list[dict]
     """
     data_path = tmp_path / "data.json"
     saver = JSONDataSaver(path=data_path)
-    
+
     metadata = saver.save_data(data)
     loaded_data = json.loads(data_path.read_text())
-        
+
     assert JSONDataSaver.applicable_types() == [dict, List[dict]]
     assert data_path.exists()
     assert metadata[FILE_METADATA]["path"] == str(data_path)
     assert data == loaded_data
-    
-    
-@pytest.mark.parametrize(
-    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]]
-)
+
+
+@pytest.mark.parametrize("data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]])
 def test_json_load_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
     the top-level is an object `{ }` -> dict or an array `[ ]` -> list[dict]
     """
     data_path = tmp_path / "data.json"
     loader = JSONDataLoader(path=data_path)
-    
+
     json.dump(data, data_path.open("w"))
     loaded_data, metadata = loader.load_data(type(data))
-        
+
     assert JSONDataLoader.applicable_types() == [dict, List[dict]]
     assert data == loaded_data


### PR DESCRIPTION
At the top level, JSON files are either a mapping `{ }` or a list `[ ]`. Currently, the default JSON DataSaver and DataLoader only map to a Python `dict` type and don't support a `list[dict]` annotation.

For example:
```python
JSON_FILE_CONTENT = [
    {"name": "A"},
    {"name": "B"}
]

# this works
def node(json_data: dict) -> dict:
    return json_data

# this should work but doesn't
def from_to_bug(json_data: list[dict]) -> list[dict]:
    return json_data

# this doesn't work because of `from_`
def from_bug(json_data: list[dict]) -> dict:
    return json_data

# this doesn't work because of `to`
def to_bug(json_data: dict) -> list[dict]:
    return json_data


if __name__ == "__main__":
    from hamilton import driver
    from hamilton.io.materialization import to, from_
    import __main__
    
    dr = driver.Builder().with_modules(__main__).build()
    
    # comment out functions to avoid name/type conflicts
    dr.materialize(
        from_.json(target="json_data", path="data.json"),
        to.json(path="./out.json", id="out__json", dependencies=["from_to_bug"]),
        additional_vars=["from_to_bug"],
    )
```

## Changes
- Changed the type annotations for JSON `DataSaver` and `DataLoader`

## How I tested this
- the test suite runs successfully
- the above example now works

## Notes
- ❗ one issue with supporting both `dict` and `list[dict]` is that the object might be miss-typed and still load/save. For example, 

```python
JSON_FILE_CONTENT = [
    {"name": "A"},
    {"name": "B"}
]

# with the fix, the next 2 fucnctions would work
# however, `json_data` can't be `list[dict]` and `dict`

# for the above data,
# this one fails because isinstance(json_data, dict) is False
def from_bug_alert(json_data: list[dict]) -> dict:
    return json_data

# this one works / fails silently because type(json_data) in (dict, list[dict])
def from_bug_silent(json_data: dict) -> list[dict]:
    return json_data
    
# similar logic applies with `to`, but it matters less because nothing
# depends on materializer nodes
```

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
