### PR TITLE
added Builder.with_materializers()

### DIFF
--- a/tests/resources/test_for_materialization.py
+++ b/tests/resources/test_for_materialization.py
@@ -10,3 +10,7 @@ def json_to_save_2() -> dict:
         "key3": "value3",
         "key4": "value4",
     }
+
+
+def expects_loader(external: dict) -> dict:
+    return external

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -12,7 +12,7 @@ from hamilton.driver import (
     Variable,
 )
 from hamilton.execution import executors
-from hamilton.io.materialization import to
+from hamilton.io.materialization import to, from_
 
 import tests.resources.cyclic_functions
 import tests.resources.dummy_functions
@@ -20,6 +20,7 @@ import tests.resources.dynamic_parallelism.parallel_linear_basic
 import tests.resources.tagging
 import tests.resources.test_default_args
 import tests.resources.very_simple_dag
+import tests.resources.test_for_materialization
 
 """This file tests driver capabilities.
 Anything involving execution is tested for multiple executors/driver configuration.
@@ -529,6 +530,62 @@ def test_builder_copy():
         # if isinstance(attr_value, bool):
         #     continue
         # assert attr_value_copy is not attr_value
+
+
+def test_builder_with_loader_materializer():
+    loader_target = "external"
+    loader = from_.json(target=loader_target, path="/my/file.json")
+    dr = (
+        Builder()
+        .with_modules(tests.resources.test_for_materialization)
+        .with_materializers(loader)
+        .build()
+    )
+
+    assert any(n.name == f"load_data.{loader_target}" for n in dr.graph.get_nodes())
+
+
+def test_builder_with_saver_materializer():
+    saver_id = "saver_node"
+    saver = to.json(
+        id=saver_id,
+        dependencies=["expects_loader"],
+        path="/my/file.json",
+    )
+    dr = (
+        Builder()
+        .with_modules(tests.resources.test_for_materialization)
+        .with_materializers(saver)
+        .build()
+    )
+
+    assert any(n.name == saver_id for n in dr.graph.get_nodes())
+
+
+def test_builder_materializer_and_execution_materializer(tmp_path):
+    static_saver = to.json(
+        id="static_saver",
+        dependencies=["json_to_save_1"],
+        path=f"{tmp_path}/file.json",
+    )
+    dynamic_saver = to.json(
+        id="dynamic_saver",
+        dependencies=["json_to_save_2"],
+        path=f"{tmp_path}/file2.json",
+    )
+    dr = (
+        Builder()
+        .with_modules(tests.resources.test_for_materialization)
+        .with_materializers(static_saver)
+        .build()
+    )
+    metadata, additional = dr.materialize(
+        dynamic_saver,
+        additional_vars=["static_saver"]
+    )
+
+    assert "dynamic_saver" in metadata.keys()
+    assert "static_saver" in additional.keys()
 
 
 def test_materialize_checks_required_input(tmp_path):


### PR DESCRIPTION
Following #877 

Added the ability to add materializer nodes to the `FunctionGraph` at `Driver` build time. 

Use cases:
- Easier to view materializers as part of `.display_all_functions()`
- Allows to call materializers by name with `.execute()`. Would allow some users to completely ignore `.materialize()` 
- Possible to combine "static" materializers at build time and "dynamic" materializers at execution time
- Catch invalid dataflows earlier than `dr.materialize()`

## Changes
- Builder now accepts `.with_materializers(*materializers)`
- `Builder.build()` adds materializer nodes after creating the `Driver` and returns the updated Driver. The logic is derived from `Driver.materialize()`
- `Builder.copy()` copies the materializers

## How I tested this
- Added tests to check materializer nodes (savers and loaders) are properly added
- test that "static" and "dynamic" materializers can be used together

## Notes
- each time materializers are added `post_graph_construct` hooks are triggered
- Should be include materializers in the `version` hashing of the dataflow? should we treat "static" and "dynamic" differently. IMO, we might want two create two versions: one for "the dataflow transform, ignoring materializers" and one for "all nodes" since they answer different equality / diffing questions 
- there's duplicate logic between `Builder.build()` and `Driver.materialize()`. A better approach could be to have `Driver.add_materializers()` and `Driver.execute_materializers()`. Both `Builder.build()` and `Driver.materialize()` could call `Driver.add_materializers()`  
- Related to #713,  users need to be aware that materializers need a valid `target` or `dependencies` (type and name) to connect to.
