### PR TITLE
added tests for databackends and schema adapter

### DIFF
--- a/hamilton/experimental/h_databackends.py
+++ b/hamilton/experimental/h_databackends.py
@@ -28,7 +28,7 @@ polars_extension.py`, etc.
 
 import importlib
 import inspect
-from typing import Tuple, Type, Union
+from typing import Tuple
 
 from hamilton.experimental.databackend import AbstractBackend
 
@@ -128,7 +128,7 @@ class AbstractModinDataFrame(AbstractBackend):
     _backends = [("modin.pandas", "DataFrame")]
 
 
-def register_backends() -> Tuple[Type, Type]:
+def register_backends() -> Tuple[Tuple[type], Tuple[type]]:
     """Register databackends defined in this module that
     include `DataFrame` and `Column` in their class name
     """
@@ -143,8 +143,8 @@ def register_backends() -> Tuple[Type, Type]:
             abstract_column_types.add(cls)
 
     # Union[tuple()] creates a Union type object
-    DATAFRAME_TYPES = Union[tuple(abstract_dataframe_types)]
-    COLUMN_TYPES = Union[tuple(abstract_column_types)]
+    DATAFRAME_TYPES = tuple(abstract_dataframe_types)
+    COLUMN_TYPES = tuple(abstract_column_types)
     return DATAFRAME_TYPES, COLUMN_TYPES
 
 

--- a/hamilton/plugins/h_schema.py
+++ b/hamilton/plugins/h_schema.py
@@ -278,7 +278,9 @@ def _(df: h_databackends.AbstractIbisDataFrame, **kwargs) -> pyarrow.Schema:
 # ongoing polars discussion: https://github.com/pola-rs/polars/issues/15600
 
 
-def get_dataframe_schema(df: h_databackends.DATAFRAME_TYPES, node: HamiltonNode) -> pyarrow.Schema:
+def get_dataframe_schema(
+    df: Union[h_databackends.DATAFRAME_TYPES], node: HamiltonNode
+) -> pyarrow.Schema:
     """Get pyarrow schema of a node result and store node metadata on the pyarrow schema."""
     schema = _get_arrow_schema(df)
     metadata = dict(

--- a/tests/experimental/test_h_databackends.py
+++ b/tests/experimental/test_h_databackends.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from hamilton.experimental import h_databackends
+
+
+def test_isinstance_dataframe():
+    value = pd.DataFrame()
+    assert isinstance(value, h_databackends.DATAFRAME_TYPES)
+
+
+def test_issubclass_dataframe():
+    class_ = pd.DataFrame
+    assert issubclass(class_, h_databackends.DATAFRAME_TYPES)
+
+
+def test_not_isinstance_dataframe():
+    value = 6
+    assert not isinstance(value, h_databackends.DATAFRAME_TYPES)
+
+
+def test_not_issubclass_dataframe():
+    class_ = int
+    assert not issubclass(class_, h_databackends.DATAFRAME_TYPES)
+
+
+def test_isinstance_column():
+    value = pd.Series()
+    assert isinstance(value, h_databackends.COLUMN_TYPES)
+
+
+def test_issubclass_column():
+    class_ = pd.Series
+    assert issubclass(class_, h_databackends.COLUMN_TYPES)
+
+
+def test_not_isinstance_column():
+    value = 6
+    assert not isinstance(value, h_databackends.COLUMN_TYPES)
+
+
+def test_not_issubclass_column():
+    class_ = int
+    assert not issubclass(class_, h_databackends.COLUMN_TYPES)


### PR DESCRIPTION
Fixed a bug for `experimental.h_databackends` and the use of `isinstance()` in `Union[]` types.

Also, added tests for the `SchemaValidator()` adapter