### PR TITLE
Spellchecking for new docs/concepts pages

### DIFF
--- a/docs/concepts/driver.rst
+++ b/docs/concepts/driver.rst
@@ -93,7 +93,7 @@ The Driver automatically determines the minimum required path to compute request
 Development tips
 ----------------
 
-With Hamilton, development time is mostly spent writing functions for your dataflow in a Python module. Rebuilding the Driver and visualizing your dataflow as you make changes helps iterative development. Find below two ways to useful development workflows.
+With Hamilton, development time is mostly spent writing functions for your dataflow in a Python module. Rebuilding the Driver and visualizing your dataflow as you make changes helps iterative development. Find below two useful development workflows.
 
 With a Python module
 ~~~~~~~~~~~~~~~~~~~~
@@ -127,7 +127,7 @@ With a Jupyter notebook
 
 Another approach is to define the dataflow in a module (e.g., ``my_dataflow.py``) and reload the Driver in a Jupyter notebook. This allows for a more interactive experience when you want to inspect the results of functions as you're developing.
 
-By default, Python only imports a module once and subsequent ``import`` statements don't reload the module. We use reload our imported module with ``importlib.reload(my_dataflow)`` and rebuild the Driver as we make changes to our dataflow.
+By default, Python only imports a module once and subsequent ``import`` statements don't reload the module. We reload our imported module with ``importlib.reload(my_dataflow)`` and rebuild the Driver as we make changes to our dataflow.
 
 .. code-block:: python
 
@@ -155,7 +155,7 @@ Learn other Jupyter development tips on the page :doc:`../how-tos/use-in-jupyter
 Recap
 -----
 - The Driver automatically assembles a dataflow from Python modules
-- The Driver visualize the dataflow created from your code
+- The Driver visualizes the dataflow created from your code
 - Functions are executed by requesting nodes to driver ``.execute()``
 
 Next step

--- a/docs/concepts/driver.rst
+++ b/docs/concepts/driver.rst
@@ -2,7 +2,7 @@
 Driver
 ======
 
-Once you defined your dataflow in a Python module, you will need to create a Hamilton Driver to execute it. This page details the Driver basics, which include:
+Once you defined your dataflow in a Python module, you need to create a Hamilton Driver to execute it. This page details the Driver basics, which include:
 
 1. Defining the Driver
 2. Visualizing the dataflow
@@ -28,9 +28,9 @@ For this page, let's pretend we defined the following module ``my_dataflow.py``:
 Define the Driver
 -----------------
 
-First, you need to create a ``driver.Driver`` object. This is possible through the ``driver.Builder()`` object to which you give Python modules and other configurations, and call ``.build()`` to create the Driver.
+First, you need to create a ``driver.Driver`` object. This is done by passing Python modules to the ``driver.Builder()`` object along other configurations and calling ``.build()``.
 
-The most basic Driver looks like this:
+The most basic Driver is built like this:
 
 .. code-block:: python
 
@@ -42,7 +42,7 @@ The most basic Driver looks like this:
     # it is created by a `driver.Builder` object
     dr = driver.Builder().with_modules(my_dataflow).build()
 
-The ``.build()`` method will fail if the definition found in ``my_dataflow`` is invalid (e.g., type mismatch, missing annotations) allowing to fix issues and iterate quickly.
+The ``.build()`` method will fail if the definition found in ``my_dataflow`` is invalid (e.g., type mismatch, missing annotations) allowing you to fix issues and iterate quickly.
 
 The ``Driver`` is defined in the context you intend to run, separately from your dataflow module. It can be in a script, notebook, server, web app, or anywhere else Python can run. As a convention, most Hamilton code examples use a script named ``run.py``.
 
@@ -61,14 +61,14 @@ Once you successfully created your Driver, you can visualize the entire dataflow
     dr.display_all_functions("dag.png")  # outputs a file dag.png
     dr.display_all_functions()  # to view directly in a notebook
 
-The dataflow visualization is useful for documenting your project and quickly making sense of what it does (see :doc:`visualization`).
+Dataflow visualizations are useful for documenting your project and quickly making sense of what a dataflow does (see :doc:`visualization`).
 
 Execute the dataflow
 --------------------
 
-With the Driver, you can request the value of specific nodes by calling ``dr.execute()`` with a list node names. These requested nodes are specified via ``final_vars``.  By default, results are returned in a dictionary with ``{node_name: result}``.
+From the Driver, you can request the value of specific nodes by calling ``dr.execute(final_vars=[...])``, where ``final_vars`` is a list of node names. By default, results are returned in a dictionary with ``{node_name: result}``.
 
-The following requests the node ``C`` and visualizes the execution path:
+The following requests the node ``C`` and visualizes the dataflow execution:
 
 .. code-block:: python
 
@@ -82,7 +82,7 @@ The following requests the node ``C`` and visualizes the execution path:
 
     print(results["C"])  # access results dictionary
 
-The Driver automatically determines and computes the minimum required path to requested nodes. See the respective outputs for ``dr.visualize_execution(["C"])`` and ``dr.visualize_execution(["B"])``:
+The Driver automatically determines the minimum required path to compute requested nodes. See the respective outputs for ``dr.visualize_execution(["C"])`` and ``dr.visualize_execution(["B"])``:
 
 .. image:: ../_static/execute_c.png
     :height: 250px
@@ -93,7 +93,7 @@ The Driver automatically determines and computes the minimum required path to re
 Development tips
 ----------------
 
-With Hamilton, most of your development time is spent on writing functions for your dataflow in a Python module. Rebuilding the Driver and visualizing your dataflow as you make changes helps iterative development. So here's helpful workflows:
+With Hamilton, development time is mostly spent writing functions for your dataflow in a Python module. Rebuilding the Driver and visualizing your dataflow as you make changes helps iterative development. Find below two ways to useful development workflows.
 
 With a Python module
 ~~~~~~~~~~~~~~~~~~~~
@@ -127,7 +127,7 @@ With a Jupyter notebook
 
 Another approach is to define the dataflow in a module (e.g., ``my_dataflow.py``) and reload the Driver in a Jupyter notebook. This allows for a more interactive experience when you want to inspect the results of functions as you're developing.
 
-By default, Python only imports a module once and subsequent ``import`` statements don't reload the module. We use ``importlib.reload`` to reload ``my_dataflow`` before rebuilding the Driver.
+By default, Python only imports a module once and subsequent ``import`` statements don't reload the module. We use reload our imported module with ``importlib.reload(my_dataflow)`` and rebuild the Driver as we make changes to our dataflow.
 
 .. code-block:: python
 
@@ -154,8 +154,8 @@ Learn other Jupyter development tips on the page :doc:`../how-tos/use-in-jupyter
 
 Recap
 -----
