### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Hamilton is a novel paradigm for specifying a flow of delayed execution in pytho
 
 This paradigm makes modifications easy to build and track, ensures code is self-documenting, and makes it natural to unit test your data transformations. When connected together, these functions form a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (DAG), which the Hamilton framework can execute, optimize, and report on.
 
-Note: Hamilton describes DAGs. If you're looking for something to handle loops or conditional edges (say, for a human-in-the-loop application like a chatbot or agent), you might appreciate [Burr](github.com/dagworks-inc/burr) -- it integrates well with any python library (including Hamilton!).
+Note: Hamilton describes DAGs. If you're looking for something to handle loops or conditional edges (say, for a human-in-the-loop application like a chatbot or agent), you might appreciate [Burr](https://github.com/dagworks-inc/burr) -- it integrates well with any python library (including Hamilton!).
 
 ## Problems Hamilton Solves
 ✅ Model a dataflow -- If you can model your problem as a DAG in python, Hamilton is the cleanest way to build it.<br/>
@@ -37,7 +37,7 @@ Note: Hamilton describes DAGs. If you're looking for something to handle loops o
 ## Problems Hamilton Does not Solve
 ❌ Provisioning infrastructure -- you want a macro-orchestration system (see airflow, kubeflow, sagemaker, etc...).<br/>
 ❌ Doing your ML for you -- we organize your code, BYOL (bring your own libraries).<br/>
-❌ Tracking execution + associated artifacts -- Hamilton is lightweight, but if this is important to you see the [DAGWorks product](www.dagworks.io).
+❌ Tracking execution + associated artifacts -- Hamilton is lightweight, but if this is important to you see the [DAGWorks product](https://www.dagworks.io).
 
 See the table below for more specifics/how it compares to other common tooling.
 


### PR DESCRIPTION
It seems like because a few links lack a protocol, GitHub is treating them as [Relative Links](https://github.blog/2013-01-31-relative-links-in-markup-files/).

## Changes

Just cosmetic fixes to the README.

## How I tested this

Previewing my changes in the rich diff shows the links are now correct.

## Notes

N/A

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
