### PR TITLE
`fix` reduce type constraints on JSON materializer

### DIFF
--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -4,7 +4,7 @@ import json
 import os
 import pathlib
 import pickle
-from typing import Any, Collection, Dict, List, Tuple, Type, Union
+from typing import Any, Collection, Dict, Tuple, Type, Union
 
 from hamilton.io.data_adapters import DataLoader, DataSaver
 from hamilton.io.utils import get_file_metadata
@@ -16,7 +16,7 @@ class JSONDataLoader(DataLoader):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [dict, List[dict]]
+        return [dict, list]
 
     def load_data(self, type_: Type) -> Tuple[dict, Dict[str, Any]]:
         with open(self.path, "r") as f:
@@ -33,7 +33,7 @@ class JSONDataSaver(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [dict, List[dict]]
+        return [dict, list]
 
     @classmethod
     def name(cls) -> str:

--- a/tests/io/test_default_adapters.py
+++ b/tests/io/test_default_adapters.py
@@ -1,7 +1,6 @@
 import io
 import json
 import pathlib
-from typing import List
 
 import pytest
 
@@ -32,7 +31,7 @@ def test_raw_file_adapter(data, tmp_path: pathlib.Path) -> None:
 @pytest.mark.parametrize("data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]])
 def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
-    the top-level is an object `{ }` -> dict or an array `[ ]` -> list[dict]
+    the top-level is an object `{ }` -> dict or an array `[ ]` -> list
     """
     data_path = tmp_path / "data.json"
     saver = JSONDataSaver(path=data_path)
@@ -40,7 +39,7 @@ def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
     metadata = saver.save_data(data)
     loaded_data = json.loads(data_path.read_text())
 
-    assert JSONDataSaver.applicable_types() == [dict, List[dict]]
+    assert JSONDataSaver.applicable_types() == [dict, list]
     assert data_path.exists()
     assert metadata[FILE_METADATA]["path"] == str(data_path)
     assert data == loaded_data
@@ -49,7 +48,7 @@ def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
 @pytest.mark.parametrize("data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]])
 def test_json_load_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
-    the top-level is an object `{ }` -> dict or an array `[ ]` -> list[dict]
+    the top-level is an object `{ }` -> dict or an array `[ ]` -> list
     """
     data_path = tmp_path / "data.json"
     loader = JSONDataLoader(path=data_path)
@@ -57,5 +56,5 @@ def test_json_load_object_and_array(data, tmp_path: pathlib.Path):
     json.dump(data, data_path.open("w"))
     loaded_data, metadata = loader.load_data(type(data))
 
-    assert JSONDataLoader.applicable_types() == [dict, List[dict]]
+    assert JSONDataLoader.applicable_types() == [dict, list]
     assert data == loaded_data

--- a/tests/io/test_default_adapters.py
+++ b/tests/io/test_default_adapters.py
@@ -28,7 +28,9 @@ def test_raw_file_adapter(data, tmp_path: pathlib.Path) -> None:
     assert data_processed == data2
 
 
-@pytest.mark.parametrize("data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]])
+@pytest.mark.parametrize(
+    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}], ["value1", "value2"], [0, 1]]
+)
 def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
     the top-level is an object `{ }` -> dict or an array `[ ]` -> list
@@ -45,7 +47,9 @@ def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
     assert data == loaded_data
 
 
-@pytest.mark.parametrize("data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}]])
+@pytest.mark.parametrize(
+    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}], ["value1", "value2"], [0, 1]]
+)
 def test_json_load_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
     the top-level is an object `{ }` -> dict or an array `[ ]` -> list


### PR DESCRIPTION
This issue is a follow-up on #690 

Before, the JSON Loader&Saver would only support `dict` type objects. However, the [JSON format specs](https://www.json.org/json-en.html) are more flexible. We then introduced support for `List[dict]`.

However, it seems reasonable to support more generally `list` (of `str`, `int`, `None`, etc.). By making it more flexible, we delegate to the underlying `json` Python library to surface "not json-serializable" errors to the user.

## Changes
- changed supported types from `List[dict]` to `list`
- adjusted tests accordingly

## How I tested this
- test succeed locally

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
