### PR TITLE
Updates docstring of data adapters to be public facing

### DIFF
--- a/hamilton/io/data_adapters.py
+++ b/hamilton/io/data_adapters.py
@@ -115,12 +115,6 @@ class DataLoader(AdapterCommon, abc.ABC):
     """Base class for data loaders. Data loaders are used to load data from a data source.
     Note that they are inherently polymorphic -- they declare what type(s) they can load to,
     and may choose to load differently depending on the type they are loading to.
-
-    Note that this is not yet a public-facing API -- the current set of data loaders will
-    be managed by the library, and the user will not be able to create their own.
-
-    We intend to change this and provide an extensible user-facing API,
-    but if you subclass this, beware! It might change.
     """
 
     @abc.abstractmethod
@@ -162,12 +156,6 @@ class DataSaver(AdapterCommon, abc.ABC):
     """Base class for data savers. Data savers are used to save data to a data source.
     Note that they are inherently polymorphic -- they declare what type(s) they can save from,
     and may choose to save differently depending on the type they are saving from.
-
-    Note that this is not yet a public-facing API -- the current set of data savers will
-    be managed by the library, and the user will not be able to create their own.
-
-    We intend to change this and provide an extensible user-facing API,
-    but if you subclass this, beware! It might change.
     """
 
     @abc.abstractmethod

--- a/hamilton/version.py
+++ b/hamilton/version.py
@@ -1,1 +1,1 @@
-VERSION = (1, 52, 0)
+VERSION = (1, 53, 0, "rc0")


### PR DESCRIPTION
Quick docstring update

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit cbdca27d46997dd20f4b02b2627712fbf4a5e0e2.  | 
|--------|--------|

### Summary:
This PR updates the docstrings of `DataLoader` and `DataSaver` classes in `hamilton/io/data_adapters.py` to reflect their public-facing status and increments the Hamilton library version to 1.53.0rc0.

**Key points**:
- Updated docstrings of `DataLoader` and `DataSaver` classes in `hamilton/io/data_adapters.py`.
- Removed notes about these classes not being public-facing APIs.
- Updated Hamilton library version to 1.53.0rc0 in `hamilton/version.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
