### PR TITLE
Fix misspelled 'answer' in Graph-RAG example prompt

### DIFF
--- a/examples/LLM_Workflows/GraphRAG/application.py
+++ b/examples/LLM_Workflows/GraphRAG/application.py
@@ -52,7 +52,7 @@ def set_inital_chat_history(schema_prompt: str) -> list[dict]:
     SYSTEM_MESSAGE = "You are a Cypher expert with access to a directed knowledge graph\n"
     SYSTEM_MESSAGE += schema_prompt
     SYSTEM_MESSAGE += (
-        "Query the knowledge graph to extract relevant information to help you anwser the users "
+        "Query the knowledge graph to extract relevant information to help you answer the users "
         "questions, base your answer only on the context retrieved from the knowledge graph, "
         "do not use preexisting knowledge."
     )


### PR DESCRIPTION
# Fix typo in Graph RAG Example OpenAI prompt system message

## Changes

`anwser` -> `answer`

## How I tested this

Visual inspection.

## Notes

Just housekeeping. I seriously doubt there is any performance change, though if you wanted to test for any performance change, it would be a good example of (blog self-promotion alert) how [Prompts just blew up your configuration space (and what to do about it)](https://munichpavel.github.io/2023/06/21/llm-ops-configuration-explosion/)

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
