### PR TITLE
Fixes default parameter calculation

### DIFF
--- a/hamilton/function_modifiers/macros.py
+++ b/hamilton/function_modifiers/macros.py
@@ -135,7 +135,7 @@ class does(base.NodeCreator):
         dummy_param_values = {
             key: SENTINEL_ARG_VALUE
             for key, param_spec in fn_signature.parameters.items()
-            if param_spec.default != inspect.Parameter.empty
+            if param_spec.default is not inspect.Parameter.empty
         }
         # Then we update with the dummy values. Again, replacing doesn't matter (we'll be mimicking it later)
         dummy_param_values.update({key: SENTINEL_ARG_VALUE for key in fn_signature.parameters})
@@ -214,7 +214,7 @@ class does(base.NodeCreator):
             final_kwarg_values = {
                 key: param_spec.default
                 for key, param_spec in inspect.signature(fn).parameters.items()
-                if param_spec.default != inspect.Parameter.empty
+                if param_spec.default is not inspect.Parameter.empty
             }
             final_kwarg_values.update(kwargs)
             final_kwarg_values = does.map_kwargs(final_kwarg_values, self.argument_mapping)

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -187,7 +187,7 @@ def _check_keyword_args_only(func: Callable) -> bool:
     """Checks if a function only takes keyword arguments."""
     sig = inspect.signature(func)
     for param in sig.parameters.values():
-        if param.default == inspect.Parameter.empty and param.kind not in [
+        if param.default is inspect.Parameter.empty and param.kind not in [
             inspect.Parameter.KEYWORD_ONLY,
             inspect.Parameter.VAR_KEYWORD,
         ]:

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -36,7 +36,7 @@ class DependencyType(Enum):
 
     @staticmethod
     def from_parameter(param: inspect.Parameter):
-        if param.default == inspect.Parameter.empty:
+        if param.default is inspect.Parameter.empty:
             return DependencyType.REQUIRED
         return DependencyType.OPTIONAL
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 from typing import Any, Literal, TypeVar
 
@@ -104,3 +105,15 @@ def test_node_handles_annotated():
 )
 def test_tags_match_query(tags: dict, query: dict, expected: bool):
     assert matches_query(tags, query) == expected
+
+
+def test_from_parameter_default_override_equals():
+    class BrokenEquals:
+        def __eq__(self, other):
+            raise ValueError("I'm broken")
+
+    def foo(b: BrokenEquals = BrokenEquals()):
+        pass
+
+    param = DependencyType.from_parameter(inspect.signature(foo).parameters["b"])
+    assert param == DependencyType.OPTIONAL


### PR DESCRIPTION
The defaults overwrote the equals operator, which then failed on cmoparison to .empty. This fixes it to use is Parameter.empty which is a better approach in python.

This was sloppy in the first place. Not adding tests everywhere but just where it matters.
## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
