### PR TITLE
Adds ability to provide same validator N times

### DIFF
--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -142,8 +142,8 @@ The ``@check_output`` function modifiers are applied on the **node output / func
 
     In the future, validatation capabailities may be added to ``@schema``. For now, it's only added metadata.
 
-@check_output
-~~~~~~~~~~~~~
+@check_output*
+~~~~~~~~~~~~~~
 
 The ``@check_output`` implements many data checks for Python objects and DataFrame/Series including data type, min/max/between, count, fraction of null/nan values, and allow null/nan. Failed checks are either logged (``importance="warn"``) or make the dataflow fail (``importance="fail"``).
 
@@ -162,6 +162,7 @@ The next snippet checks if the returned Series is of type ``np.int32``, which is
 
 - To see all available validators, go to the file ``hamilton/data_quality/default_validators.py`` and view the variable ``AVAILABLE_DEFAULT_VALIDATORS``.
 - The function modifier ``@check_output_custom`` allows you to define your own validator. Validators inherit the ``base.BaseDefaultValidator`` class and are essentially standardized Hamilton node definitions (instead of functions). See ``hamilton/data_quality/default_validators.py`` or reach out on `Slack <https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg>`_ for help!
+- Note: ``@check_output_custom`` decorators cannot be stacked, but they instead can take multiple validators.
 
 .. note::
 

--- a/hamilton/function_modifiers/validation.py
+++ b/hamilton/function_modifiers/validation.py
@@ -1,4 +1,5 @@
 import abc
+from collections import defaultdict
 from typing import Any, Callable, Collection, Dict, List, Type
 
 from hamilton import node
@@ -38,6 +39,7 @@ class BaseDataValidationDecorator(base.NodeTransformer):
         validators = self.get_validators(node_)
         validator_nodes = []
         validator_name_map = {}
+        validator_name_count = defaultdict(int)
         for validator in validators:
 
             def validation_function(validator_to_call: dq_base.DataValidator = validator, **kwargs):
@@ -45,6 +47,13 @@ class BaseDataValidationDecorator(base.NodeTransformer):
                 return validator_to_call.validate(result)
 
             validator_node_name = node_.name + "_" + validator.name()
+            validator_name_count[validator_node_name] = (
+                validator_name_count[validator_node_name] + 1
+            )
+            if validator_name_count[validator_node_name] > 1:
+                validator_node_name = (
+                    validator_node_name + "_" + str(validator_name_count[validator_node_name] - 1)
+                )
             validator_node = node.Node(
                 name=validator_node_name,  # TODO -- determine a good approach towards naming this
                 typ=dq_base.ValidationResult,

--- a/hamilton/function_modifiers/validation.py
+++ b/hamilton/function_modifiers/validation.py
@@ -134,6 +134,10 @@ class check_output_custom(BaseDataValidationDecorator):
             4. **Collection[str]**: This will check all nodes specified in the list.
 
             In all likelihood, you *don't* want ``...``, but the others are useful.
+
+            Note: you cannot stack `@check_output_custom` decorators. If you want to use multiple custom validators, \
+            you should pass them all in as arguments to a single `@check_output_custom` decorator.
+
         """
         super(check_output_custom, self).__init__(target=target_)
         self.validators = list(validators)


### PR DESCRIPTION
Fixes #950 by allowing multiple validators with the same name.

## Changes
 - validators

## How I tested this
 - locally via unit tests

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
