### PR TITLE
ui/fix: open link in new tab

### DIFF
--- a/ui/frontend/src/components/dashboard/Dashboard.tsx
+++ b/ui/frontend/src/components/dashboard/Dashboard.tsx
@@ -213,7 +213,7 @@ const MiniSideBar = (props: {
           aria-hidden="true"
           title="Search"
         />
-        <a href="https://hamilton.dagworks.io/en/latest/concepts/ui">
+        <a href="https://hamilton.dagworks.io/en/latest/concepts/ui" target="_blank" rel="noopener noreferrer">
           <QuestionMarkCircleIcon
             className={classNames(
               "text-gray-300 hover:bg-gray-700 hover:text-white hover:cursor-pointer rounded-md",


### PR DESCRIPTION
Clicking this button used to open the link in the current tab. Now it opens a new tab. 

The `rel` statement in the HTML relates to our current constraints in React, but it appears an older security measure ([ref](https://stackoverflow.com/a/50709724))

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/6fd6f954-20f5-4d8c-849a-b503d7bab671)