### PR TITLE
Adds dask-expr to test dependency

### DIFF
--- a/plugin_tests/h_dask/conftest.py
+++ b/plugin_tests/h_dask/conftest.py
@@ -1,4 +1,9 @@
+import dask
+
 from hamilton import telemetry
 
 # disable telemetry for all tests!
 telemetry.disable_telemetry()
+
+# required until we fix the DataFrameResultBuilder to work with dask-expr
+dask.config.set({"dataframe.query-planning": False})

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,7 @@
 -r requirements-dev.txt
 alabaster>=0.7,<0.8,!=0.7.5  # read the docs pins
 commonmark==0.9.1 # read the docs pins
+dask-expr
 dask[distributed]
 ddtrace
 diskcache

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 dask
+dask-expr; python_version >= '3.9'
 diskcache
 fsspec
 graphviz


### PR DESCRIPTION
So that tests don't fail -- dask now needs it as
a dependency.

Also turning using dask-expr off for tests.

## Changes
 - requirements-test.txt
 - requirements-docs.txt
 - h_dask integration test conftest.py

## How I tested this
 - locally
 
## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
