### PR TITLE
Adds guards around version logic

### DIFF
--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -233,6 +233,7 @@ class LoadFromDecorator(NodeInjector):
             namespace=(
                 (namespace, "load_data") if namespace else ("load_data",)
             ),  # We want no namespace in this case
+            originating_functions=(load_data,),
         )
 
         # the filter node is the node that takes the data from the data source, filters out
@@ -259,6 +260,7 @@ class LoadFromDecorator(NodeInjector):
             # to have this weird DAG shape. For now, this solves the problem, and this is an internal component of the API
             # so we're good to go
             namespace=((namespace, "select_data") if namespace else ()),  # We want no namespace
+            originating_functions=(filter_function,),
         )
         return [loader_node, filter_node]
 
@@ -576,6 +578,7 @@ class SaveToDecorator(SingleNodeNodeTransformer):
                 "hamilton.data_saver.sink": f"{saver_cls.name()}",
                 "hamilton.data_saver.classname": f"{saver_cls.__qualname__}",
             },
+            originating_functions=(save_data,),
         )
         return save_node
 

--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -233,7 +233,6 @@ class LoadFromDecorator(NodeInjector):
             namespace=(
                 (namespace, "load_data") if namespace else ("load_data",)
             ),  # We want no namespace in this case
-            originating_functions=(load_data,),
         )
 
         # the filter node is the node that takes the data from the data source, filters out
@@ -260,7 +259,6 @@ class LoadFromDecorator(NodeInjector):
             # to have this weird DAG shape. For now, this solves the problem, and this is an internal component of the API
             # so we're good to go
             namespace=((namespace, "select_data") if namespace else ()),  # We want no namespace
-            originating_functions=(filter_function,),
         )
         return [loader_node, filter_node]
 
@@ -566,7 +564,6 @@ class SaveToDecorator(SingleNodeNodeTransformer):
             key: value for key, value in input_types.items() if key not in resolved_kwargs
         }
         input_types[node_to_save] = (node_.type, DependencyType.REQUIRED)
-
         save_node = node.Node(
             name=artifact_name,
             callabl=save_data,
@@ -578,7 +575,6 @@ class SaveToDecorator(SingleNodeNodeTransformer):
                 "hamilton.data_saver.sink": f"{saver_cls.name()}",
                 "hamilton.data_saver.classname": f"{saver_cls.__qualname__}",
             },
-            originating_functions=(save_data,),
         )
         return save_node
 

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -154,9 +154,13 @@ class HamiltonNode:
         The option `strip=True` means docstring and comments are ignored
         when hashing the function.
         """
-        if not self.originating_functions:
-            return None
+        if self.originating_functions is None or len(self.originating_functions) == 0:
+            if self.is_external_input:
+                # return the name of the config node. (we could add type but skipping for now)
+                return self.name
+            return None  # this shouldn't happen often.
         try:
+            # return hash of first function. It could be that others are Hamilton framework code.
             return hash_source_code(self.originating_functions[0], strip=True)
         except (
             OSError
@@ -203,5 +207,5 @@ class HamiltonGraph:
         Node hashes are in a sorted list, then concatenated as a string before hashing.
         To find differences between dataflows, you need to inspect the node level.
         """
-        sorted_node_versions = sorted([n.version for n in self.nodes])
+        sorted_node_versions = sorted([n.version for n in self.nodes if n.version is not None])
         return hashlib.sha256(str(sorted_node_versions).encode()).hexdigest()

--- a/hamilton/io/materialization.py
+++ b/hamilton/io/materialization.py
@@ -247,9 +247,7 @@ class MaterializerFactory:
                 callabl=join_function,
                 input_types={dep.name: dep.type for dep in node_dependencies},
                 originating_functions=(
-                    (join_function,)
-                    if self.result_builder is None
-                    else (self.result_builder.build_result,)
+                    None if self.result_builder is None else [self.result_builder.build_result]
                 ),
             )
             out.append(join_node)

--- a/hamilton/io/materialization.py
+++ b/hamilton/io/materialization.py
@@ -247,7 +247,9 @@ class MaterializerFactory:
                 callabl=join_function,
                 input_types={dep.name: dep.type for dep in node_dependencies},
                 originating_functions=(
-                    None if self.result_builder is None else [self.result_builder.build_result]
+                    (join_function,)
+                    if self.result_builder is None
+                    else (self.result_builder.build_result,)
                 ),
             )
             out.append(join_node)

--- a/tests/lifecycle/test_cache_adapter.py
+++ b/tests/lifecycle/test_cache_adapter.py
@@ -18,7 +18,7 @@ def _callable_to_node(callable) -> node.Node:
 
 @pytest.fixture()
 def hook(tmp_path: pathlib.Path):
-    return CacheAdapter(cache_path=str(tmp_path.resolve()))
+    return CacheAdapter(cache_path=str((tmp_path / "cache.db").resolve()))
 
 
 @pytest.fixture()