-- The Driver automatically assembles dataflows from Python modules
-- The Driver can build a visualization of the dataflow from your code
+- The Driver automatically assembles a dataflow from Python modules
+- The Driver visualize the dataflow created from your code
 - Functions are executed by requesting nodes to driver ``.execute()``
 
 Next step
@@ -165,8 +165,8 @@ Now, you know the basics of authoring and executing Hamilton dataflows! We encou
 - Write some code with our `interactive tutorials <https://www.tryhamilton.dev/intro>`_
 - Kickstart your project with `community dataflows <https://hub.dagworks.io/docs/>`_
 
-The next Concepts page covers notions to write more expressive and powerful code. If you feel stuck or constrained with the basics, it's probably a good time to visit them. They include:
+The next **Concepts** pages cover notions to write more expressive and powerful code. If you feel stuck or constrained with the basics, it's probably a good time to (re)visit them. They include:
 
-- Materialization: interact with external data source
+- Materialization: interact with external data sources
 - Function modifiers: write expressive dataflows without repeating code
 - Builder: how to customize your Driver

--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -4,7 +4,7 @@ Function modifiers
 
 In :doc:`node`, we discussed how to write Python functions to define Hamilton nodes and dataflow. In the basic case, each function defines one node.
 
-Yet, it's common to need nodes serving similar purposes, such as "preprocess training set" and "preprocess evaluation set". In that case, use a **function modifier** to create both nodes from a single Hamilton function!
+Yet, it's common to need nodes with similar purposes, but different dependencies such as preprocessing a training and an evaluation dataset. In that case, using a **function modifier** can help create both nodes from a single Hamilton function!
 
 On this page, you'll learn:
 
@@ -58,7 +58,7 @@ This section from the page :doc:`node` details how a Python function maps to a H
      - Function name and return type annotation
      - Node name and type
    * - 2
-     - Parameter(s) name and type annotation
+     - Parameter names and type annotations
      - Node dependencies
    * - 3
      - Docstring
@@ -75,7 +75,7 @@ Add metadata to a node
 
 @tag
 ~~~~~~~~
-The ``@tag`` decorator **doesn't modify the function/node**. It attaches metadata to the node that Hamilton and you can use. It can help tag nodes by ownership, data source, version, infrastructure, and anything else.
+The ``@tag`` decorator **doesn't modify the function/node**. It attaches metadata to the node that can be used by Hamilton and you. It can help tag nodes by ownership, data source, version, infrastructure, and anything else.
 
 For example, this tags the associated data product and the sensitivity of the data.
 
