### PR TITLE
`fix` arg name conflict positional `module_name` and named `module_name`

### DIFF
--- a/hamilton/plugins/jupyter_magic.py
+++ b/hamilton/plugins/jupyter_magic.py
@@ -212,7 +212,7 @@ class HamiltonMagics(Magics):
         return config
 
     @magic_arguments()  # needed on top to enable parsing
-    @argument("module_name", nargs="?", help="Name for the module defined in this cell.")
+    @argument("name", nargs="?", help="Name for the module defined in this cell.")
     @argument(
         "-m",
         "--module_name",
@@ -311,8 +311,15 @@ class HamiltonMagics(Magics):
         if config is False:
             return
 
-        # resolve the values of args
-        module_name = args.module_name
+        # check if string instance because module_name has default `True`
+        if isinstance(args.name, str) and isinstance(args.module_name, str):
+            print(
+                f"ValueError: Received both positional arg name={args.name} and named arg module_name={args.module_name}. Pass either one."
+            )
+            return
+
+        # merged the positional arg `name` with named arg `module_name` for backwards compatibility
+        module_name = args.module_name if isinstance(args.module_name, str) else args.name
         base_builder = self.shell.user_ns[args.builder] if args.builder else driver.Builder()
         inputs = self.shell.user_ns[args.inputs] if args.inputs else {}
         overrides = self.shell.user_ns[args.overrides] if args.overrides else {}


### PR DESCRIPTION

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/84b91926-f3ed-4746-b45c-47db86c533ce)

## Changes
- renamed the positional arg `module_name` to `name`. There should be no conflict since it's positional and therefore not "invoked by name"

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
