### PR TITLE
Fixes tag_outputs to tag everything

### DIFF
--- a/hamilton/function_modifiers/metadata.py
+++ b/hamilton/function_modifiers/metadata.py
@@ -169,11 +169,13 @@ class tag_outputs(base.NodeDecorator):
                return pd.DataFrame.from_records({"a": [1], "b": [2]})
 
         """
-        super(base.NodeDecorator, self).__init__(target=None)
+        super(base.NodeDecorator, self).__init__(target=...)
         self.tag_mapping = tag_mapping
 
     def decorate_node(self, node_: node.Node) -> node.Node:
         """Decorates all final nodes with the specified tags."""
+        if node_.name not in self.tag_mapping:
+            return node_  # in this case we have no desire to update tags
         new_tags = node_.tags.copy()
         new_tags.update(self.tag_mapping.get(node_.name, {}))
         return tag(**new_tags).decorate_node(node_)

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -74,6 +74,28 @@ def test_tag_outputs():
     assert node_map["b"].tags["tag_b_gets"] == "tag_value_b_gets"
 
 
+def test_tag_outputs_tags_all():
+    @function_modifiers.extract_columns("a", "b")
+    def dummy_tagged_function() -> pd.DataFrame:
+        """dummy doc"""
+        return pd.DataFrame.from_records({"a": [1], "b": [2]})
+
+    annotation = function_modifiers.tag_outputs(
+        a={"tag_a_gets": "tag_value_a_gets"},
+        b={"tag_b_gets": "tag_value_b_gets"},
+        dummy_tagged_function={"tag_fn_gets": "tag_value_fn_gets"},
+    )
+    nodes = annotation.transform_dag(
+        function_modifiers.base.resolve_nodes(dummy_tagged_function, {}),
+        config={},
+        fn=dummy_tagged_function,
+    )
+    node_map = {node_.name: node_ for node_ in nodes}
+    assert node_map["a"].tags["tag_a_gets"] == "tag_value_a_gets"
+    assert node_map["b"].tags["tag_b_gets"] == "tag_value_b_gets"
+    assert node_map["dummy_tagged_function"].tags["tag_fn_gets"] == "tag_value_fn_gets"
+
+
 def test_tag_outputs_and_tag_together():
     """Tests that tag_outputs and tag work together"""
 


### PR DESCRIPTION
This was overly restrictive at first. tag_outputs should be able to tag any intermediate nodes as well, given that its specified by name. We use the ... annotation to say that we want to tag everything, but that's hidden internally. While this could be construed as backwards incompatible, it would be a very strange case, and its more reasonable to argue that the documentation suggests that this is the intendecd behavior and it was always wrong.

## Changes

## How I tested this

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