@@ -92,7 +92,7 @@ For example, this tags the associated data product and the sensitivity of the da
 Query node by tag
 ~~~~~~~~~~~~~~~~~
 
-Once you built your Driver, you can use ``Driver.list_available_variables()`` and then filter them by tag. The following gets all the nodes for which ``data_product="final"`` and passes them to ``driver.execute()``
+Once you built your Driver, you can get all nodes with ``Driver.list_available_variables()`` and then filter them by tag. The following gets all the nodes for which ``data_product="final"`` and passes them to ``driver.execute()``
 
 .. code-block:: python
 
@@ -106,7 +106,7 @@ Once you built your Driver, you can use ``Driver.list_available_variables()`` an
 Customize visualization by tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tags are also accessible to the visualization styling feature, allowing you to highlight important nodes for your documentation (e.g., by infrastructure, ownership). See :ref:`custom-visualization-style` for details.
+Tags are also accessible to the visualization styling feature, allowing you to highlight important nodes for your documentation. See :ref:`custom-visualization-style` for details.
 
 .. image:: ./_function-modifiers/custom_viz.png
     :height: 250px
@@ -114,7 +114,7 @@ Tags are also accessible to the visualization styling feature, allowing you to h
 @schema
 ~~~~~~~
 
-The ``@schema`` function modifiers provides lightweight way to add type metadata for dataframes. It works by specifying a specifying tuples of ``(field_name, field_type)`` with types as strings.
+The ``@schema`` function modifiers provides a lightweight way to add type metadata to dataframes. It works by specifying tuples of ``(field_name, field_type)`` with types as strings.
 
 .. code-block:: python
 
@@ -136,16 +136,18 @@ The ``@schema`` function modifiers provides lightweight way to add type metadata
 Validate node output
 --------------------
 
-The ``@check_output`` function modifiers are applied on the **node output / function return** and therefore don't directly affect node behavior. Decorators separate data validation from the function body where the core logic is. Your function readability is improved, and it becomes easier to reuse and maintain standardized checks across multiple functions.
+The ``@check_output`` function modifiers are applied on the **node output / function return** and therefore don't directly affect node behavior. Decorators separate data validation from the function body where the core logic is. It improves function readability, and it helps reusing and maintaining standardized checks across multiple functions.
 
-Note, in the future ``@schema`` might also have validation capabilities, but for now, it's only for metadata.
+.. note::
+
+    In the future, validatation capabailities may be added to ``@schema``. For now, it's only added metadata.
 
 @check_output
 ~~~~~~~~~~~~~
 
 The ``@check_output`` implements many data checks for Python objects and DataFrame/Series including data type, min/max/between, count, fraction of null/nan values, and allow null/nan. Failed checks are either logged (``importance="warn"``) or make the dataflow fail (``importance="fail"``).
 
-The next snippet checks if the returned Series is of type ``np.int32``, which is non-nullable and within the range 0-100, and logs the failed checks. We could manually review instances where things failed.
+The next snippet checks if the returned Series is of type ``np.int32``, which is non-nullable, and if its within the range 0-100, and logs failed checks. This would allows us to manually review instances where data validation failed.
 
 .. code-block:: python
 
@@ -170,22 +172,22 @@ The next snippet checks if the returned Series is of type ``np.int32``, which is
 pandera support
 ~~~~~~~~~~~~~~~
 
-Hamilton has a pandera plugin for data validation that you can install with ``pip install sf-hamilton[pandera]``. Then, you can pass pandera schemas (DataFrame or Series) to ``@check_output(schema=...)``.
+Hamilton has a pandera plugin for data validation that you can install with ``pip install sf-hamilton[pandera]``. Then, you can pass a pandera schema (for DataFrame or Series) to ``@check_output(schema=...)``.
 
 
 Split node output into *n* nodes
 --------------------------------
 
-Sometimes, your node outputs multiple values that you would like to name and make accessible to other nodes. These function modifiers act on the **node output / function return**.
+Sometimes, your node outputs multiple values that you would like to name and make available to other nodes. These function modifiers act on the **node output / function return**.
 
 .. note::
 
-    You can use ``@tag_output``, which works just like ``@tag`` to add metadata to  extracted nodes.
+    To add metadata to extracted nodes, use ``@tag_output``, which works just like ``@tag``.
 
 @extract_fields
 ~~~~~~~~~~~~~~~
 
