### PR TITLE
`feature` render Driver in notebooks

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -399,6 +399,16 @@ class Driver:
             # TODO -- update this to use the lifecycle methods
             self.capture_constructor_telemetry(error, modules, config, adapter)
 
+    def _repr_mimebundle_(self, include=None, exclude=None, **kwargs):
+        """Attribute read by notebook renderers
+        This returns the attribute of the `graphviz.Digraph` returned by `self.display_all_functions()`
+
+        The parameters `include`, `exclude`, and `**kwargs` are required, but not explicitly used
+        ref: https://ipython.readthedocs.io/en/stable/config/integrating.html
+        """
+        dot = self.display_all_functions()
+        return dot._repr_mimebundle_(include=include, exclude=exclude, **kwargs)
+
     def capture_constructor_telemetry(
         self,
         error: Optional[str],


### PR DESCRIPTION
Simple quality of life improvement to directly call `driver.display_all_functions()`. The change was inspired by the logic found in Jupyter Magic.

This simply propagates the "render attribute" of the `graphviz.Digraph` object returned by `driver.display_all_functions()` so it should be robust.

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/1aeb6a7c-1516-4078-8d7e-c49842454048)

## Changes
- added `._repr_mimebundle_()` to `Driver` class

## How I tested this
- tests succeeded locally
- intended behavior works in Jupyter notebooks (browser interface) and VSCode notebooks

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
