### PR TITLE
Fixed typo in NodeFilter type alias in hamilton/lifecycle/default.py

### DIFF
--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -17,8 +17,9 @@ from hamilton.lifecycle import GraphExecutionHook, NodeExecutionHook, NodeExecut
 logger = logging.getLogger(__name__)
 
 NodeFilter = Union[
-    Callable[[str], Dict[str, Any]],
-    bool,  # filter function for nodes, mapping node name to a boolean
+    Callable[
+        [str, Dict[str, Any]], bool
+    ],  # filter function for nodes, mapping node name to a boolean
     List[str],  # list of node names to run
     str,  # node name to run
     None,  # run all nodes


### PR DESCRIPTION
Noticed a typo in the `NodeFilter` type alias in hamilton/lifecycle/default.py and fixed it.
I then ran pre-commit on it to format it with black.

## Note

Tests did not pass, because numpy 2.0 threw a lot of errors (perhaps version should be constrained to <2.0). Even with numpy<2.0 there were still dependencies missing, so I ignored test results, as the changes just affect typing.

## Checklist

- [x ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ x] Changes are limited to a single goal (no scope creep)
- [ x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
