### PR TITLE
`fix` can't sort `None` in `HamiltonGraph.version`

### DIFF
--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -203,5 +203,6 @@ class HamiltonGraph:
         Node hashes are in a sorted list, then concatenated as a string before hashing.
         To find differences between dataflows, you need to inspect the node level.
         """
-        sorted_node_versions = sorted([n.version for n in self.nodes])
+        sorted_nodes = sorted(self.nodes, key=lambda n: n.name)
+        sorted_node_versions = [n.version if n.version else "" for n in sorted_nodes]
         return hashlib.sha256(str(sorted_node_versions).encode()).hexdigest()


### PR DESCRIPTION
`HamiltonNode` can take value `None` when they have no `.originating_functions[0]`. This lead to an issue when `HamiltonGraph.version` derives its value from its constituent nodes.

## Changes
- sort nodes based on their `name` attribute; this change will break lineage with hashes from previous Hamilton versions
- replace `None` for `""` explicitly

## How I tested this
- the existing tests succeed locally
- ran the `examples/experiment_manager/run.py` successfully 
- manually checked that the experiment UI behaved properly

## Notes
- we should add tests for `.version` on more complex DAG that use function modifiers, materializers, config, etc.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
