### PR TITLE
`fix` closed `CacheAdapter`

### DIFF
--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -348,9 +348,11 @@ class CacheAdapter(NodeExecutionHook, NodeExecutionMethod, GraphExecutionHook):
             key=CacheAdapter.nodes_history_key, default=dict()
         )
         self.used_nodes_hash: Dict[str, str] = dict()
+        self.cache.close()
 
     def run_before_graph_execution(self, *, graph: HamiltonGraph, **kwargs):
         """Set `cache_vars` to all nodes if received None during `__init__`"""
+        self.cache = shelve.open(self.cache_path)
         if self.cache_vars == []:
             self.cache_vars = [n.name for n in graph.nodes]
 

--- a/tests/lifecycle/test_cache_adapter.py
+++ b/tests/lifecycle/test_cache_adapter.py
@@ -59,6 +59,7 @@ def test_set_result(hook: CacheAdapter, node_a: node.Node):
     cache_key = CacheAdapter.create_key(node_hash, node_kwargs)
     result = 2
 
+    hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
     hook.cache_vars = [node_a.name]
     # used_nodes_hash would be set by run_to_execute() hook
     hook.used_nodes_hash[node_a.name] = node_hash
@@ -79,6 +80,7 @@ def test_get_result(hook: CacheAdapter, node_a: node.Node):
     result = 2
     cache_key = CacheAdapter.create_key(node_hash, node_kwargs)
 
+    hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
     hook.cache_vars = [node_a.name]
     # run_after_node_execution() would set cache
     hook.cache[cache_key] = result
@@ -103,6 +105,7 @@ def test_append_nodes_history(
     node_kwargs = dict(external_input=7)
     hook.cache_vars = [node_a.name]
 
+    hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
     # node version 1
     hook.used_nodes_hash[node_name] = graph_types.hash_source_code(node_a.callable, strip=True)
     hook.run_to_execute_node(
@@ -129,6 +132,7 @@ def test_commit_nodes_history(hook: CacheAdapter):
     """Commit node history to cache"""
     hook.nodes_history = dict(A=["hash_1", "hash_2"])
 
+    hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
     hook.run_after_graph_execution()
 
     # need to reopen the hook cache


### PR DESCRIPTION
The `CacheAdapter()` would successfully run for the first execution, and fail on subsequent ones. This is because the cache was opened on `__init__()` (needs to read some attributes at instantiation) and closed "after graph execution".

## Changes
cache is now opened and closed at `__init__()`
cache is opened "before graph execution" and closed "after graph execution" for satefy




- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