-A good example is splitting a dataset into train, validation, and split. We will use ``@extract_fields``. You need to specify in a dictionary the ``field_name: field_type`` of each field.
+A good example is splitting a dataset into train, validation, and test splits. We will use ``@extract_fields``, which requires specifying in a dictionary the ``field_name: field_type`` of each field.
 
 .. code-block:: python
 
@@ -209,7 +211,7 @@ A good example is splitting a dataset into train, validation, and split. We will
     :height: 250px
 
 
-Now, ``X_train``, ``X_validation``, and ``X_test`` are available node names to query and execute. But, you can also query ``dataset_splits`` to get all of them in a dictionary!
+Now, ``X_train``, ``X_validation``, and ``X_test`` are available to other nodes, and they can be queried by ``.execute()``. But, since ``dataset_splits`` is its own node, you can query it to get all splits in a dictionary!
 
 @extract_columns
 ~~~~~~~~~~~~~~~~
@@ -239,14 +241,14 @@ Define one function, create *n* nodes
 
 The family of ``@parameterize`` function modifiers allows the creation of multiple nodes with the same **node implementation / function body** (and therefore output type), but different **node inputs**.
 
-This has many applications, including producing a performance plot for multiple models or computing aggregates using several groupby.
+This has many applications, such producing the same performance plot for multiple models or computing groupby aggregates along different dimensions.
 
 @parameterize
 ~~~~~~~~~~~~~
 
-You need to specify the generated **node name**, a dictionary for inputs, and optionally a docstring. For the inputs, can pass values as constant with ``value()`` or get it from the dataflow by passing a node name to ``source()`` These notions are tricky at first, but let's look at an example.
+You need to specify the generated **node name**, a dictionary of dependencies, and optionally a docstring. For the dependencies, you can pass constants with ``value()`` or get them from the dataflow by passing a node name to ``source()``. These notions are tricky at first, but let's look at an example:
 
-In this example, we create 3 nodes: ``revenue_by_age``, ``revenue_by_country``, ``revenue_by_occupation``. For each, we get the dataframe ``df`` from the dataflow using ``source()`` and specify a different ``groupby_col`` with ``value()``. Also, the docstring uses ``{groupby_col}`` to have the value inserted.
+We create 3 nodes: ``revenue_by_age``, ``revenue_by_country``, ``revenue_by_occupation``. For each, we get the dataframe ``df`` from the dataflow using ``source()`` and specify a different ``groupby_col`` with ``value()``. Also, the docstring uses ``{groupby_col}`` to have the value inserted.
 
 .. code-block:: python
 
@@ -266,19 +268,19 @@ In this example, we create 3 nodes: ``revenue_by_age``, ``revenue_by_country``, 
 
 .. image:: ./_function-modifiers/parameterize.png
 
-- The above example mixes constant ``value()`` and dataflow ``source()`` parameters and is indeed verbose. If you need only one type, you can use ``@parameterize_values`` or ``@parameterize_sources`` for a simplified syntax.
-- If you need to extract columns from the output of generated nodes, use ``@parameterize_extract_columns``
+- The above example mixes constant ``value()`` and dataflow ``source()`` dependencies. The syntax is indeed verbose. Simplified syntaxes are available through ``@parameterize_values`` and ``@parameterize_sources`` if you only need one type of dependency.
+- If you need to extract columns from the output of a generated node, use ``@parameterize_extract_columns``
 
 .. _config-decorators:
 
 Select functions to include
 ---------------------------
 
-The family of ``@config`` decorators doesn't modify the function. Rather, it tells the Driver which functions from the module (and therefore nodes) to include in the dataflow. This helps projects that need to run in different contexts (e.g., locally vs orchestrator) or need to test different implementations of a node (e.g., ML experiments, code migration, A/B testing).
+The family of ``@config`` decorators doesn't modify the function. Rather, it tells the Driver which functions from the module (and therefore nodes) to include in the dataflow. This helps projects that need to run in different contexts (e.g., locally vs orchestrator) or need to swap different implementations of a node (e.g., ML experiments, code migration, A/B testing).
 
 .. note::
 
-    At first, there can be confusion between ``@config`` and the ``inputs`` and ``overrides`` of the Driver's ``.execute()`` and ``.materialize()`` methods. In common language, people might refer to the ``.execute(inputs=..., overrides=...)`` as a configuration. However, they both affect the values passing through the dataflow **once the Driver is built** while ``@config`` determines **how the driver is built**.
+    At first, there can be confusion between ``@config`` and the ``inputs`` and ``overrides`` of the Driver's ``.execute()`` and ``.materialize()`` methods. In common language, people might refer to the ``.execute(inputs=..., overrides=...)`` as a configuration. However, these two affect the values passing through the dataflow **once the Driver is built** while ``@config`` determines **how the Driver is built**.
 
 @config
 ~~~~~~~

