### PR TITLE
Changes jupyter magic to create temporary files

### DIFF
--- a/hamilton/ad_hoc_utils.py
+++ b/hamilton/ad_hoc_utils.py
@@ -1,7 +1,11 @@
 """A suite of tools for ad-hoc use"""
 
+import atexit
+import importlib.util
 import linecache
+import os
 import sys
+import tempfile
 import types
 import uuid
 from types import ModuleType
@@ -61,7 +65,9 @@ def create_temporary_module(*functions: Callable, module_name: str = None) -> Mo
 
 
 def module_from_source(source: str) -> ModuleType:
-    """Create a temporary module from source code"""
+    """Create a temporary module from source code.
+    Deprecated in favor of `create_module()` below.
+    """
     module_name = _generate_unique_temp_module_name()
     module_object = ModuleType(module_name)
     code_object = compile(source, module_name, "exec")
@@ -74,4 +80,38 @@ def module_from_source(source: str) -> ModuleType:
         source.splitlines(True),
         module_name,
     )
+    return module_object
+
+
+def create_module(source: str, module_name: str = None, verbosity: int = 0) -> ModuleType:
+    """Create a temporary module from source code and load it as a proper Python module.
+
+    Registers the module in sys.modules and cleans up the temporary file on interpreter shutdown.
+    But if the python interpreter errors out, or the server is shutdown, the temporary file will not be cleaned up.
+    """
+    # Create a temporary file to hold the code
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".py", mode="w") as tmp_file:
+        tmp_file.write(source)
+        module_path = tmp_file.name
+        if verbosity > 1:
+            print(f"Temporary file created at {module_path}")
+
+    # Determine a module name if not provided
+    if module_name is None:
+        module_name = os.path.basename(module_path).split(".")[0]
+
+    # Load the module from the temporary file
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module_object = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module_object)
+
+    # Register the module in sys.modules
+    sys.modules[module_name] = module_object
+
+    # Clean up the temporary file on interpreter shutdown
+    def cleanup(module_path=module_path):
+        os.remove(module_path)
+
+    atexit.register(lambda: cleanup())
+
     return module_object

--- a/hamilton/plugins/jupyter_magic.py
+++ b/hamilton/plugins/jupyter_magic.py
@@ -14,12 +14,8 @@ If you are developing on this module you'll then want to use:
 
 """
 
-import atexit
-import importlib.util
 import json
 import os
-import sys
-import tempfile
 from pathlib import Path
 from types import ModuleType
 
@@ -27,41 +23,7 @@ from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from IPython.display import HTML, display
 
-from hamilton import driver, lifecycle
-
-
-def create_module(source: str, module_name: str = None, verbosity: int = 0) -> ModuleType:
-    """Create a temporary module from source code and load it as a proper Python module.
-
-    Registers the module in sys.modules and cleans up the temporary file on interpreter shutdown.
-    But if the python interpreter errors out, or the server is shutdown, the temporary file will not be cleaned up.
-    """
-    # Create a temporary file to hold the code
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".py", mode="w") as tmp_file:
-        tmp_file.write(source)
-        module_path = tmp_file.name
-        if verbosity > 1:
-            print(f"Temporary file created at {module_path}")
-
-    # Determine a module name if not provided
-    if module_name is None:
-        module_name = os.path.basename(module_path).split(".")[0]
-
-    # Load the module from the temporary file
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
-    module_object = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module_object)
-
-    # Register the module in sys.modules
-    sys.modules[module_name] = module_object
-
-    # Clean up the temporary file on interpreter shutdown
-    def cleanup(module_path=module_path):
-        os.remove(module_path)
-
-    atexit.register(lambda: cleanup())
-
-    return module_object
+from hamilton import ad_hoc_utils, driver, lifecycle
 
 
 def insert_cell_with_content():
@@ -249,7 +211,7 @@ class HamiltonMagics(Magics):
                     print("Failed to parse config as JSON. Please ensure it's a valid JSON string:")
                     print(args.config)
 
-        module_object = create_module(cell, module_name, verbosity=args.verbosity)
+        module_object = ad_hoc_utils.create_module(cell, module_name, verbosity=args.verbosity)
 
         # shell.push() assign a variable in the notebook. The dictionary keys are variable name
         self.shell.push({module_name: module_object})


### PR DESCRIPTION
Temporary files allow us to then hash the code properly for use with the Hamilton UI.

This does not change any functionality. If the interpreter is shutdown gracefully then the temporary files are deleted cleanly.

## Changes
 - adjust function that creates the module in the jupyter magic

## How I tested this
 - locally
 - on databricks

## Notes
 - this means magics in notebooks can be cleanly used with the Hamilton UI.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
