### PR TITLE
fix: fix typo in extract_columns decorator example

### DIFF
--- a/docs/concepts/decorators-overview.rst
+++ b/docs/concepts/decorators-overview.rst
@@ -77,7 +77,7 @@ write the following:
 
     from hamilton.function_modifiers import extract_columns
 
-    @extract_columns(['tv_spend', 'radio_spend', 'billboard_spend'])
+    @extract_columns('tv_spend', 'radio_spend', 'billboard_spend')
     def marketing_spend_df() -> pd.DataFrame:
         return load_all_marketing_spend_from_external_source()
 


### PR DESCRIPTION
## Changes

Fix a typo in `extract_columns` decorator example in the docs.

## How I tested this

N/A

## Notes

`extract_columns` takes `*columns: Union[Tuple[str, str], str]` as an argument. So passing `list[str]` causes the following error.

```
hamilton.function_modifiers.base.InvalidDecoratorException: Error list passed in. Please `*` in front of it to expand it.
```

I noticed this issue while reading the docs and hope it will be a little help.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
