### PR TITLE
added `__getitem__()` and `filter_nodes()`to `HamiltonGraph`

### DIFF
--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -172,7 +172,7 @@ class HamiltonNode:
             return None
 
     def __repr__(self):
-        return f"{self.name}: {htypes.get_type_as_string(self.type)}"
+        return f'Node("{self.name}": {htypes.get_type_as_string(self.type)})'
 
 
 @dataclass
@@ -209,3 +209,22 @@ class HamiltonGraph:
         """
         sorted_node_versions = sorted([n.version for n in self.nodes if n.version is not None])
         return hashlib.sha256(str(sorted_node_versions).encode()).hexdigest()
+
+    @functools.cached_property
+    def __nodes_lookup(self) -> typing.Dict[str, HamiltonNode]:
+        """Cache the mapping {node_name: node} for faster `__getitem__`"""
+        return {n.name: n for n in self.nodes}
+
+    def __getitem__(self, key: str) -> HamiltonNode:
+        """Get an HamiltonNode by name
+
+        :param key: Hamilton node name
+        :return: Hamilton node
+        """
+        return self.__nodes_lookup[key]
+
+    def filter_nodes(
+        self, filter: typing.Callable[[HamiltonNode], bool]
+    ) -> typing.List[HamiltonNode]:
+        """Return Hamilton nodes matching the filter criteria"""
+        return [n for n in self.nodes if filter(n)]

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -227,4 +227,4 @@ class HamiltonGraph:
         self, filter: typing.Callable[[HamiltonNode], bool]
     ) -> typing.List[HamiltonNode]:
         """Return Hamilton nodes matching the filter criteria"""
-        return [n for n in self.nodes if filter(n)]
+        return [n for n in self.nodes if filter(n) is True]

--- a/tests/test_graph_types.py
+++ b/tests/test_graph_types.py
@@ -160,6 +160,30 @@ def test_hamilton_graph_version_with_none_originating_functions():
     assert graph.version == hash_value
 
 
+def test_hamilton_graph_getitem():
+    dr = driver.Builder().with_modules(test_nodes).build()
+    h_graph = graph_types.HamiltonGraph.from_graph(dr.graph)
+
+    assert isinstance(h_graph["lowercased"], graph_types.HamiltonNode)
+    assert h_graph["lowercased"].name == "lowercased"
+
+
+def test_hamilton_graph_filter_nodes():
+    dr = driver.Builder().with_modules(test_nodes).build()
+    h_graph = graph_types.HamiltonGraph.from_graph(dr.graph)
+
+    # could be a lambda but flake8 doesn't like it.
+    def filter_cache_equal_str(n: graph_types.HamiltonNode) -> bool:
+        return n.tags.get("cache") == "str"
+
+    node_selection = h_graph.filter_nodes(filter)
+    node_names = [n.name for n in node_selection]
+
+    assert len(node_selection) == 2
+    assert "lowercased" in node_names
+    assert "uppercased" in node_names
+
+
 def test_json_serializable_dict():
     for name, obj in inspect.getmembers(test_nodes):
         if inspect.isfunction(obj) and not name.startswith("_"):

--- a/tests/test_graph_types.py
+++ b/tests/test_graph_types.py
@@ -176,7 +176,7 @@ def test_hamilton_graph_filter_nodes():
     def filter_cache_equal_str(n: graph_types.HamiltonNode) -> bool:
         return n.tags.get("cache") == "str"
 
-    node_selection = h_graph.filter_nodes(filter)
+    node_selection = h_graph.filter_nodes(filter=filter_cache_equal_str)
     node_names = [n.name for n in node_selection]
 
     assert len(node_selection) == 2


### PR DESCRIPTION
## Context
The `graph_types.HamiltonGraph` and `graph_types.HamiltonNode` are the public facing interfaces for the `graph.FunctionGraph` and `node.Node`. `HamiltonNode` should be accessed through a `HamiltonGraph` and not be constructed directly. 

## Motivation
The most common operations on the `HamiltonGraph` is selecting a single node or filtering them by a criteria. However, they're are no API for that, meaning some list comprehension or `filter()` are often implemented in the library code but also in the user's code. This motivated the implementation `__getitem()__` and `filter_nodes()` 

## Changes
`HamiltonGraph.__getitem()__ ` allows to get a node using it's name as key (we know the node name is unique). It does a simple dictionary lookup.
```python
HamiltonGraph(...)["my_node"] == HamiltonNode(name="my_node", ...)
```

`HamiltonGraph.filter_nodes()` receives  a `filter` argument which is a Callable that takes in a `HamiltonNode` and returns a boolean. That provides a lot of flexibility to be able to filter by name, type, tags, or any other attributes.

## Other changes
Took the opportunity to implement a one line change for #865

## How I tested this
- added tests for new functionalities
- all old tests are passing

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
