### PR TITLE
Add call out of libraries in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
-Portions of this software are licensed as follows:
+Software contained in this repository is licensed as follows:
 
 * All content that resides under the "ui/frontend/src/ee" and "ui/backend/server/trackingserver_auth" directory of this
-repository is licensed under the license defined in "ui/frontend/src/ee/LICENSE" "ui/backend/server/trackingserver_auth/LICENSE" respectively.
-* All third party components incorporated into the Hamilton Software are licensed under the original license provided by the owner of the applicable component.
-* Content outside of the above mentioned directories or restrictions above is available under the "BSD-3 Clear Clause" license as defined below.
+repository is licensed under the license defined in "ui/frontend/src/ee/LICENSE", "ui/backend/server/trackingserver_auth/LICENSE" respectively.
+* All third party components incorporated into the Hamilton UI Software under "ui/" are licensed under the original license provided by the owner of the applicable component.
+* Content outside of the above mentioned directories or restrictions above is available under the "BSD-3 Clear Clause" license as defined below. For example, the libraries sf-hamilton, sf-hamilton-contrib, and sf-hamilton-sdk are all "BSD-3 Clear Clause" licensed.
 
 Copyright (c) 2023-2024 DAGWorks Inc.
 All rights reserved.


### PR DESCRIPTION
Just incase someone browsing the repository gets confused.

All the libraries published are BSD-3.
Most of the code under "ui/" is also BSD-3 apart from the explicitly designated folders that have an EE license.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
