### PR TITLE
add a "resolve from config" wrapper around the resolve decorator

### DIFF
--- a/hamilton/function_modifiers/__init__.py
+++ b/hamilton/function_modifiers/__init__.py
@@ -87,6 +87,7 @@ parameterized_subdag = recursive.parameterized_subdag
 
 resolve = delayed.resolve
 ResolveAt = delayed.ResolveAt
+resolve_from_config = delayed.resolve_from_config
 
 # materialization stuff
 load_from = adapters.load_from

--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -151,5 +151,15 @@ class resolve(DynamicResolver):
 
 
 class resolve_from_config(resolve):
+    """Decorator class to delay evaluation of decorators until after the configuration is available.
+    Note: this is a power-user feature, and you have to enable power-user mode! To do so, you have
+    to add the configuration hamilton.enable_power_user_mode=True to the config you pass into the
+    driver.
+
+    This is a convenience decorator that is a subclass of `resolve` and passes
+    `ResolveAt.CONFIG_AVAILABLE` to the `when` argument such that the decorator is resoled at
+    compile time, E.G. when the driver is instantiated.
+    """
+
     def __init__(self, *, decorate_with: Callable[..., NodeTransformLifecycle]):
         super().__init__(when=ResolveAt.CONFIG_AVAILABLE, decorate_with=decorate_with)

--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -148,3 +148,8 @@ class resolve(DynamicResolver):
             if key in config:
                 kwargs[key] = config[key]
         return self.decorate_with(**kwargs)
+
+
+class resolve_from_config(resolve):
+    def __init__(self, *, decorate_with: Callable[..., NodeTransformLifecycle]):
+        super().__init__(when=ResolveAt.CONFIG_AVAILABLE, decorate_with=decorate_with)

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -3,7 +3,13 @@ from typing import Callable
 import pytest
 
 from hamilton import settings
-from hamilton.function_modifiers import ResolveAt, base, extract_columns, resolve, resolve_from_config
+from hamilton.function_modifiers import (
+    ResolveAt,
+    base,
+    extract_columns,
+    resolve,
+    resolve_from_config,
+)
 
 CONFIG_WITH_POWER_MODE_ENABLED = {
     settings.ENABLE_POWER_USER_MODE: True,

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -3,7 +3,7 @@ from typing import Callable
 import pytest
 
 from hamilton import settings
-from hamilton.function_modifiers import ResolveAt, base, extract_columns, resolve
+from hamilton.function_modifiers import ResolveAt, base, extract_columns, resolve, resolve_from_config
 
 CONFIG_WITH_POWER_MODE_ENABLED = {
     settings.ENABLE_POWER_USER_MODE: True,
@@ -47,6 +47,19 @@ def test_extract_and_validate_params_unhappy(fn: Callable):
 def test_dynamic_resolves():
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
+        decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
+    )
+    decorator_resolved = decorator.resolve(
+        {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED}, fn=test_dynamic_resolves
+    )
+    # This uses an internal component of extract_columns
+    # We may want to add a little more comprehensive testing
+    # But for now this will work
+    assert decorator_resolved.columns == ("a", "b")
+
+
+def test_dynamic_resolve_with_configs():
+    decorator = resolve_from_config(
         decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
     )
     decorator_resolved = decorator.resolve(


### PR DESCRIPTION
Add a small wrapper around `resolve` function modifier to "resolve from config"

## Changes

Add a `hamilton.function_modifiers.resolve_from_config` hook that just passes `ResolveAt.CONFIG_AVAILABLE` flag to the original `resolve` class.

## How I tested this

Have been using this as a small custom snippet (albeit not as a wrapper around the class) in some internal projects for quite a while. Its really just a convenience wrapper to make my pipeline code a little cleaner.

I've made a very small attempt to duplicate a relevant unit test.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
