### PR TITLE
`.with_materializers()` added helpful error message

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -9,6 +9,7 @@ import time
 # required if we want to run this code stand alone.
 import typing
 import uuid
+from collections.abc import Sequence  # typing.Sequence is deprecated in >=3.9
 from datetime import datetime
 from types import ModuleType
 from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, Union
@@ -1756,6 +1757,11 @@ class Builder:
         :param materializers: materializers to add to the dataflow
         :return: self
         """
+        if len(materializers) == 1 and isinstance(materializers[0], Sequence):
+            raise ValueError(
+                "`.with_materializers()` received a sequence. Unpack it by prepending `*` e.g., `*[to.json(...), from_.parquet(...)]`"
+            )
+
         self.materializers.extend(materializers)
         return self
 

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1757,10 +1757,17 @@ class Builder:
         :param materializers: materializers to add to the dataflow
         :return: self
         """
-        if len(materializers) == 1 and isinstance(materializers[0], Sequence):
-            raise ValueError(
-                "`.with_materializers()` received a sequence. Unpack it by prepending `*` e.g., `*[to.json(...), from_.parquet(...)]`"
-            )
+        if any(
+            m for m in materializers if not isinstance(m, (ExtractorFactory, MaterializerFactory))
+        ):
+            if len(materializers) == 1 and isinstance(materializers[0], Sequence):
+                raise ValueError(
+                    "`.with_materializers()` received a sequence. Unpack it by prepending `*` e.g., `*[to.json(...), from_.parquet(...)]`"
+                )
+            else:
+                raise ValueError(
+                    f"`.with_materializers()` only accepts materializers. Received instead: {materializers}"
+                )
 
         self.materializers.extend(materializers)
         return self

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -585,6 +585,31 @@ def test_builder_materializer_and_execution_materializer(tmp_path):
     assert "static_saver" in additional.keys()
 
 
+def test_builder_materializer_error():
+    static_saver = to.json(
+        id="static_saver",
+        dependencies=["json_to_save_1"],
+        path="/file.json",
+    )
+
+    materializers = [static_saver]
+    with pytest.raises(ValueError):
+        (
+            Builder()
+            .with_modules(tests.resources.test_for_materialization)
+            .with_materializers(materializers)
+            .build()
+        )
+
+    # also check that using `*` leads to no issue
+    (
+        Builder()
+        .with_modules(tests.resources.test_for_materialization)
+        .with_materializers(*materializers)
+        .build()
+    )
+
+
 def test_materialize_checks_required_input(tmp_path):
     dr = Builder().with_modules(tests.resources.dummy_functions).build()
 


### PR DESCRIPTION
When first using `.with_materializers()`, it's not obvious that it expects:
```python
.with_materializers(to.json(...), to.parquet(...))
```
Rather than the invalid:
```python
.with_materializers([to.json(...), to.parquet(...)])
```

If encountering the above case, the error will now specify to unpack the sequence with `*`, leading to the valid code
```python
.with_materializers(*[to.json(...), to.parquet(...)])
```

## Changes
- explicitly catch an invalid argument for `.with_materializers()` when building the driver