### PR TITLE
Adds project ID to projects page

### DIFF
--- a/ui/frontend/src/components/dashboard/Project/Projects.tsx
+++ b/ui/frontend/src/components/dashboard/Project/Projects.tsx
@@ -818,7 +818,7 @@ export const ProjectsView = () => {
           item,
         ])}
         columns={projectCols}
-        dataTypeName=""
+        dataTypeName="Project ID"
         extraRowData={{
           shouldRender: (project: ProjectWithData) =>
             project.id === expandedProject,


### PR DESCRIPTION
This was not displayed before. It is now
more obvious to a user what is the project ID.

![Screen Shot 2024-06-13 at 12 26 52 AM](https://github.com/DAGWorks-Inc/hamilton/assets/2328071/f81b6571-9697-40ee-9a60-b64ca765d615)


## Changes
 - projects.tsx

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
