### PR TITLE
Enables inputs to be also outputs; Fixes #936

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -156,6 +156,8 @@ class DefaultGraphExecutor(GraphExecutor):
         nodes = [fg.nodes[node_name] for node_name in final_vars if node_name in fg.nodes]
         fg.execute(nodes, memoized_computation, overrides, inputs, run_id=run_id)
         outputs = {
+            # we do this here to enable inputs to also be used as outputs
+            # putting inputs into memoized before execution doesn't work due to some graphadapter assumptions.
             final_var: memoized_computation.get(final_var, inputs.get(final_var))
             for final_var in final_vars
         }  # only want request variables in df.

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -153,10 +153,11 @@ class DefaultGraphExecutor(GraphExecutor):
         """Basic executor for a function graph. Does no task-based execution, just does a DFS
         and executes the graph in order, in memory."""
         memoized_computation = dict()  # memoized storage
-        nodes = [fg.nodes[node_name] for node_name in final_vars]
+        nodes = [fg.nodes[node_name] for node_name in final_vars if node_name in fg.nodes]
         fg.execute(nodes, memoized_computation, overrides, inputs, run_id=run_id)
         outputs = {
-            final_var: memoized_computation[final_var] for final_var in final_vars
+            final_var: memoized_computation.get(final_var, inputs.get(final_var))
+            for final_var in final_vars
         }  # only want request variables in df.
         del memoized_computation  # trying to cleanup some memory
         return outputs

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -1035,6 +1035,8 @@ class FunctionGraph:
         missing_vars = []
         for var in starting_nodes:
             if var not in self.nodes and var not in self.config:
+                # checking for runtime_inputs because it's not in the graph isn't really a graph concern. So perhaps we
+                # should move this outside of the graph in the future. This will do fine for now.
                 if var not in runtime_inputs:
                     # if it's not in the runtime inputs, it's a properly missing variable
                     missing_vars.append(var)

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -981,7 +981,9 @@ class FunctionGraph:
                 deps.append(dep)
             return deps
 
-        return self.directional_dfs_traverse(next_nodes_function, starting_nodes=final_vars)
+        return self.directional_dfs_traverse(
+            next_nodes_function, starting_nodes=final_vars, runtime_inputs=runtime_inputs
+        )
 
     def nodes_between(self, start: str, end: str) -> Set[node.Node]:
         """Given our function graph, and a list of desired output variables, returns the subgraph
@@ -1006,15 +1008,19 @@ class FunctionGraph:
         self,
         next_nodes_fn: Callable[[node.Node], Collection[node.Node]],
         starting_nodes: List[str],
+        runtime_inputs: Dict[str, Any] = None,
     ):
         """Traverses the DAG directionally using a DFS.
 
         :param next_nodes_fn: Function to give the next set of nodes
         :param starting_nodes: Which nodes to start at.
+        :param runtime_inputs: runtime inputs to the DAG. This is here to allow for inputs to be also outputs.
         :return: a tuple of sets:
             - set of all nodes.
             - subset of nodes that human input is required for.
         """
+        if runtime_inputs is None:
+            runtime_inputs = {}
         nodes = set()
         user_nodes = set()
 
@@ -1029,7 +1035,9 @@ class FunctionGraph:
         missing_vars = []
         for var in starting_nodes:
             if var not in self.nodes and var not in self.config:
-                missing_vars.append(var)
+                if var not in runtime_inputs:
+                    # if it's not in the runtime inputs, it's a properly missing variable
+                    missing_vars.append(var)
                 continue  # collect all missing final variables
             dfs_traverse(self.nodes[var])
         if missing_vars:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -464,6 +464,9 @@ def test_driver_extra_inputs_can_be_outputs():
     actual = dr.execute(["d", "e"], inputs={"a": 1, "e": 10})
     assert actual["d"] == 4
     assert actual["e"] == 10
+    # validates validate functions
+    dr.validate_execution(["d", "e"], inputs={"a": 1, "e": 10})
+    dr.validate_materialization(additional_vars=["d", "e"], inputs={"a": 1, "e": 10})
     # Checks dataframe use case
     dr = (
         driver.Builder()


### PR DESCRIPTION
This enables one to pass in inputs and request them as outputs independent of the graph.

The use case here is that you want to join some data at the end that is extra and not in the DAG. E.g. extra pandas data.

I skip the visualization parts because this is an odd case.

This was easier than expected because the new executor already uses inputs as outputs... So really only had to modify the old code path. 

## Changes
 - modifies dfs function to check inputs if node isn't in graph or config.

## How I tested this
 - locally via unit tests

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
