### PR TITLE
Update link in glossary to use reST formatting

### DIFF
--- a/docs/concepts/glossary.rst
+++ b/docs/concepts/glossary.rst
@@ -28,7 +28,7 @@ Before we dive into the concepts, let's clarify the terminology we'll be using:
        many (using function modifiers). See :doc:`node`.
    * - Module |
        Python module
-     - Python code organized into a ``.py`` file. These are natural groupings of functions that turn to a set of nodes. See [code organization](https://hamilton.dagworks.io/en/latest/concepts/best-practices/code-organization/#code-organization) for more details.
+     - Python code organized into a ``.py`` file. These are natural groupings of functions that turn to a set of nodes. See :doc:`best-practices/code-organization` for more details.
    * - Driver |
        Hamilton Driver
      - An object that loads Python modules to build a dataflow. It is responsible for visualizing and executing the \


### PR DESCRIPTION
I made a PR earlier today (#857) that updated the wording of an entry in `docs/concepts/glossary.rst`. Some additional info was added to the entry including a link, but it looks like the link was added in Markdown format instead of reST, which produces an unformatted link, as shown below:

![Screenshot 2024-04-26 at 11 45 27 AM](https://github.com/DAGWorks-Inc/hamilton/assets/43649615/404edd6e-232b-4146-8110-da3ba04c75ea)


I built the docs locally after updating to reST format, which now produces the following formatting:

![Screenshot 2024-04-26 at 11 45 47 AM](https://github.com/DAGWorks-Inc/hamilton/assets/43649615/95d33c9d-2046-4f16-84bb-f19254271ecf)

## Changes
- Updated link to Code Organization in `docs/concepts/glossary.rst` to use reST formatting instead of Markdown formatting.
## How I tested this
- built docs locally using the instructions in `README-DOCS.md` and verified formatting of link.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