--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -4,7 +4,7 @@ Function modifiers
 
 In :doc:`node`, we discussed how to write Python functions to define Hamilton nodes and dataflow. In the basic case, each function defines one node.
 
-Yet, it's common to need nodes with similar purposes, but different dependencies such as preprocessing a training and an evaluation dataset. In that case, using a **function modifier** can help create both nodes from a single Hamilton function!
+Yet, it's common to need nodes with similar purposes but different dependencies, such as preprocessing training and evaluation datasets. In that case, using a **function modifier** can help create both nodes from a single Hamilton function!
 
 On this page, you'll learn:
 
@@ -241,7 +241,7 @@ Define one function, create *n* nodes
 
 The family of ``@parameterize`` function modifiers allows the creation of multiple nodes with the same **node implementation / function body** (and therefore output type), but different **node inputs**.
 
-This has many applications, such producing the same performance plot for multiple models or computing groupby aggregates along different dimensions.
+This has many applications, such as producing the same performance plot for multiple models or computing groupby aggregates along different dimensions.
 
 @parameterize
 ~~~~~~~~~~~~~

--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -147,7 +147,7 @@ The ``@check_output`` function modifiers are applied on the **node output / func
 
 The ``@check_output`` implements many data checks for Python objects and DataFrame/Series including data type, min/max/between, count, fraction of null/nan values, and allow null/nan. Failed checks are either logged (``importance="warn"``) or make the dataflow fail (``importance="fail"``).
 
-The next snippet checks if the returned Series is of type ``np.int32``, which is non-nullable, and if its within the range 0-100, and logs failed checks. This would allows us to manually review instances where data validation failed.
+The next snippet checks if the returned Series is of type ``np.int32``, which is non-nullable, and if its within the range 0-100, and logs failed checks. This allows us to manually review instances where data validation failed.
 
 .. code-block:: python
 

--- a/docs/concepts/materialization.rst
+++ b/docs/concepts/materialization.rst
@@ -14,14 +14,14 @@ On this page, you'll learn:
 Different ways to write the same dataflow
 -----------------------------------------
 
-Below is the code and the visualization for 3 ways to write a dataflow that:
+Below are 3 ways to write a dataflow that:
 
 1. loads a dataframe from a parquet file
 2. preprocesses the dataframe
 3. trains a machine learning model
 4. saves the trained model
 
-The first two options use ``Driver.execute()`` and the latter ``Driver.materialize()``. Notice where in the code data artifacts are loaded and saved and how it affects the dataflow graph.
+The first two options use ``Driver.execute()`` and the latter ``Driver.materialize()``. Notice where in the code data is loaded and saved and how it affects the dataflow.
 
 .. table:: Model training
    :align: left
@@ -40,7 +40,7 @@ As explained previously, ``Driver.execute()`` walks the graph to compute the lis
 
 .. note::
 
-    ``Driver.materialize()`` can do everything ``Driver.execute()`` and more. It can receive ``inputs`` and ``overrides``. Instead of using ``final_vars``, you can use ``additional_vars`` to request nodes that you don't want to materialize/save.
+    ``Driver.materialize()`` can do everything ``Driver.execute()`` does, and more. It can receive ``inputs`` and ``overrides``. Instead of using ``final_vars``, you can use ``additional_vars`` to request nodes that you don't want to materialize/save.
 
 Why use materialization
 -----------------------
@@ -56,38 +56,35 @@ Benefits
 
 - the functions ``raw_df()`` and ``save_model()`` are transparent as to how they load/save data
 - can easily change data location using the strings ``data_path`` and ``model_dir`` as inputs
-- All operations are part of the dataflow
+- all operations are part of the dataflow
 
 Limitations
 
-- need to write a unique function for each loaded parquet file and saved model. Code duplication could be reduced by using utility functions ``_load_parquet()``
-- data location is hard coded and difficult to change. Could override ``raw_df`` in the ``.execute()`` call.
+- need to write a unique function for each loaded parquet file and saved model. To reduce code duplication, one could write a utility function ``_load_parquet()``
+- can be too restrictive as to how to load data. Using ``override`` in the ``.execute()`` call can add flexibility.
 
 Driver context
 ~~~~~~~~~~~~~~
 
-This approach loads and saves data outside the dataflow and uses ``Driver.execute()``. Since the Driver is responsible for executing your dataflow, it makes sense to handle data loading/saving in this context if they change often.
+This approach loads and saves data outside the dataflow and uses ``Driver.execute()``. Since the Driver is responsible for executing your dataflow, it makes sense to handle data loading/saving in the context of the "driver code" (e.g., ``run.py``) if they change often.
 
 Benefits
 
