### PR TITLE
`ui` sklearn attr

### DIFF
--- a/ui/frontend/src/components/dashboard/Runs/Task/result-summaries/DataObservability.tsx
+++ b/ui/frontend/src/components/dashboard/Runs/Task/result-summaries/DataObservability.tsx
@@ -3,6 +3,7 @@ import {
   AttributeDagworksDescribe3,
   AttributeDict1,
   AttributeDict2,
+  AttributeHTML1,
   AttributePandasDescribe1,
   AttributePrimitive1,
   AttributeUnsupported1,
@@ -18,6 +19,7 @@ import { RunLink } from "../../../../common/CommonLinks";
 import { PandasDescribe1View } from "./PandasDescribe";
 import { Dict1View, Dict2View } from "./DictView";
 import { DAGWorksDescribe3View } from "./DAGWorksDescribe";
+import { HTML1View } from "./HTMLView";
 
 const Primitive1View = (props: {
   taskName: string;
@@ -248,6 +250,21 @@ export const ResultsSummaryView = (props: {
         taskName={props.taskName || ""}
         runIds={dict2Views.map((i) => i.runId)}
         values={dict2Views.map((i) => i.value)}
+      />
+    );
+  }
+
+  const html1Views = getNodeRunAttributes<AttributeHTML1>(
+    props.runAttributes,
+    props.runIds,
+    "AttributeHTML1"
+  );
+  if (html1Views.length > 0) {
+    allViews.push(
+      <HTML1View
+        taskName={props.taskName || ""}
+        runIds={html1Views.map((i) => i.runId)}
+        values={html1Views.map((i) => i.value)}
       />
     );
   }

--- a/ui/frontend/src/components/dashboard/Runs/Task/result-summaries/HTMLView.tsx
+++ b/ui/frontend/src/components/dashboard/Runs/Task/result-summaries/HTMLView.tsx
@@ -1,0 +1,36 @@
+import { AttributeHTML1 } from "../../../../../state/api/friendlyApi";
+import { GenericTable } from "../../../../common/GenericTable";
+
+
+interface HTMLDisplayProps {
+  htmlContent: string;
+}
+
+const HTMLDisplay: React.FC<HTMLDisplayProps> = ({ htmlContent }) => {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
+  );
+};
+
+export const HTML1View = (props: {
+    taskName: string;
+    runIds: number[];
+    values: AttributeHTML1[];
+  }) => {
+    return (
+      <GenericTable
+        data={props.runIds.map((runId, i) => {
+          return [runId.toString(), {props: props.values[i].html}];
+        })}
+        columns={[
+          {
+            displayName: "data",
+            Render: (value) => {
+              return <HTMLDisplay htmlContent={value.props}/>;
+            },
+          },
+        ]}
+        dataTypeName={"run"}
+      ></GenericTable>
+    );
+  };

--- a/ui/frontend/src/state/api/backendApiRaw.ts
+++ b/ui/frontend/src/state/api/backendApiRaw.ts
@@ -521,6 +521,9 @@ export type AttributeDagworksDescribe3 = {
     | DwDescribeV003CategoryColumnStatistics
     | DwDescribeV003StringColumnStatistics;
 };
+export type AttributeHTML1 = {
+  html: string;
+};
 export type AllAttributeTypes = {
   documentation_loom__1: AttributeDocumentationLoom1;
   primitive__1: AttributePrimitive1;
@@ -530,6 +533,7 @@ export type AllAttributeTypes = {
   dict__1: AttributeDict1;
   dict__2: AttributeDict2;
   dagworks_describe__3: AttributeDagworksDescribe3;
+  html__1: AttributeHTML1;
 };
 export type CodeVersionGit1 = {
   git_hash: string;

--- a/ui/frontend/src/state/api/friendlyApi.ts
+++ b/ui/frontend/src/state/api/friendlyApi.ts
@@ -201,6 +201,8 @@ export type AttributeDict2 = AllAttributeTypes["dict__2"];
 export type AttributeDagworksDescribe3 =
   AllAttributeTypes["dagworks_describe__3"];
 
+export type AttributeHTML1 = AllAttributeTypes["html__1"];
+
 export const nodeAttributeTypeMap = {
   AttributePrimitive1: { version: 1, type: "primitive" },
   AttributeUnsupported1: { version: 1, type: "unsupported" },
@@ -209,6 +211,7 @@ export const nodeAttributeTypeMap = {
   AttributeDict1: { version: 1, type: "dict" },
   AttributeDict2: { version: 2, type: "dict" },
   AttributeDagworksDescribe3: { version: 3, type: "dagworks_describe" },
+  AttributeHTML1: {version: 1, type: "html"},
 };
 
 export type DAGWorksDescribeColumn =

--- a/ui/sdk/src/hamilton_sdk/tracking/scikit_learn_stats.py
+++ b/ui/sdk/src/hamilton_sdk/tracking/scikit_learn_stats.py
@@ -1,0 +1,30 @@
+from typing import List
+
+from hamilton_sdk.tracking import stats
+from sklearn.base import BaseEstimator
+
+"""Module that houses functions to compute statistics on numpy objects"""
+
+
+@stats.compute_stats.register(BaseEstimator)
+def get_estimator_html_representation(result, *args, **kwargs) -> List[stats.StatsType]:
+    """
+    ref: https://scikit-learn.org/stable/auto_examples/miscellaneous/plot_display_object_visualization.html
+    """
+    return [
+        {
+            "name": "Parameters",
+            "observability_type": "dict",
+            "observability_value": {
+                "type": str(type(result)),
+                "value": result.get_params(deep=True),
+            },
+            "observability_schema_version": "0.0.2",
+        },
+        {
+            "name": "Components",
+            "observability_type": "html",
+            "observability_value": {"html": result._repr_html_inner()},  # get_params(deep=True),
+            "observability_schema_version": "0.0.1",
+        },
+    ]


### PR DESCRIPTION
Display scikit-learn objects as a dictionary of estimator/model parameters and an HTML widget (produce by scikit-learn). 

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/987708ba-3227-45d5-b791-5b7f4b307f4b)

## Changes
- SDK: Track scikit-learn objects
- SDK: the adapter can handle more than one "stats/result/attribute"
- frontend/backend: HTML attribute type that can be tracked and displayed
- Hit an issue with `compute_stats_dict()` recursive inspection for scikit-learn's function that returns a list rather than a dict

## How I tested this
- manual testing with `examples/hamilton_ui`. Other attributes don't seem broken either.

## Note
- commit history is a bit messy. Needed to use `cherry-pick` to avoid merge conflict with the addition of `pydantic` in the list of supported "attributes"