### PR TITLE
Adds checks for applicable types to YAMLData*

### DIFF
--- a/hamilton/plugins/yaml_extensions.py
+++ b/hamilton/plugins/yaml_extensions.py
@@ -11,7 +11,8 @@ from hamilton import registry
 from hamilton.io.data_adapters import DataLoader, DataSaver
 from hamilton.io.utils import get_file_metadata
 
-PrimitiveType = Union[str, int, bool, dict, list]
+PrimitiveTypes = str, int, float, bool, dict, list
+AcceptedTypes = Union[PrimitiveTypes]
 
 
 @dataclasses.dataclass
@@ -20,13 +21,13 @@ class YAMLDataLoader(DataLoader):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [str, int, bool, dict, list]
+        return [*PrimitiveTypes]
 
     @classmethod
     def name(cls) -> str:
         return "yaml"
 
-    def load_data(self, type_: Type) -> Tuple[PrimitiveType, Dict[str, Any]]:
+    def load_data(self, type_: Type) -> Tuple[AcceptedTypes, Dict[str, Any]]:
         path = self.path
         if isinstance(self.path, str):
             path = pathlib.Path(self.path)
@@ -41,13 +42,13 @@ class YAMLDataSaver(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[Type]:
-        return [str, int, bool, dict, list]
+        return [*PrimitiveTypes]
 
     @classmethod
     def name(cls) -> str:
         return "yaml"
 
-    def save_data(self, data: Any) -> Dict[str, Any]:
+    def save_data(self, data: AcceptedTypes) -> Dict[str, Any]:
         path = self.path
         if isinstance(path, str):
             path = pathlib.Path(path)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -31,4 +31,3 @@ sphinx-rtd-theme # read the docs pins
 sphinx-sitemap
 tqdm
 xgboost
-yaml

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -31,3 +31,4 @@ sphinx-rtd-theme # read the docs pins
 sphinx-sitemap
 tqdm
 xgboost
+yaml

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -20,6 +20,7 @@ pillow
 polars
 pyarrow >= 1.0.0
 pyspark
+PyYAML
 ray
 readthedocs-sphinx-ext<2.3 # read the docs pins
 recommonmark==0.5.0  # read the docs pins

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -25,4 +25,3 @@ typer
 xgboost
 xlsx2csv  # for excel data loader
 xlsxwriter  # Excel export requires 'xlsxwriter'
-yaml

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,6 +18,7 @@ pyarrow
 pyreadstat  # for SPSS data loader
 pytest
 pytest-cov
+PyYAML
 scikit-learn
 sqlalchemy==1.4.49; python_version == '3.7.*'
 sqlalchemy; python_version >= '3.8'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -25,3 +25,4 @@ typer
 xgboost
 xlsx2csv  # for excel data loader
 xlsxwriter  # Excel export requires 'xlsxwriter'
+yaml

--- a/tests/plugins/test_yaml_extension.py
+++ b/tests/plugins/test_yaml_extension.py
@@ -1,9 +1,12 @@
 import pathlib
+from typing import List, Type
 
 import pytest
 import yaml
 
-from hamilton.plugins.yaml_extensions import YAMLDataLoader, YAMLDataSaver
+from hamilton.function_modifiers.adapters import resolve_adapter_class
+from hamilton.io.data_adapters import DataLoader, DataSaver
+from hamilton.plugins.yaml_extensions import PrimitiveTypes, YAMLDataLoader, YAMLDataSaver
 
 TEST_DATA_FOR_YAML = [
     (1, "int.yaml"),
@@ -46,3 +49,23 @@ def test_yaml_loader_and_saver(tmp_path: pathlib.Path, data, file_name):
     loader = YAMLDataLoader(path)
     loaded_data = loader.load_data(type(data))
     assert data == loaded_data[0]
+
+
+@pytest.mark.parametrize(
+    "type_,classes,correct_class",
+    [(t, [YAMLDataLoader], YAMLDataLoader) for t in PrimitiveTypes],
+)
+def test_resolve_correct_loader_class(
+    type_: Type[Type], classes: List[Type[DataLoader]], correct_class: Type[DataLoader]
+):
+    assert resolve_adapter_class(type_, classes) == correct_class
+
+
+@pytest.mark.parametrize(
+    "type_,classes,correct_class",
+    [(t, [YAMLDataSaver], YAMLDataSaver) for t in PrimitiveTypes],
+)
+def test_resolve_correct_saver_class(
+    type_: Type[Type], classes: List[Type[DataSaver]], correct_class: Type[DataLoader]
+):
+    assert resolve_adapter_class(type_, classes) == correct_class


### PR DESCRIPTION
Some fun facts:

```python
Union[int, float, bool] == Union[(int, float, bool)]
```

So just needed to change the types to be a tuple
rather than a list, and then things work in a DRY way.

We could just want dict & list (since that is most likely from an actual user setting) -- you're likely not going to just save values, but in some sort of list or dict...

## Changes
- yaml_extensions.py
- test_yaml_extenstions.py

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