-- Flexibility for Driver users to change data location
-- Fewer dataflow functions to define and maintain.
+- Driver users is responsible for loading/saving data
+- fewer dataflow functions to define and maintain
+- the functions for ``raw_df()`` and ``save_model()`` can live in another Python module that you can optionally build the Driver with.
 
 Limitations
 
-- Adds complexity to the Driver code (e.g., ``run.py``).
-- Lose the Hamilton benefits of having data loading and saving part of the dataflow (visualize, lifecycle hook, etc.)
-- If data loading/saving needs flexibility, adopt approach the **nodes/dataflow context** approach with ``@config`` for alternative implementations (see :ref:`config-decorators`).
+- add complexity to the "driver code".
+- lose the benefits of Hamilton for loading and saving operations (visualize, lifecycle hook, etc.)
+- to add flexibility to data loading/saving, one can adopt the **nodes/dataflow context** approach and add functions with ``@config`` for alternative implementations (see :ref:`config-decorators`).
 
-.. note::
-
-    Notice that the **Driver context** approach is equivalent to the **nodes/dataflow context** if you add to this Driver a separate Python module with the functions ``raw_df()`` and ``save_model()``
 
 Materialization
 ~~~~~~~~~~~~~~~
 
 This approach tries to strike a balance between the two previous methods and uses ``Driver.materialize()``.
-
 
 Unique benefits
 
@@ -104,15 +101,14 @@ Benefits
 Limitations
 
 - Writing a custom DataSaver or DataLoader requires more effort than adding a function to the dataflow.
-- Adds complexity to the Driver (e.g., ``run.py``).
-
+- Adds *some* complexity to the Driver (e.g., ``run.py``).
 
 DataLoader and DataSaver
 ------------------------
 
 In Hamilton, ``DataLoader`` and ``DataSaver`` are classes that define how to load or save a particular data format. Calling ``Driver.materialize(DataLoader(), DataSaver())`` adds nodes to the dataflow (see visualizations above).
 
-Here are simplified snippets for saving and loading an XGBoost model to JSON.
+Here are simplified snippets for saving and loading an XGBoost model to/from JSON.
 
    +----------------------------------------------+-----------------------------------------------+
    | DataLoader                                   | DataSaver                                     |
@@ -121,7 +117,7 @@ Here are simplified snippets for saving and loading an XGBoost model to JSON.
    |                                              |                                               |
    +----------------------------------------------+-----------------------------------------------+
 
-To define your own DataSaver and DataLoader, the Hamilton `XGBoost extension <https://github.com/DAGWorks-Inc/hamilton/blob/main/hamilton/plugins/xgboost_extensions.py>`_ is a good example
+To define your own DataSaver and DataLoader, the Hamilton `XGBoost extension <https://github.com/DAGWorks-Inc/hamilton/blob/main/hamilton/plugins/xgboost_extensions.py>`_ provides a good example
 
 ``@load_from`` and ``@save_to``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/concepts/node.rst
+++ b/docs/concepts/node.rst
@@ -110,7 +110,7 @@ Dataflow
 
 From a collection of nodes, Hamilton automatically assembles the dataflow. For each node, it creates edges between itself and its dependencies, resulting in a `dataflow <https://en.wikipedia.org/wiki/Dataflow_programming>`_ (or a `graph <https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)>`_ in more mathematical terms).
 
-From the user perspective, you give Hamilton a Python module containing your functions, and it will generate your dataflow! This is a key difference with popular orchestration / pipeline / workflow frameworks (Airflow, Kedro, Prefect, VertexAI, SageMaker, etc.)
+From the user perspective, you give Hamilton a Python module containing your functions and it will generate your dataflow! This is a key difference with popular orchestration / pipeline / workflow frameworks (Airflow, Kedro, Prefect, VertexAI, SageMaker, etc.)
 
 How other frameworks build graphs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/concepts/node.rst
+++ b/docs/concepts/node.rst
@@ -10,14 +10,14 @@ Functions
 Hamilton requires you to write your code using functions. To get started, you simply need to:
 
 - `Annotate the type <https://docs.python.org/3/library/typing.html>`_ of the function parameters and return value.
-- Specify the function's dependency with the parameters' name.
+- Specify the function dependencies with the parameter names.
 - Store your code in Python modules (``.py`` files).
 
-Since your code doesn't depend on special "Hamilton code", it can be reused any other way you want!
+Since your code doesn't depend on special "Hamilton code", you can reuse it however you want!
 
 Specifying dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
