### PR TITLE
added Builder.copy()

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1832,6 +1832,23 @@ class Builder:
             _use_legacy_adapter=False,
         )
 
+    def copy(self) -> "Builder":
+        """Creates a copy of the current state of this Builder.
+
+        NOTE. The copied Builder currently holds reference of Builder attributes
+        """
+        new_builder = Builder()
+        new_builder.v2_executor = self.v2_executor
+        new_builder.config = self.config.copy()
+        new_builder.modules = self.modules.copy()
+        new_builder.legacy_graph_adapter = self.legacy_graph_adapter
+        new_builder.adapters = self.adapters.copy()
+        new_builder.execution_manager = self.execution_manager
+        new_builder.local_executor = self.local_executor
+        new_builder.remote_executor = self.remote_executor
+        new_builder.grouping_strategy = self.grouping_strategy
+        return new_builder
+
 
 if __name__ == "__main__":
     """some example test code"""

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -509,6 +509,28 @@ def test_builder_defaults_to_dict_result():
     assert result == {"C": 4}
 
 
+def test_builder_copy():
+    builder = (
+        Builder()
+        .with_modules(tests.resources.dummy_functions)
+        .with_config({"config_key": 13})
+        .enable_dynamic_execution(allow_experimental_mode=True)
+        .with_adapter(base.DefaultAdapter())
+        .with_local_executor(executors.SynchronousLocalTaskExecutor())
+        .with_remote_executor(executors.SynchronousLocalTaskExecutor())
+    )
+    builder_copy = builder.copy()
+
+    assert builder_copy is not builder
+    for attr, attr_value in builder.__dict__.items():
+        attr_value_copy = getattr(builder_copy, attr)
+        assert attr_value_copy == attr_value
+        # TODO check that each objects
+        # if isinstance(attr_value, bool):
+        #     continue
+        # assert attr_value_copy is not attr_value
+
+
 def test_materialize_checks_required_input(tmp_path):
     dr = Builder().with_modules(tests.resources.dummy_functions).build()
 


### PR DESCRIPTION
This is useful in the Jupyter Magic V2, plugins and other scenarios where we want users to be able to pass a `Builder()` and another function be responsible for completing the `Driver` creation.

## Changes
- add `Builder().copy()` as currently implemented in the Jupyter magics V2 PR

## How I tested this
- check the copy points to a different object
- check the copy and original have equal attributes

## Notes
Currently, the copied `Builder()` holds references to the original Builder attributes. AFAIK, this means the original `Builder()` can be garbage collected, but not its attribute (assuming they're useful to the new Builder copy. An odd edge case would be:
1. create `Builder foo` with stateful adapters
2. copy `Builder foo` to create `Builder bar`
3. create `Driver foo` and `Driver bar` from both.
4. both `Driver` seemingly share an adapter with the same state, which could be odd for `CachingAdapter`, `ExperimentTracker`, and others given they store metadata as they progress through the DAG 



