### PR TITLE
No Output Requested while materializer should lead to error

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1454,6 +1454,8 @@ class Driver:
         materializer_vars = []
         try:
             materializer_factories, extractor_factories = self._process_materializers(materializers)
+            if len(materializer_factories)==0:
+                raise ValueError("No output requested or materializer factories were provided.")
             function_graph = materialization.modify_graph(
                 self.graph, materializer_factories, extractor_factories
             )


### PR DESCRIPTION
Address [#796 ](https://github.com/DAGWorks-Inc/hamilton/issues/796) 

## Changes
Added a check to to throw Error if materializer are 0.
Added Test case for the same

## How I tested this
Unit Tested
Run Example on local as well
![test_no_materializer](https://github.com/DAGWorks-Inc/hamilton/assets/14887440/09174181-a79e-416d-9dfa-c5cfc2ad9ba4)

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
