### PR TITLE
fixed <figcaption>

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To create a DAG, write regular Python functions that specify their dependencies 
   <img src="./docs/_static/abc_highlight.png" alt="Create a project" width="65%"/>
 </div>
 <div align="center">
-   Functions <code>B()</code> and <code>C()</code> refer to function <code>A</code> in their parameters
+   Functions <code>B()</code> and <code>C()</code> refer to function <code>A</code> via their parameters
 </div>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ To create a DAG, write regular Python functions that specify their dependencies 
 
 <div align="center">
   <img src="./docs/_static/abc_highlight.png" alt="Create a project" width="65%"/>
-  <figcaption>Functions <code>B()</code> and <code>C()</code> refer to function <code>A</code> in their parameters</figcaption>
+</div>
+<div align="center">
+   <em>Functions <code>B()</code> and <code>C()</code> refer to function <code>A</code> in their parameters</em>
 </div>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To create a DAG, write regular Python functions that specify their dependencies 
   <img src="./docs/_static/abc_highlight.png" alt="Create a project" width="65%"/>
 </div>
 <div align="center">
-   <em>Functions <code>B()</code> and <code>C()</code> refer to function <code>A</code> in their parameters</em>
+   Functions <code>B()</code> and <code>C()</code> refer to function <code>A</code> in their parameters
 </div>
 <br>
 


### PR DESCRIPTION
Apparently, GitHub markdown doesn't like `<figcaption>`

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/5b38ab0d-a39a-47ed-aa47-8a658e943313)