### PR TITLE
`fix` make visualization nodes `filled` by default

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -299,19 +299,20 @@ def create_graphviz_graph(
         if node_type == "config":
             node_style = dict(
                 shape="note",
-                style="",
+                style="filled",
                 fontname=fontname,
             )
         elif node_type == "input":
             node_style = dict(
                 shape="rectangle",
                 margin="0.15",
-                style="dashed",
+                style="filled,dashed",
                 fontname=fontname,
             )
         elif node_type == "materializer":
             node_style = dict(
                 shape="cylinder",
+                style="filled",
                 margin="0.15,0.1",
                 fontname=fontname,
             )
@@ -383,6 +384,7 @@ def create_graphviz_graph(
                 label="Legend",
                 rank="same",  # makes the legend perpendicular to the main DAG
                 fontname="helvetica",
+                fillcolor="#ffffff",
             ),
         )
 
@@ -420,6 +422,14 @@ def create_graphviz_graph(
             ranksep="0.4",
             compound="true",
             concentrate="true",
+            style="filled",
+            # bgcolor="transparent",
+        ),
+        node_attr=dict(
+            fillcolor="#ffffff",
+        ),
+        edge_attr=dict(
+            # color="#ffffff",
         ),
     )
     # we need to update the graph_attr dict instead of overwriting it

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -701,8 +701,8 @@ def test_function_graph_display(tmp_path: pathlib.Path):
     expected_set = set(
         [
             '\t\tfunction [fillcolor="#b4d8e4" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]\n',
-            "\t\tgraph [fontname=helvetica label=Legend rank=same]\n",
-            "\t\tinput [fontname=Helvetica margin=0.15 shape=rectangle style=dashed]\n",
+            '\t\tgraph [fillcolor="#ffffff" fontname=helvetica label=Legend rank=same]\n',
+            '\t\tinput [fontname=Helvetica margin=0.15 shape=rectangle style="filled,dashed"]\n',
             '\t\toutput [fillcolor="#FFC857" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]\n',
             "\tA -> B\n",
             "\tA -> C\n",
@@ -711,7 +711,8 @@ def test_function_graph_display(tmp_path: pathlib.Path):
             '\tC [label=<<b>C</b><br /><br /><i>int</i>> fillcolor="#b4d8e4" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]\n',
             "\t_A_inputs -> A\n",
             # commenting out input node: '\t_A_inputs [label=<<table border="0"><tr><td>c</td><td>int</td></tr><tr><td>b</td><td>int</td></tr></table>> fontname=Helvetica margin=0.15 shape=rectangle style=dashed]\n',
-            "\tgraph [compound=true concentrate=true rankdir=LR ranksep=0.4]\n",
+            "\tgraph [compound=true concentrate=true rankdir=LR ranksep=0.4 style=filled]\n",
+            '\tnode [fillcolor="#ffffff"]\n',
             "\tsubgraph cluster__legend {\n",
             "\t}\n",
             "// Dependency Graph\n",
@@ -726,7 +727,6 @@ def test_function_graph_display(tmp_path: pathlib.Path):
         render_kwargs={"view": False},
         node_modifiers=node_modifiers,
     )
-
     dot = dot_file_path.open("r").readlines()
     dot_set = set(dot)
 
@@ -964,17 +964,18 @@ def test_create_graphviz_graph():
             "// Dependency Graph",
             "",
             "digraph {",
-            "\tgraph [compound=true concentrate=true rankdir=LR ranksep=0.4 ratio=1]",
+            '\tnode [fillcolor="#ffffff"]',
+            "\tgraph [compound=true concentrate=true rankdir=LR ranksep=0.4 ratio=1 style=filled]",
             '\tB [label=<<b>B</b><br /><br /><i>int</i>> fillcolor="#FFC857" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]',
             '\tC [label=<<b>C</b><br /><br /><i>int</i>> fillcolor="#b4d8e4" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]',
             '\tA [label=<<b>A</b><br /><br /><i>int</i>> fillcolor="#b4d8e4" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]',
             "\tA -> B",
             "\tA -> C",
-            '\t_A_inputs [label=<<table border="0"><tr><td>b</td><td>int</td></tr><tr><td>b</td><td>int</td></tr></table>> fontname=Helvetica margin=0.15 shape=rectangle style=dashed]',
+            '\t_A_inputs [label=<<table border="0"><tr><td>b</td><td>int</td></tr><tr><td>b</td><td>int</td></tr></table>> fontname=Helvetica margin=0.15 shape=rectangle style="filled,dashed"]',
             "\t_A_inputs -> A",
             "\tsubgraph cluster__legend {",
-            "\t\tgraph [fontname=helvetica label=Legend rank=same]",
-            "\t\tinput [fontname=Helvetica margin=0.15 shape=rectangle style=dashed]",
+            '\t\tgraph [fillcolor="#ffffff" fontname=helvetica label=Legend rank=same]',
+            '\t\tinput [fontname=Helvetica margin=0.15 shape=rectangle style="filled,dashed"]',
             '\t\tfunction [fillcolor="#b4d8e4" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]',
             '\t\toutput [fillcolor="#FFC857" fontname=Helvetica margin=0.15 shape=rectangle style="rounded,filled"]',
             "\t}",


### PR DESCRIPTION
Previously, certain nodes types didn't have a `style="filled"`. 

Setting the visualization background color to transparent with `graphviz_kwargs=dict(graph_attr=dict(bgcolor="transparent"))` would also make nodes transparent. It is very hard to fix by user in an ad hoc way because of graphviz's quirks.

before
![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/5ac567c6-a34d-4072-bb98-b3911417d66b)


after
![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/b62af916-6b5d-4b87-9c5c-09ab0727e207)

## Changes
- change default attributes
- update tests accordingly

## How I tested this
- successfully ran the test suite locally

## Notes
- I am making this change to help with the VSCode Hamilton extension.
- edges can be set to white or black for visibility depending on the background

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
