### PR TITLE
Unit test stub autogenerator

### DIFF
--- a/hamilton/cli/__main__.py
+++ b/hamilton/cli/__main__.py
@@ -54,6 +54,17 @@ MODULES_ANNOTATIONS = Annotated[
     ),
 ]
 
+PYTHON_FILE_MODULE_ANNOTATIONS = Annotated[
+    Path,
+    typer.Argument(
+        help="Path to python file or module",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+    ),
+]
+
 NAME_ANNOTATIONS = Annotated[
     Optional[str],
     typer.Option("--name", "-n", help="Name of the dataflow. Default: Derived from MODULES."),
@@ -83,6 +94,19 @@ VIZ_OUTPUT_ANNOTATIONS = Annotated[
         resolve_path=True,
     ),
 ]
+
+OUTPUT_ANNOTATIONS = Annotated[
+    Path,
+    typer.Option(
+        "--output",
+        "-o",
+        help="Output path of unit test file.",
+        dir_okay=False,
+        writable=True,
+        resolve_path=True,
+    ),
+]
+
 
 
 # TODO add `experiments` for `hamilton.plugins.h_experiments`
@@ -281,6 +305,27 @@ def view(
     _response_handler(
         ctx=ctx,
         response=Response(command="view", success=True, message={"path": str(output_file_path)}),
+    )
+
+
+
+@cli.command()
+def create_tests(
+    ctx: typer.Context,
+    python_file_module: PYTHON_FILE_MODULE_ANNOTATIONS,
+    output_file_path: OUTPUT_ANNOTATIONS = None,
+):
+    """Create unit tests for given python file or module"""
+    if output_file_path is None:
+        output_file_path = Path(f"test_{Path(python_file_module).stem}.py")
+
+    if output_file_path.is_dir():
+        raise ValueError("output_file_path can not be a directory")
+
+    _try_command(cmd=commands.create_tests, input_file_path=python_file_module, output_file_path=output_file_path)
+    _response_handler(
+        ctx=ctx,
+        response=Response(command="create_tests", success=True, message={"path": str(output_file_path)}),
     )
 
 

--- a/hamilton/cli/__main__.py
+++ b/hamilton/cli/__main__.py
@@ -108,7 +108,6 @@ OUTPUT_ANNOTATIONS = Annotated[
 ]
 
 
-
 # TODO add `experiments` for `hamilton.plugins.h_experiments`
 # TODO add `dataflows` submenu to manage locally installed dataflows
 # TODO add `init` to load project template
@@ -308,7 +307,6 @@ def view(
     )
 
 
-
 @cli.command()
 def create_tests(
     ctx: typer.Context,
@@ -322,10 +320,16 @@ def create_tests(
     if output_file_path.is_dir():
         raise ValueError("output_file_path can not be a directory")
 
-    _try_command(cmd=commands.create_tests, input_file_path=python_file_module, output_file_path=output_file_path)
+    _try_command(
+        cmd=commands.create_tests,
+        input_file_path=python_file_module,
+        output_file_path=output_file_path,
+    )
     _response_handler(
         ctx=ctx,
-        response=Response(command="create_tests", success=True, message={"path": str(output_file_path)}),
+        response=Response(
+            command="create_tests", success=True, message={"path": str(output_file_path)}
+        ),
     )
 
 

--- a/hamilton/cli/commands.py
+++ b/hamilton/cli/commands.py
@@ -108,3 +108,9 @@ def version(dr: driver.Driver) -> dict:
 def view(dr: driver.Driver, output_file_path: Path = Path("dag.png")) -> None:
     """Display all functions of the instantiated Driver"""
     dr.display_all_functions(output_file_path)
+
+
+def create_tests(input_file_path: Path, output_file_path: Optional[Path] = None) -> None:
+    """Create unit tests for the given input file path"""
+    res = logic.create_tests(input_file_path, output_file_path)
+    return res

--- a/hamilton/cli/logic.py
+++ b/hamilton/cli/logic.py
@@ -355,10 +355,10 @@ def create_tests(input: Path, output: Path) -> None:
         output_annotations, output_names = _get_functions_and_annotations(output_module)
         strip_output_names = [name.lstrip("test_") for name in output_names]
     else:
-        with open(output, 'a') as f:
+        with open(output, "a") as f:
             f.write(f"import {input.stem}\n")
         _write_import_statement(output, annotations)
-    
+
     new_functions = [name for name in names if name not in strip_output_names]
 
     for name, annotation in zip(names, annotations):
@@ -378,14 +378,8 @@ def _get_test_stub(input_name: str, name: str, annotation: dict) -> str:
         if k == "return":
             k = "expected"
         test_stub += textwrap.indent(
-            f"""{k}: {v.__name__} = {v.__name__}() #TODO fill in""",
-        "\n    "
+            f"""{k}: {v.__name__} = {v.__name__}() #TODO fill in""", "\n    "
         )
-    test_stub += textwrap.indent(
-        f"""assert expected == {input_name}.{name}()""",
-        "\n    "
-    )
+    test_stub += textwrap.indent(f"""assert expected == {input_name}.{name}()""", "\n    ")
 
     return test_stub
-
-


### PR DESCRIPTION
Address #74 

## Changes
- Added new command create-tests in cli module.
- Wrote logic for generating testcase of given python file

## How I tested this
- Tested with file `test1.py`
```import pandas as pd

def pr(b: int, c: int) -> int:
    return b + c

def divide(b: pd.Series, c: pd.Series) -> pd.Series:
    return b/c
```

OUTPUT: `test_test1.py`
```import test1
from pandas.core.series import Series


def test_divide():
    b: Series = Series() #TODO fill in
    c: Series = Series() #TODO fill in
    expected: Series = Series() #TODO fill in
    assert expected == test1.divide()

def test_pr():
    b: int = int() #TODO fill in
    c: int = int() #TODO fill in
    expected: int = int() #TODO fill in
    assert expected == test1.pr()
```

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
