### PR TITLE
Fixes issues in which foreign key IDs were not displayed in the UI (+ a few others)

### DIFF
--- a/examples/hamilton_ui/run.py
+++ b/examples/hamilton_ui/run.py
@@ -11,11 +11,11 @@ from hamilton.lifecycle import PrintLnHook
 @click.option(
     "--load-from-parquet", is_flag=True, help="Load from saved parquet or load fresh dataset."
 )
-@click.option("--email", help="Email for the Hamilton UI", type=str, required=True)
+@click.option("--username", help="Email for the Hamilton UI", type=str, required=True)
 @click.option(
     "--project-id", help="Project ID to log to for the Hamilton UI", type=int, required=True
 )
-def run(load_from_parquet: bool, email: str, project_id: int):
+def run(load_from_parquet: bool, username: str, project_id: int):
     """
     Runs the machine_learning hamilton DAG emitting metadata to the Hamilton UI.
 
@@ -34,7 +34,7 @@ def run(load_from_parquet: bool, email: str, project_id: int):
 
     # create tracker object
     tracker = adapters.HamiltonTracker(
-        username=email,
+        username=username,
         project_id=project_id,
         dag_name=dag_name,
         tags={

--- a/ui/backend/server/commands.py
+++ b/ui/backend/server/commands.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import threading
@@ -8,6 +9,8 @@ from contextlib import contextmanager
 import hamilton_ui
 import requests
 from django.core.management import execute_from_command_line
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -73,6 +76,15 @@ def run(port: int, base_dir: str, no_migration: bool, no_open: bool):
         thread.start()
     with set_env_variables(env):
         with extend_sys_path(hamilton_ui.__path__[0]):
+            # This is here as some folks didn't have it created automatically through django
+            if not os.path.exists(base_dir):
+                try:
+                    os.makedirs(os.path.join(base_dir, "blobs"))
+                    os.makedirs(os.path.join(base_dir, "db"))
+                except Exception as e:
+                    logger.exception(
+                        f"Error creating directories -- manually create them instead: {e}"
+                    )
             if not no_migration:
                 execute_from_command_line(
                     ["manage.py", "migrate", "--settings=server.settings_mini"]

--- a/ui/backend/server/trackingserver_run_tracking/schema.py
+++ b/ui/backend/server/trackingserver_run_tracking/schema.py
@@ -21,12 +21,13 @@ class DAGRunUpdate(Schema):
 
 
 class DAGRunOut(ModelSchema):
+    dag_template_id: int
+
     class Meta:
         model = DAGRun
         fields = "__all__"
 
     username_resolved: Optional[str] = None
-    dag_template_id: int
 
     @classmethod
     def create_with_username(cls, orm_model: DAGRun) -> "DAGRunOut":
@@ -62,6 +63,8 @@ class NodeRunAttributeIn(ModelSchema):
 
 
 class NodeRunAttributeOut(ModelSchema):
+    dag_run_id: int
+
     class Meta:
         model = NodeRunAttribute
         fields = "__all__"

--- a/ui/backend/server/trackingserver_template/api.py
+++ b/ui/backend/server/trackingserver_template/api.py
@@ -298,6 +298,10 @@ async def get_dag_template_catalog(
     node_templates = [
         NodeTemplateOut.from_orm(node_template) for node_template in all_node_templates
     ]
+    for i, node_template in enumerate(node_templates):
+        node_template.dag_template = all_node_templates[i].dag_template_id
+    # node_templates = []
+    # dag_template = node_template.dag_template_id
     code_artifacts = list(
         {
             code_artifact
@@ -306,7 +310,7 @@ async def get_dag_template_catalog(
         }
     )
     out = CatalogResponse(
-        nodes=node_templates,
+        nodes=node_templates[:],
         code_artifacts=code_artifacts,
     )
     logger.info(

--- a/ui/backend/server/trackingserver_template/api.py
+++ b/ui/backend/server/trackingserver_template/api.py
@@ -300,8 +300,6 @@ async def get_dag_template_catalog(
     ]
     for i, node_template in enumerate(node_templates):
         node_template.dag_template = all_node_templates[i].dag_template_id
-    # node_templates = []
-    # dag_template = node_template.dag_template_id
     code_artifacts = list(
         {
             code_artifact

--- a/ui/backend/server/trackingserver_template/schema.py
+++ b/ui/backend/server/trackingserver_template/schema.py
@@ -22,12 +22,19 @@ class NodeTemplateIn(ModelSchema):
 
 
 class NodeTemplateOut(ModelSchema):
+    dag_template_id: int
+
     class Meta:
         model = NodeTemplate
         fields = "__all__"
-        # exclude =
 
     primary_code_artifact: Optional[str] = None
+
+    # @classmethod
+    # def from_orm(cls, obj: Any, **kw: Any) -> "NodeTemplateOut":
+    #     out = super().from_orm(obj, **kw)
+    #     out.dag_template_id = obj.dag_template_id
+    #     return out
 
 
 class File(Schema):

--- a/ui/backend/server/trackingserver_template/schema.py
+++ b/ui/backend/server/trackingserver_template/schema.py
@@ -30,12 +30,6 @@ class NodeTemplateOut(ModelSchema):
 
     primary_code_artifact: Optional[str] = None
 
-    # @classmethod
-    # def from_orm(cls, obj: Any, **kw: Any) -> "NodeTemplateOut":
-    #     out = super().from_orm(obj, **kw)
-    #     out.dag_template_id = obj.dag_template_id
-    #     return out
-
 
 class File(Schema):
     path: str

--- a/ui/backend/setup.py
+++ b/ui/backend/setup.py
@@ -18,7 +18,7 @@ def load_requirements():
 
 setup(
     name="sf-hamilton-ui",  # there's already a hamilton in pypi
-    version="0.0.5",
+    version="0.0.6",
     description="Hamilton, the micro-framework for creating dataframes.",
     long_description="""Hamilton tracking server, see [the docs for more](https://github.com/dagworks-inc/hamilton/tree/main/ui/)""",
     long_description_content_type="text/markdown",

--- a/ui/frontend/openapi-config.json
+++ b/ui/frontend/openapi-config.json
@@ -1,5 +1,5 @@
 {
-  "schemaFile": "http://127.0.0.1:8000/api/openapi.json",
+  "schemaFile": "http://127.0.0.1:8241/api/openapi.json",
   "apiFile": "./src/state/api/emptyApi.ts",
   "apiImport": "emptySplitApi",
   "outputFile": "./src/state/api/backendApiRaw.ts",

--- a/ui/frontend/src/components/dashboard/Runs/RunSummary.tsx
+++ b/ui/frontend/src/components/dashboard/Runs/RunSummary.tsx
@@ -219,8 +219,8 @@ function serialize(query: Query): URLSearchParams {
 
 function deserialize(
   searchParams: URLSearchParams,
-  minDate: Date,
-  maxDate: Date
+  minDate: Date | null,
+  maxDate: Date | null
 ): Query {
   const selectedTags = searchParams.get("selectedTags");
   const startDate = searchParams.get("startDate");
@@ -652,14 +652,24 @@ export const RunSummary = (props: {
       run.run_start_time ? new Date(run.run_start_time) : new Date(Date.now())
     )
     .sort((a, b) => a.getTime() - b.getTime());
-  const minDate = new Date(runsSortedByStartDate[0]);
-  const maxDate = new Date(
-    runsSortedByStartDate[runsSortedByStartDate.length - 1]
-  );
+  const minDate =
+    runsSortedByStartDate.length > 0
+      ? new Date(runsSortedByStartDate[0])
+      : null;
+  const maxDate =
+    runsSortedByStartDate.length > 0
+      ? new Date(runsSortedByStartDate[runsSortedByStartDate.length - 1])
+      : null;
 
   // Quick buffer to ensure no runs are missed
-  minDate.setDate(minDate.getDate() - 1);
-  maxDate.setDate(maxDate.getDate() + 1);
+  console.log("minDate", minDate);
+  console.log("maxDate", maxDate);
+  if (minDate !== null) {
+    minDate.setDate(minDate.getDate() - 1);
+  }
+  if (maxDate !== null) {
+    maxDate.setDate(maxDate.getDate() + 1);
+  }
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [query, setQuery] = useState(() =>

--- a/ui/frontend/src/state/api/backendApiRaw.ts
+++ b/ui/frontend/src/state/api/backendApiRaw.ts
@@ -19,6 +19,12 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: () => ({ url: `/api/v1/metadata/node_metadata/schema` }),
     }),
+    trackingserverBaseApiHealthCheck: build.query<
+      TrackingserverBaseApiHealthCheckApiResponse,
+      TrackingserverBaseApiHealthCheckApiArg
+    >({
+      query: () => ({ url: `/api/v1/health` }),
+    }),
     trackingserverAuthApiPhoneHome: build.query<
       TrackingserverAuthApiPhoneHomeApiResponse,
       TrackingserverAuthApiPhoneHomeApiArg
@@ -260,6 +266,9 @@ export type TrackingserverBaseApiGetCodeVersionTypesApiArg = void;
 export type TrackingserverBaseApiGetNodeMetadataTypesApiResponse =
   /** status 200 OK */ AllNodeMetadataTypes;
 export type TrackingserverBaseApiGetNodeMetadataTypesApiArg = void;
+export type TrackingserverBaseApiHealthCheckApiResponse =
+  /** status 200 OK */ boolean;
+export type TrackingserverBaseApiHealthCheckApiArg = void;
 export type TrackingserverAuthApiPhoneHomeApiResponse =
   /** status 200 OK */ PhoneHomeResult;
 export type TrackingserverAuthApiPhoneHomeApiArg = void;
@@ -587,10 +596,10 @@ export type ProjectOut = {
   updated_at: string;
 };
 export type Visibility = {
-  user_ids_visible: (number | string)[];
+  user_ids_visible: (string | number)[];
   team_ids_visible: number[];
   team_ids_writable: number[];
-  user_ids_writable: (number | string)[];
+  user_ids_writable: (string | number)[];
 };
 export type ProjectAttributeIn = {
   name: string;
@@ -700,6 +709,7 @@ export type DagTemplateIn = {
   code_version_info_schema?: number | null;
 };
 export type NodeTemplateOut = {
+  dag_template_id: number;
   primary_code_artifact?: string | null;
   id?: number | null;
   created_at: string;
@@ -760,8 +770,8 @@ export type DagTemplateUpdate = {
   is_active?: boolean;
 };
 export type DagRunOut = {
-  username_resolved?: string | null;
   dag_template_id: number;
+  username_resolved?: string | null;
   id?: number | null;
   created_at: string;
   updated_at: string;
@@ -784,6 +794,7 @@ export type DagRunIn = {
   outputs: any[];
 };
 export type NodeRunAttributeOut = {
+  dag_run_id: number;
   id?: number | null;
   created_at: string;
   updated_at: string;
@@ -810,8 +821,8 @@ export type NodeRunOutWithAttributes = {
   dag_run_id: number;
 };
 export type DagRunOutWithData = {
-  username_resolved?: string | null;
   dag_template_id: number;
+  username_resolved?: string | null;
   id?: number | null;
   created_at: string;
   updated_at: string;
@@ -873,6 +884,7 @@ export const {
   useTrackingserverBaseApiGetAttributesTypeQuery,
   useTrackingserverBaseApiGetCodeVersionTypesQuery,
   useTrackingserverBaseApiGetNodeMetadataTypesQuery,
+  useTrackingserverBaseApiHealthCheckQuery,
   useTrackingserverAuthApiPhoneHomeQuery,
   useTrackingserverAuthApiWhoamiQuery,
   useTrackingserverAuthApiCreateApiKeyMutation,


### PR DESCRIPTION
This is a bit ugly -- we're still identifying the underlying cause, but it turns out that in the SQL orm interaction with django ninja, foreign keys will not show up as IDs.

If you have foreign_key_id: int in the model it'll work. So adding this in fixed it.
