### PR TITLE
Ray Remote Options

### DIFF
--- a/hamilton/function_modifiers/metadata.py
+++ b/hamilton/function_modifiers/metadata.py
@@ -309,7 +309,7 @@ def ray_remote_options(**kwargs: Union[int, Dict[str, int]]) -> RayRemote:
 
     .. code-block:: python
 
-        @ray_remote(
+        @ray_remote_options(
             num_gpus=1,
             resources={"my_custom_resource": 1},
         )

--- a/hamilton/function_modifiers/metadata.py
+++ b/hamilton/function_modifiers/metadata.py
@@ -1,4 +1,5 @@
 """Decorators that attach metadata to nodes"""
+
 import json
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -6,6 +7,7 @@ from hamilton import htypes, node, registry
 from hamilton.function_modifiers import base
 
 RAY_REMOTE_TAG_NAMESPACE = "ray_remote"
+
 
 class tag(base.NodeDecorator):
     """Decorator class that adds a tag to a node. Tags take the form of key/value pairings.
@@ -58,7 +60,13 @@ class tag(base.NodeDecorator):
         RAY_REMOTE_TAG_NAMESPACE,
     ]  # Anything that starts with any of these is banned, the framework reserves the right to manage it
 
-    def __init__(self, *, target_: base.TargetType = None, bypass_reserved_namespaces_: bool = False, **tags: Union[str, List[str]]):
+    def __init__(
+        self,
+        *,
+        target_: base.TargetType = None,
+        bypass_reserved_namespaces_: bool = False,
+        **tags: Union[str, List[str]],
+    ):
         """Constructor for adding tag annotations to a function.
 
         :param bypass_reserved_namespaces\\_: Whether to bypass Reserved Namespace checking.
@@ -101,8 +109,7 @@ class tag(base.NodeDecorator):
         if len(key_components) == 0:
             # empty string...
             return False
-        if not self.bypass_reserved_namespaces and \
-           key_components[0] in tag.RESERVED_TAG_NAMESPACES:
+        if not self.bypass_reserved_namespaces and key_components[0] in tag.RESERVED_TAG_NAMESPACES:
             # Reserved prefixes
             return False
         for key in key_components:
@@ -284,10 +291,7 @@ class RayRemote(tag):
 
         ray_tags = {f"ray_remote.{option}": json.dumps(value) for option, value in options.items()}
 
-        super(RayRemote, self).__init__(
-            bypass_reserved_namespaces_ = True,
-            **ray_tags
-        )
+        super(RayRemote, self).__init__(bypass_reserved_namespaces_=True, **ray_tags)
 
 
 def ray_remote_options(**kwargs: Union[int, Dict[str, int]]) -> RayRemote:

--- a/hamilton/function_modifiers/metadata.py
+++ b/hamilton/function_modifiers/metadata.py
@@ -282,7 +282,7 @@ class schema:
 class RayRemote(tag):
 
     def __init__(self, **options: Union[int, Dict[str, int]]):
-        """Initializes RayRemote. See docs for `@ray_remote` for more details."""
+        """Initializes RayRemote. See docs for `@ray_remote_options` for more details."""
 
         ray_tags = {f"ray_remote.{option}": json.dumps(value) for option, value in options.items()}
 
@@ -294,16 +294,16 @@ class RayRemote(tag):
         return self._key_allowed(key, reserved_forbidden = False)
 
 
-def ray_remote(**kwargs: Union[int, Dict[str, int]]) -> RayRemote:
-    """Initializes a `@ray_remote` decorator. This takes in a list of options to pass to ray.remote().
+def ray_remote_options(**kwargs: Union[int, Dict[str, int]]) -> RayRemote:
+    """Initializes a `@ray_remote_options` decorator. This takes in a list of options to pass to ray.remote().
 
     Supported options include resources, as well as other options:
     https://docs.ray.io/en/latest/ray-core/scheduling/resources.html
 
     This is implemented using tags, but that might change. Thus you should not
-    rely on the tags created by this decorator (which is why they are prefixed with `internal`).
+    rely on the tags created by this decorator (which is why they are on a reserved namespace).
 
-    To use this, you should decorate a node with `@ray_remote`
+    To use this, you should decorate a node with `@ray_remote_options`
 
     Example usage:
 

--- a/hamilton/function_modifiers/metadata.py
+++ b/hamilton/function_modifiers/metadata.py
@@ -61,6 +61,7 @@ class tag(base.NodeDecorator):
     def __init__(self, *, target_: base.TargetType = None, bypass_reserved_namespaces_: bool = False, **tags: Union[str, List[str]]):
         """Constructor for adding tag annotations to a function.
 
+        :param bypass_reserved_namespaces\\_: Whether to bypass Reserved Namespace checking.
         :param target\\_: Target nodes to decorate. This can be one of the following:
 
             * **None**: tag all nodes outputted by this that are "final" (E.g. do not have a node\

--- a/hamilton/plugins/h_ray.py
+++ b/hamilton/plugins/h_ray.py
@@ -39,7 +39,7 @@ def parse_ray_remote_options_from_tags(tags: typing.Dict[str, str]) -> typing.Di
     :param tags: Full set of Tags for a Node
     :return: The ray-friendly version
     """
- 
+
     ray_tags = {
         tag_name: tag_value
         for tag_name, tag_value in tags.items()

--- a/hamilton/plugins/h_ray.py
+++ b/hamilton/plugins/h_ray.py
@@ -99,7 +99,7 @@ class RayGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         :param kwargs: the arguments that should be passed to it.
         :return: returns a ray object reference.
         """
-        # Tags are normally added to nodes via the @ray_remote decorator
+        # Tags are added to nodes via the @ray_remote_options decorator
         ray_tags = {
             tag_name: tag_value
             for tag_name, tag_value in node.tags.items()
@@ -199,7 +199,7 @@ class RayWorkflowGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         :param kwargs: the arguments that should be passed to it.
         :return: returns a ray object reference.
         """
-        # Tags are normally added to nodes via the @ray_remote decorator
+        # Tags are added to nodes via the @ray_remote_options decorator
         ray_tags = {
             tag_name: tag_value
             for tag_name, tag_value in node.tags.items()

--- a/plugin_tests/h_ray/test_parse_ray_remote_options_from_tags.py
+++ b/plugin_tests/h_ray/test_parse_ray_remote_options_from_tags.py
@@ -1,0 +1,15 @@
+from hamilton.plugins import h_ray
+
+
+def test_parse_ray_remote_options_from_tags():
+
+    tags = {
+        h_ray.RAY_REMOTE_TAG_NAMESPACE: '{"resources": {"GPU": 1}}',
+        "another_tag": "another_value",
+    }
+
+    ray_options = h_ray.parse_ray_remote_options_from_tags(tags)
+
+    assert len(ray_options) == 1
+    assert "resources" in ray_options
+    assert ray_options["resources"] == {"GPU": 1}

--- a/plugin_tests/h_ray/test_parse_ray_remote_options_from_tags.py
+++ b/plugin_tests/h_ray/test_parse_ray_remote_options_from_tags.py
@@ -4,7 +4,7 @@ from hamilton.plugins import h_ray
 def test_parse_ray_remote_options_from_tags():
 
     tags = {
-        h_ray.RAY_REMOTE_TAG_NAMESPACE: '{"resources": {"GPU": 1}}',
+        f"{h_ray.RAY_REMOTE_TAG_NAMESPACE}.resources": '{"GPU": 1}',
         "another_tag": "another_value",
     }
 

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -3,7 +3,7 @@ import pytest
 
 from hamilton import function_modifiers, node
 from hamilton.function_modifiers import base as fm_base
-from hamilton.function_modifiers.metadata import RAY_REMOTE_TAG_NAMESPACE
+from hamilton.function_modifiers.metadata import RAY_REMOTE_TAG_NAMESPACE, ray_remote_options
 
 
 def test_tags():
@@ -230,7 +230,7 @@ def test_decorate_node_with_ray_remote_options():
     # quick test to decorate node with ray_remote_options
     # this tests an internal implementation, so we will likely change
     # in the future, but we'll want to keep the same behavior for now
-    @function_modifiers.ray_remote_options({"resources": {"GPU": 1}})
+    @ray_remote_options({"resources": {"GPU": 1}})
     def foo() -> pd.DataFrame:
         return pd.DataFrame.from_records([{"foo": 1, "bar": 2.0, "baz": "3"}])
 

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -27,7 +27,8 @@ def test_tags():
     ],
 )
 def test_tags_invalid_key(key):
-    assert not function_modifiers.tag._key_allowed(key)
+    tag = function_modifiers.tag(**{key: "Dummy Value"})
+    assert not tag._key_allowed(key)
 
 
 @pytest.mark.parametrize(
@@ -39,7 +40,8 @@ def test_tags_invalid_key(key):
     ],
 )
 def test_tags_valid_key(key):
