### PR TITLE
fix: ibis extension registration

### DIFF
--- a/hamilton/plugins/ibis_extensions.py
+++ b/hamilton/plugins/ibis_extensions.py
@@ -26,7 +26,7 @@ def register_types():
 
 @registry.fill_with_scalar.register(ir.Table)
 def fill_with_scalar_ibis(df: ir.Table, column_name: str, scalar_value: Any) -> ir.Table:
-    raise NotImplementedError
+    raise NotImplementedError("As of Hamilton version 1.5.1, default values for Ibis columns aren't supported. This feature is actively being developed")
 
 
 register_types()

--- a/hamilton/plugins/ibis_extensions.py
+++ b/hamilton/plugins/ibis_extensions.py
@@ -26,7 +26,7 @@ def register_types():
 
 @registry.fill_with_scalar.register(ir.Table)
 def fill_with_scalar_ibis(df: ir.Table, column_name: str, scalar_value: Any) -> ir.Table:
-    raise NotImplementedError("As of Hamilton version 1.5.1, default values for Ibis columns aren't supported. This feature is actively being developed")
+    raise NotImplementedError("As of Hamilton version 1.5.1, filling Ibis columns with scalars isn't supported. This feature is actively being developed")
 
 
 register_types()

--- a/hamilton/plugins/ibis_extensions.py
+++ b/hamilton/plugins/ibis_extensions.py
@@ -26,7 +26,9 @@ def register_types():
 
 @registry.fill_with_scalar.register(ir.Table)
 def fill_with_scalar_ibis(df: ir.Table, column_name: str, scalar_value: Any) -> ir.Table:
-    raise NotImplementedError("As of Hamilton version 1.5.1, filling Ibis columns with scalars isn't supported. This feature is actively being developed")
+    raise NotImplementedError(
+        "As of Hamilton version 1.5.1, filling Ibis columns with scalars isn't supported. This feature is actively being developed"
+    )
 
 
 register_types()

--- a/hamilton/plugins/ibis_extensions.py
+++ b/hamilton/plugins/ibis_extensions.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Any, Type
 
 from hamilton import registry
 
@@ -22,6 +22,11 @@ def get_column_ibis(df: ir.Table, column_name: str) -> ir.Column:
 def register_types():
     """Function to register the types for this extension."""
     registry.register_types("ibis", DATAFRAME_TYPE, COLUMN_TYPE)
+
+
+@registry.fill_with_scalar.register(ir.Table)
+def fill_with_scalar_ibis(df: ir.Table, column_name: str, scalar_value: Any) -> ir.Table:
+    raise NotImplementedError
 
 
 register_types()


### PR DESCRIPTION
Dataframe extensions need to register functions:
- get_column_EXTENSION
- register_types
- fill_with_scalar_EXTENSION

## Changes
- a placeholder for fill_with_scalar_EXTENSION was added


<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 211d47aa7ac6ff5daf1ec018eb5510a23d509902.  | 
|--------|--------|

### Summary:
This PR adds and modifies the `fill_with_scalar_ibis` function in `ibis_extensions.py`, registering it with the `fill_with_scalar` registry and indicating that filling Ibis columns with scalars is not yet supported.

**Key points**:
- Added and modified the `fill_with_scalar_ibis` function in `ibis_extensions.py`.
- Registered `fill_with_scalar_ibis` with the `fill_with_scalar` registry.
- The function raises a `NotImplementedError`, indicating that filling Ibis columns with scalars is not supported.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
