### PR TITLE
added missing config from legend

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -475,6 +475,7 @@ def create_graphviz_graph(
         # append config key to node label
         config_key = n.tags.get("hamilton.config", None)
         if config_key:
+            seen_node_types.add("config")
             label = _get_node_label(n, name=f"{n.name}: {config_key}")
 
         node_style = _get_node_style(node_type)


### PR DESCRIPTION
Follow-up #872 

## Changes
- single line change to add `config` to node types to include in legend, even when the "config" isn't part of the node path.

## How I tested this
- all tests succeed locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
