### PR TITLE
Update documentation to resolve a small typo in glossary

### DIFF
--- a/docs/concepts/glossary.rst
+++ b/docs/concepts/glossary.rst
@@ -28,7 +28,7 @@ Before we dive into the concepts, let's clarify the terminology we'll be using:
        many (using function modifiers). See :doc:`node`.
    * - Module |
        Python module
-     - Python code organized into a ``.py`` file.
+     - Python code organized into a ``.py`` file. These are natural groupings of functions that turn to a set of nodes. See [code organization](https://hamilton.dagworks.io/en/latest/concepts/best-practices/code-organization/#code-organization) for more details.
    * - Driver |
        Hamilton Driver
      - An object that loads Python modules to build a dataflow. It is responsible for visualizing and executing the \

--- a/docs/concepts/glossary.rst
+++ b/docs/concepts/glossary.rst
@@ -28,8 +28,7 @@ Before we dive into the concepts, let's clarify the terminology we'll be using:
        many (using function modifiers). See :doc:`node`.
    * - Module |
        Python module
-     - Python code organized into a ``.py`` file. exte function written by a user to create a
-       single node (in the standard case) or many (using function modifiers). See :doc:`node`.
+     - Python code organized into a ``.py`` file.
    * - Driver |
        Hamilton Driver
      - An object that loads Python modules to build a dataflow. It is responsible for visualizing and executing the \


### PR DESCRIPTION
The current glossary page of the Hamilton documentation provides the following definition for "Module | Python Module":

> Python code organized into a .py file. exte function written by a user to create a single node (in the standard case) or many (using function modifiers). See [Functions, nodes & dataflow](https://hamilton.dagworks.io/en/latest/concepts/node/).

It appears that everything after the first sentence here may have been accidentally copied from the definition for "Function | Python function | Hamilton function | Node definition". To me this seemed like a likely typo, but if this is intentional feel free to disregard this PR.

## Changes
- Changes definition of "Module | Python Module" in documentation from:
> Python code organized into a .py file. exte function written by a user to create a single node (in the standard case) or many (using function modifiers). See [Functions, nodes & dataflow](https://hamilton.dagworks.io/en/latest/concepts/node/).

to 

> Python code organized into a ``.py`` file.

## How I tested this
- I did not test this, since it looks like docs are built in CI.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