-In Hamilton, you define dependencies by matching parameter names with the names of other functions. Below, the function name and return type ``A() -> int``match the parameter ``A: int`` found in functions ``B()`` and ``C()``.
+In Hamilton, you define dependencies by matching parameter names with the names of other functions. Below, the function name and return type ``A() -> int`` match the parameter ``A: int`` found in functions ``B()`` and ``C()``.
 
 .. code-block:: python
 
@@ -70,7 +70,7 @@ Unlike the common practice of including meaningful verbs in function names (e.g.
 Nodes
 -----
 
-A node is a single "step" in a dataflow. Hamilton users write Python `functions` that Hamilton converts into `nodes`. They never directly create nodes.
+A node is a single "operation" or "step" in a dataflow. Hamilton users write Python `functions` that Hamilton converts into `nodes`. User never directly create nodes.
 
 
 Anatomy of a node
@@ -93,7 +93,7 @@ The following figure and table detail how a Python function maps to a Hamilton n
      - Function name and return type annotation
      - Node name and type
    * - 2
-     - Parameter(s) name and type annotation
+     - Parameter names and type annotations
      - Node dependencies
    * - 3
      - Docstring
@@ -103,26 +103,26 @@ The following figure and table detail how a Python function maps to a Hamilton n
      - Implementation of the node
 
 
-Since functions almost always map 1-to-1 to nodes, the two terms are used interchangeably. However, there are exceptions that we'll discuss later in this guide.
+Since functions almost always map to nodes 1-to-1, the two terms are often used interchangeably. However, there are exceptions that we'll discuss later in this guide.
 
 Dataflow
 --------
 
 From a collection of nodes, Hamilton automatically assembles the dataflow. For each node, it creates edges between itself and its dependencies, resulting in a `dataflow <https://en.wikipedia.org/wiki/Dataflow_programming>`_ (or a `graph <https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)>`_ in more mathematical terms).
 
-From the user perspective, you just have to give Hamilton a Python module containing your functions for it to generate your dataflow! This is a key difference with popular orchestration / pipeline / workflow frameworks (Airflow, Kedro, Prefect, VertexAI, SageMaker, etc.)
+From the user perspective, you give Hamilton a Python module containing your functions, and it will generate your dataflow! This is a key difference with popular orchestration / pipeline / workflow frameworks (Airflow, Kedro, Prefect, VertexAI, SageMaker, etc.)
 
 How other frameworks build graphs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In most frameworks, you first define steps / tasks / components. Then, you need to create your dataflow by explicitly specifying the relationship between each node.
+In most frameworks, you first define nodes / steps / tasks / components. Then, you need to create your dataflow by explicitly specifying the relationship between each node.
 
 Readability
 ^^^^^^^^^^^
-In that case, the code for ``step A`` doesn't tell you how it relates ``step B`` or the broader dataflow. Hamilton solves this problem by tying functions, nodes, and dataflow definitions in a single place. The ratio of reading to writing code can be as high as `10:1 <https://www.goodreads.com/quotes/835238-indeed-the-ratio-of-time-spent-reading-versus-writing-is>`_, especially for complex dataflows, so optimizing for readability is very high-value.
+In that case, the code for ``step A`` doesn't tell you how it relates ``step B`` or the broader dataflow. Hamilton solves this problem by tying functions, nodes, and dataflow definitions in a single place. The ratio of reading to writing code can be as high as `10:1 <https://www.goodreads.com/quotes/835238-indeed-the-ratio-of-time-spent-reading-versus-writing-is>`_, especially for complex dataflows, so optimizing for readability is high-value.
 
 Maintainability
 ^^^^^^^^^^^^^^^
-Typically, editing a dataflow (new feature, debugging, etc.) alters both what a **node** does and how the **dataflow** is structured. Consequently, changes to ``step A`` require you to manually ensure consistent edits to the definition of dataflows, which is likely in another file. In enterprise settings, it can become difficult to discover and track every location ``step A`` is used (potentially 10s or 100s of pipelines), increasing the likelihood of breaking changes. Hamilton avoids entirely this problem because changes to the node definitions, and thus the dataflow, will propagate to all places this code is used. This greatly improves maintainability and development speed by facilitating code changes.
+Typically, editing a dataflow (new feature, debugging, etc.) alters both what a **node** does and how the **dataflow** is structured. Consequently, changes to ``step A`` require you to manually ensure consistent edits to the definition of dataflows, which is likely in another file. In enterprise settings, it can become difficult to discover and track every location where ``step A`` is used (potentially 10s or 100s of pipelines), increasing the likelihood of breaking changes. Hamilton avoids this problem entirely because changes to the node definitions, and thus the dataflow, will propagate to all places the code is used. This greatly improves maintainability and development speed by facilitating code changes.
 
 Recap
 --------

--- a/docs/concepts/visualization.rst
+++ b/docs/concepts/visualization.rst
@@ -2,15 +2,15 @@
 Visualization
 =============
 
-After assembling the dataflow, the Driver can display it in several ways. Hamilton dataflow visualizations are great for documentation because they are directly derived from the code.
+After assembling the dataflow, several visualization features become available to the Driver. Hamilton dataflow visualizations are great for documentation because they are directly derived from the code.
 
 On this page, you'll learn:
 
 - the available visualization functions
 - how to answer lineage questions
-- how to apply a custom style
+- how to apply a custom style to your visualization
 
-For this page, we'll assume to have the following dataflow and Driver:
+For this page, we'll assume we have the following dataflow and Driver:
 
 .. code-block:: python
 
@@ -124,13 +124,11 @@ Learn more about :doc:`materialization`.
 View node dependencies
 ----------------------
 
-Representing data pipelines, ML experiments, or LLM applications as a dataflow helps reason about the dependencies between operations. The Hamilton Driver has the following utilities to select and return a list of nodes:
+Representing data pipelines, ML experiments, or LLM applications as a dataflow helps reason about the dependencies between operations. The Hamilton Driver has the following utilities to select and return a list of nodes (to learn more :doc:`../how-tos/use-hamilton-for-lineage`):
 
 - ``.what_is_upstream_of(*node_names: str)``
 - ``.what_is_downstream_of(*node_names: str)``
-- ``.what_is_the_path_between(upstream_node_name: str, down_stream_node_name: str)``
-
-See our user guide on :doc:`../how-tos/use-hamilton-for-lineage` to learn more.
+- ``.what_is_the_path_between(upstream_node_name: str, downstream_node_name: str)``
 
 These functions are wrapped into their visualization counterparts:
 
@@ -143,7 +141,7 @@ Display ancestors of ``B``:
 .. image:: _visualization/upstream.png
     :height: 200px
 
-Display descendants of ``D`` and its immediate parents, which is only ``A``.
+Display descendants of ``D`` and its immediate parents (``A`` only).
 
 .. code-block:: python
 
@@ -166,9 +164,7 @@ Filter nodes to the necessary path:
 Configure your visualization
 ----------------------------
 
-All of the above visualization functions share parameters to customize the visualization (e.g., hide legend, hide inputs). The API reference for `Driver.display_all_functions() <https://hamilton.dagworks.io/en/latest/reference/drivers/Driver/#hamilton.driver.Driver.display_all_functions>`_ should apply to all other visualizations.
-
-We won't provide visual examples here, but you try them yourself in your browser on tryhamilton.dev (#TODO add tutorial)
+All of the above visualization functions share parameters to customize the visualization (e.g., hide legend, hide inputs). Learn more by reviewing the API reference for `Driver.display_all_functions() <https://hamilton.dagworks.io/en/latest/reference/drivers/Driver/#hamilton.driver.Driver.display_all_functions>`_; parameters should apply to all other visualizations.
 
 .. _custom-visualization-style:
 
@@ -177,16 +173,16 @@ Apply custom style
 
 By default, each node is labeled with name and type, and stylized (shape, color, outline, etc.). By passing a function to the parameter ``custom_style_function``, you can customize the node style based on its attributes. This pairs nicely with the ``@tag`` function modifier (learn more :ref:`tag-decorators`)
 
-To define your own style:
+Your own custom style function must:
 
-1. The function must use only keyword arguments, taking in ``node`` and ``node_class``.
-2. It needs to return a tuple ``(style, node_class, legend_name)`` where:
+1. Use only keyword arguments, taking in ``node`` and ``node_class``.
+2. Return a tuple ``(style, node_class, legend_name)`` where:
     - ``style``: dictionary of valid graphviz node style attributes.
     - ``node_class``: class used to style the default visualization - we recommend returning the input ``node_class``
     - ``legend_name``: text to display in the legend. Return ``None`` for no legend entry.
 3. For the execution-focused visualizations, your custom styles are applied before the modifiers for outputs and overrides are applied.
 
-If you need more customization, we suggest getting the graphviz object back and then modifying it yourself.
+If you need more customization, we suggest getting the graphviz object produced, and modifying it directly.
 
 This `online graphviz editor <https://edotor.net/>`_ can help you get started!
 


### PR DESCRIPTION
Spellcheck / correction of recently added docs/concepts pages

## Changes
- fixed typos
- reworded unclear sentences
- added missing words

## How I tested this
- successfully rebuilt docs locally