--- a/tests/test_graph_types.py
+++ b/tests/test_graph_types.py
@@ -114,7 +114,7 @@ def test_create_hamilton_node():
     }
 
 
-def test_create_hamilton_config_node_verssion():
+def test_create_hamilton_config_node_version():
     """Config nodes now return the name as the version."""
     n = Node("foo", int, node_source=NodeType.EXTERNAL)
     hamilton_node = graph_types.HamiltonNode.from_node(n)
@@ -139,7 +139,12 @@ def test_create_hamilton_node_missing_version():
 def test_hamilton_graph_version_normal():
     dr = driver.Builder().with_modules(no_parallel).build()
     graph = graph_types.HamiltonGraph.from_graph(dr.graph)
-    assert graph.version == "3b3487599ccc4fc56995989c6d32b58a90c0b91b8c16b3f453a2793f47436831"
+    # assumption is for python 3
+    if sys.version_info.minor == 8:
+        hash_value = "0a375f3366590453dea8927d4c02c15dc090f8be42e9129d9a1139284eac920c"
+    else:
+        hash_value = "3b3487599ccc4fc56995989c6d32b58a90c0b91b8c16b3f453a2793f47436831"
+    assert graph.version == hash_value
 
 
 def test_hamilton_graph_version_with_none_originating_functions():
@@ -147,7 +152,12 @@ def test_hamilton_graph_version_with_none_originating_functions():
     graph = graph_types.HamiltonGraph.from_graph(dr.graph)
     # if this gets flakey we should find a specific node to make None
     graph.nodes[-1].originating_functions = None
-    assert graph.version == "781d89517c1744c40a7afcdc49ee8592fbb23955e28d87f1b584d08430a3e837"
+    # assumption is for python 3
+    if sys.version_info.minor == 8:
+        hash_value = "7d556424cd84b97a395d9b6219f502e8f818f17002ce88f47974266c0cce454a"
+    else:
+        hash_value = "781d89517c1744c40a7afcdc49ee8592fbb23955e28d87f1b584d08430a3e837"
+    assert graph.version == hash_value
 
 
 def test_json_serializable_dict():

--- a/tests/test_graph_types.py
+++ b/tests/test_graph_types.py
@@ -5,10 +5,11 @@ import textwrap
 
 import pytest
 
-from hamilton import graph_types, node
+from hamilton import driver, graph_types, node
 from hamilton.node import Node, NodeType
 
 from tests import nodes as test_nodes
+from tests.resources.dynamic_parallelism import no_parallel
 
 
 @pytest.fixture()
@@ -113,12 +114,40 @@ def test_create_hamilton_node():
     }
 
 
-def test_create_hamilton_node_missing_version():
+def test_create_hamilton_config_node_verssion():
+    """Config nodes now return the name as the version."""
     n = Node("foo", int, node_source=NodeType.EXTERNAL)
+    hamilton_node = graph_types.HamiltonNode.from_node(n)
+    # the above will have no specified versions
+    assert hamilton_node.version == "foo"
+    assert hamilton_node.as_dict()["version"] == "foo"
+
+
+def test_create_hamilton_node_missing_version():
+    """We contrive a case where originating_functions is None."""
+
+    def foo(i: int) -> int:
+        return i
+
+    n = Node("foo", int, "", foo, node_source=NodeType.STANDARD)
     hamilton_node = graph_types.HamiltonNode.from_node(n)
     # the above will have no specified versions
     assert hamilton_node.version is None
     assert hamilton_node.as_dict()["version"] is None
+
+
+def test_hamilton_graph_version_normal():
+    dr = driver.Builder().with_modules(no_parallel).build()
+    graph = graph_types.HamiltonGraph.from_graph(dr.graph)
+    assert graph.version == "3b3487599ccc4fc56995989c6d32b58a90c0b91b8c16b3f453a2793f47436831"
+
+
+def test_hamilton_graph_version_with_none_originating_functions():
+    dr = driver.Builder().with_modules(no_parallel).build()
+    graph = graph_types.HamiltonGraph.from_graph(dr.graph)
+    # if this gets flakey we should find a specific node to make None
+    graph.nodes[-1].originating_functions = None
+    assert graph.version == "781d89517c1744c40a7afcdc49ee8592fbb23955e28d87f1b584d08430a3e837"
 
 
 def test_json_serializable_dict():


### PR DESCRIPTION
HamiltonNode.version was returning None in certain cases. This broke graph.version. Culprits: config, and materializers.

This change:

1. makes the node version for config == name of the node.
2. ~makes materializers all have originating function values.~ Most do get values. So no need to modify them.
3. guards graph.version against computing functions with None as the version value.

So node.version should now hardly ever be None. But if it is for some strange reason, we should now handle it better.

Adds tests for it.
Also fixed a fixture that was failing for me for the shelve caching adapter.

## Changes
 - graph_types
 - tests

## How I tested this
- locally
- tested experiment example run.py works without issue

## Notes
- 

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
