### PR TITLE
[feature] YAMLDataLoader and YAMLDataSaver as default data adapters

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -21,6 +21,7 @@ if not registry.INITIALIZED:
     # right now. Side note: ray serializes things weirdly, so we need to do this here rather than in
     # in the other choice of hamilton/base.py.
     plugins_modules = [
+        "yaml",
         "matplotlib",
         "numpy",
         "pandas",

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -6,8 +6,47 @@ import pathlib
 import pickle
 from typing import Any, Collection, Dict, Tuple, Type, Union
 
+import yaml
+
 from hamilton.io.data_adapters import DataLoader, DataSaver
 from hamilton.io.utils import get_file_metadata
+
+PrimitiveType = Union[str, int, bool, dict, list]
+
+
+@dataclasses.dataclass
+class YAMLDataLoader(DataLoader):
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [str, int, bool, dict, list]
+
+    @classmethod
+    def name(cls) -> str:
+        return "yaml"
+
+    def load_data(self, type_: Type) -> Tuple[PrimitiveType, Dict[str, Any]]:
+        with pathlib.Path(self.path).open(mode="r") as f:
+            return yaml.safe_load(f), get_file_metadata(self.path)
+
+
+@dataclasses.dataclass
+class YAMLDataSaver(DataSaver):
+    path: str
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [str, int, bool, dict, list]
+
+    @classmethod
+    def name(cls) -> str:
+        return "yaml"
+
+    def save_data(self, data: Any) -> Dict[str, Any]:
+        with pathlib.Path(self.path).open("w") as f:
+            yaml.dump(data, f)
+        return get_file_metadata(self.path)
 
 
 @dataclasses.dataclass

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -239,6 +239,8 @@ class InMemoryResult(DataSaver):
 
 
 DATA_ADAPTERS = [
+    YAMLDataSaver,
+    YAMLDataLoader,
     JSONDataSaver,
     JSONDataLoader,
     LiteralValueDataLoader,

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -16,7 +16,7 @@ PrimitiveType = Union[str, int, bool, dict, list]
 
 @dataclasses.dataclass
 class YAMLDataLoader(DataLoader):
-    path: str
+    path: Union[str, pathlib.Path]
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
@@ -27,13 +27,17 @@ class YAMLDataLoader(DataLoader):
         return "yaml"
 
     def load_data(self, type_: Type) -> Tuple[PrimitiveType, Dict[str, Any]]:
-        with pathlib.Path(self.path).open(mode="r") as f:
-            return yaml.safe_load(f), get_file_metadata(self.path)
+        path = self.path
+        if isinstance(self.path, str):
+            path = pathlib.Path(self.path)
+
+        with path.open(mode="r") as f:
+            return yaml.safe_load(f), get_file_metadata(path)
 
 
 @dataclasses.dataclass
 class YAMLDataSaver(DataSaver):
-    path: str
+    path: Union[str, pathlib.Path]
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
@@ -44,7 +48,10 @@ class YAMLDataSaver(DataSaver):
         return "yaml"
 
     def save_data(self, data: Any) -> Dict[str, Any]:
-        with pathlib.Path(self.path).open("w") as f:
+        path = self.path
+        if isinstance(path, str):
+            path = pathlib.Path(path)
+        with path.open("w") as f:
             yaml.dump(data, f)
         return get_file_metadata(self.path)
 

--- a/hamilton/io/default_data_loaders.py
+++ b/hamilton/io/default_data_loaders.py
@@ -6,54 +6,8 @@ import pathlib
 import pickle
 from typing import Any, Collection, Dict, Tuple, Type, Union
 
-import yaml
-
 from hamilton.io.data_adapters import DataLoader, DataSaver
 from hamilton.io.utils import get_file_metadata
-
-PrimitiveType = Union[str, int, bool, dict, list]
-
-
-@dataclasses.dataclass
-class YAMLDataLoader(DataLoader):
-    path: Union[str, pathlib.Path]
-
-    @classmethod
-    def applicable_types(cls) -> Collection[Type]:
-        return [str, int, bool, dict, list]
-
-    @classmethod
-    def name(cls) -> str:
-        return "yaml"
-
-    def load_data(self, type_: Type) -> Tuple[PrimitiveType, Dict[str, Any]]:
-        path = self.path
-        if isinstance(self.path, str):
-            path = pathlib.Path(self.path)
-
-        with path.open(mode="r") as f:
-            return yaml.safe_load(f), get_file_metadata(path)
-
-
-@dataclasses.dataclass
-class YAMLDataSaver(DataSaver):
-    path: Union[str, pathlib.Path]
-
-    @classmethod
-    def applicable_types(cls) -> Collection[Type]:
-        return [str, int, bool, dict, list]
-
-    @classmethod
-    def name(cls) -> str:
-        return "yaml"
-
-    def save_data(self, data: Any) -> Dict[str, Any]:
-        path = self.path
-        if isinstance(path, str):
-            path = pathlib.Path(path)
-        with path.open("w") as f:
-            yaml.dump(data, f)
-        return get_file_metadata(self.path)
 
 
 @dataclasses.dataclass
@@ -239,8 +193,6 @@ class InMemoryResult(DataSaver):
 
 
 DATA_ADAPTERS = [
-    YAMLDataSaver,
-    YAMLDataLoader,
     JSONDataSaver,
     JSONDataLoader,
     LiteralValueDataLoader,

--- a/hamilton/plugins/yaml_extensions.py
+++ b/hamilton/plugins/yaml_extensions.py
@@ -20,7 +20,7 @@ class YAMLDataLoader(DataLoader):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [PrimitiveType]
+        return [str, int, bool, dict, list]
 
     @classmethod
     def name(cls) -> str:
@@ -41,7 +41,7 @@ class YAMLDataSaver(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [PrimitiveType]
+        return [str, int, bool, dict, list]
 
     @classmethod
     def name(cls) -> str:

--- a/hamilton/plugins/yaml_extensions.py
+++ b/hamilton/plugins/yaml_extensions.py
@@ -1,0 +1,70 @@
+try:
+    import yaml
+except ImportError:
+    raise NotImplementedError("yaml is not installed and is needed for yaml hamilton plugin")
+
+import dataclasses
+import pathlib
+from typing import Any, Collection, Dict, Tuple, Type, Union
+
+from hamilton import registry
+from hamilton.io.data_adapters import DataLoader, DataSaver
+from hamilton.io.utils import get_file_metadata
+
+PrimitiveType = Union[str, int, bool, dict, list]
+
+
+@dataclasses.dataclass
+class YAMLDataLoader(DataLoader):
+    path: Union[str, pathlib.Path]
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [PrimitiveType]
+
+    @classmethod
+    def name(cls) -> str:
+        return "yaml"
+
+    def load_data(self, type_: Type) -> Tuple[PrimitiveType, Dict[str, Any]]:
+        path = self.path
+        if isinstance(self.path, str):
+            path = pathlib.Path(self.path)
+
+        with path.open(mode="r") as f:
+            return yaml.safe_load(f), get_file_metadata(path)
+
+
+@dataclasses.dataclass
+class YAMLDataSaver(DataSaver):
+    path: Union[str, pathlib.Path]
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [PrimitiveType]
+
+    @classmethod
+    def name(cls) -> str:
+        return "yaml"
+
+    def save_data(self, data: Any) -> Dict[str, Any]:
+        path = self.path
+        if isinstance(path, str):
+            path = pathlib.Path(path)
+        with path.open("w") as f:
+            yaml.dump(data, f)
+        return get_file_metadata(self.path)
+
+
+COLUMN_FRIENDLY_DF_TYPE = False
+
+
+def register_data_loaders():
+    for materializer in [
+        YAMLDataLoader,
+        YAMLDataSaver,
+    ]:
+        registry.register_adapter(materializer)
+
+
+register_data_loaders()

--- a/tests/io/test_default_adapters.py
+++ b/tests/io/test_default_adapters.py
@@ -3,9 +3,58 @@ import json
 import pathlib
 
 import pytest
+import yaml
 
-from hamilton.io.default_data_loaders import JSONDataLoader, JSONDataSaver, RawFileDataSaverBytes
+from hamilton.io.default_data_loaders import (
+    JSONDataLoader,
+    JSONDataSaver,
+    RawFileDataSaverBytes,
+    YAMLDataLoader,
+    YAMLDataSaver,
+)
 from hamilton.io.utils import FILE_METADATA
+
+TEST_DATA_FOR_YAML = [
+    (1, "int.yaml"),
+    ("string", "string.yaml"),
+    (True, "bool.yaml"),
+    ({"key": "value"}, "test.yaml"),
+    ([1, 2, 3], "data.yaml"),
+    ({"nested": {"a": 1, "b": 2}}, "config.yaml"),
+]
+
+
+@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
+def test_yaml_loader(tmp_path: pathlib.Path, data, file_name):
+    path = tmp_path / pathlib.Path(file_name)
+    with path.open(mode="w") as f:
+        yaml.dump(data, f)
+    assert path.exists()
+    loader = YAMLDataLoader(path)
+    loaded_data = loader.load_data(type(data))
+    assert loaded_data[0] == data
+
+
+@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
+def test_yaml_saver(tmp_path: pathlib.Path, data, file_name):
+    path = tmp_path / pathlib.Path(file_name)
+    saver = YAMLDataSaver(path)
+    saver.save_data(data)
+    assert path.exists()
+    with path.open("r") as f:
+        loaded_data = yaml.safe_load(f)
+    assert data == loaded_data
+
+
+@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
+def test_yaml_loader_and_saver(tmp_path: pathlib.Path, data, file_name):
+    path = tmp_path / pathlib.Path(file_name)
+    saver = YAMLDataSaver(path)
+    saver.save_data(data)
+    assert path.exists()
+    loader = YAMLDataLoader(path)
+    loaded_data = loader.load_data(type(data))
+    assert data == loaded_data[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/io/test_default_adapters.py
+++ b/tests/io/test_default_adapters.py
@@ -3,58 +3,9 @@ import json
 import pathlib
 
 import pytest
-import yaml
 
-from hamilton.io.default_data_loaders import (
-    JSONDataLoader,
-    JSONDataSaver,
-    RawFileDataSaverBytes,
-    YAMLDataLoader,
-    YAMLDataSaver,
-)
+from hamilton.io.default_data_loaders import JSONDataLoader, JSONDataSaver, RawFileDataSaverBytes
 from hamilton.io.utils import FILE_METADATA
-
-TEST_DATA_FOR_YAML = [
-    (1, "int.yaml"),
-    ("string", "string.yaml"),
-    (True, "bool.yaml"),
-    ({"key": "value"}, "test.yaml"),
-    ([1, 2, 3], "data.yaml"),
-    ({"nested": {"a": 1, "b": 2}}, "config.yaml"),
-]
-
-
-@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
-def test_yaml_loader(tmp_path: pathlib.Path, data, file_name):
-    path = tmp_path / pathlib.Path(file_name)
-    with path.open(mode="w") as f:
-        yaml.dump(data, f)
-    assert path.exists()
-    loader = YAMLDataLoader(path)
-    loaded_data = loader.load_data(type(data))
-    assert loaded_data[0] == data
-
-
-@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
-def test_yaml_saver(tmp_path: pathlib.Path, data, file_name):
-    path = tmp_path / pathlib.Path(file_name)
-    saver = YAMLDataSaver(path)
-    saver.save_data(data)
-    assert path.exists()
-    with path.open("r") as f:
-        loaded_data = yaml.safe_load(f)
-    assert data == loaded_data
-
-
-@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
-def test_yaml_loader_and_saver(tmp_path: pathlib.Path, data, file_name):
-    path = tmp_path / pathlib.Path(file_name)
-    saver = YAMLDataSaver(path)
-    saver.save_data(data)
-    assert path.exists()
-    loader = YAMLDataLoader(path)
-    loaded_data = loader.load_data(type(data))
-    assert data == loaded_data[0]
 
 
 @pytest.mark.parametrize(
@@ -78,7 +29,13 @@ def test_raw_file_adapter(data, tmp_path: pathlib.Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}], ["value1", "value2"], [0, 1]]
+    "data",
+    [
+        {"key": "value"},
+        [{"key": "value1"}, {"key": "value2"}],
+        ["value1", "value2"],
+        [0, 1],
+    ],
 )
 def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where
@@ -97,7 +54,13 @@ def test_json_save_object_and_array(data, tmp_path: pathlib.Path):
 
 
 @pytest.mark.parametrize(
-    "data", [{"key": "value"}, [{"key": "value1"}, {"key": "value2"}], ["value1", "value2"], [0, 1]]
+    "data",
+    [
+        {"key": "value"},
+        [{"key": "value1"}, {"key": "value2"}],
+        ["value1", "value2"],
+        [0, 1],
+    ],
 )
 def test_json_load_object_and_array(data, tmp_path: pathlib.Path):
     """Test that `from_.json` and `to.json` can handle JSON objects where

--- a/tests/plugins/test_yaml_extension.py
+++ b/tests/plugins/test_yaml_extension.py
@@ -1,0 +1,48 @@
+import pathlib
+
+import pytest
+import yaml
+
+from hamilton.plugins.yaml_extensions import YAMLDataLoader, YAMLDataSaver
+
+TEST_DATA_FOR_YAML = [
+    (1, "int.yaml"),
+    ("string", "string.yaml"),
+    (True, "bool.yaml"),
+    ({"key": "value"}, "test.yaml"),
+    ([1, 2, 3], "data.yaml"),
+    ({"nested": {"a": 1, "b": 2}}, "config.yaml"),
+]
+
+
+@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
+def test_yaml_loader(tmp_path: pathlib.Path, data, file_name):
+    path = tmp_path / pathlib.Path(file_name)
+    with path.open(mode="w") as f:
+        yaml.dump(data, f)
+    assert path.exists()
+    loader = YAMLDataLoader(path)
+    loaded_data = loader.load_data(type(data))
+    assert loaded_data[0] == data
+
+
+@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
+def test_yaml_saver(tmp_path: pathlib.Path, data, file_name):
+    path = tmp_path / pathlib.Path(file_name)
+    saver = YAMLDataSaver(path)
+    saver.save_data(data)
+    assert path.exists()
+    with path.open("r") as f:
+        loaded_data = yaml.safe_load(f)
+    assert data == loaded_data
+
+
+@pytest.mark.parametrize("data, file_name", TEST_DATA_FOR_YAML)
+def test_yaml_loader_and_saver(tmp_path: pathlib.Path, data, file_name):
+    path = tmp_path / pathlib.Path(file_name)
+    saver = YAMLDataSaver(path)
+    saver.save_data(data)
+    assert path.exists()
+    loader = YAMLDataLoader(path)
+    loaded_data = loader.load_data(type(data))
+    assert data == loaded_data[0]


### PR DESCRIPTION


Adding the option to do I/O using YAML files, similar as what we have with json.

## Changes

Adding YAML as default data adapter


## How I tested this
Same test module as others default data adapters, 3 unit tests:
1. Isolated load
2. Isolated save
3. Using both loader and saver.

## Notes
Followed pattern of json, but expanded the options of applicable_types

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