-    assert function_modifiers.tag._key_allowed(key)
+    tag = function_modifiers.tag(**{key: "Dummy Value"})
+    assert tag._key_allowed(key)
 
 
 @pytest.mark.parametrize(

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -230,7 +230,7 @@ def test_decorate_node_with_ray_remote_options():
     # quick test to decorate node with ray_remote_options
     # this tests an internal implementation, so we will likely change
     # in the future, but we'll want to keep the same behavior for now
-    @ray_remote_options({"resources": {"GPU": 1}})
+    @ray_remote_options(resources={"GPU": 1})
     def foo() -> pd.DataFrame:
         return pd.DataFrame.from_records([{"foo": 1, "bar": 2.0, "baz": "3"}])
 

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -3,6 +3,7 @@ import pytest
 
 from hamilton import function_modifiers, node
 from hamilton.function_modifiers import base as fm_base
+from hamilton.function_modifiers.metadata import RAY_REMOTE_TAG_NAMESPACE
 
 
 def test_tags():
@@ -223,3 +224,17 @@ def test_decorate_node_with_schema_output_invalid_type():
 
     with pytest.raises(fm_base.InvalidDecoratorException):
         function_modifiers.base.resolve_nodes(foo, {})
+
+
+def test_decorate_node_with_ray_remote_options():
+    # quick test to decorate node with ray_remote_options
+    # this tests an internal implementation, so we will likely change
+    # in the future, but we'll want to keep the same behavior for now
+    @function_modifiers.ray_remote_options({"resources": {"GPU": 1}})
+    def foo() -> pd.DataFrame:
+        return pd.DataFrame.from_records([{"foo": 1, "bar": 2.0, "baz": "3"}])
+
+    nodes = function_modifiers.base.resolve_nodes(foo, {})
+    node_map = {node_.name: node_ for node_ in nodes}
+    node_ = node_map["foo"]
+    assert node_.tags[RAY_REMOTE_TAG_NAMESPACE] == '{"resources": {"GPU": 1}}'

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -237,4 +237,4 @@ def test_decorate_node_with_ray_remote_options():
     nodes = function_modifiers.base.resolve_nodes(foo, {})
     node_map = {node_.name: node_ for node_ in nodes}
     node_ = node_map["foo"]
-    assert node_.tags[RAY_REMOTE_TAG_NAMESPACE] == '{"resources": {"GPU": 1}}'
+    assert node_.tags[f"{RAY_REMOTE_TAG_NAMESPACE}.resources"] == '{"GPU": 1}'


### PR DESCRIPTION
## Changes

Support to pass options to ray.remote() via @ray_remote_options() decorator
- uses Tags internally, so ray_remote. namespace is now reserved.

## How I tested this

I setup 4 different Ray nodes with different resources available & then decorated 4 functions to target these nodes and one with no decorator.
I confirmed that the functions ran on the correct nodes when using RayGraphAdapter, just as if I wasn't using Hamilton and that the undecorated function also ran

RayWorkflowGraphAdapter also tested.

## Notes

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [N/A] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
