### PR TITLE
data loaders now display the same as data savers

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -500,6 +500,13 @@ def create_graphviz_graph(
             node_style.update(**modifier_style)
             seen_node_types.add("materializer")
 
+        if n.tags.get("hamilton.data_loader") and "load_data." in n.name:
+            materializer_type = n.tags["hamilton.data_loader.classname"]
+            label = _get_node_label(n, type_string=materializer_type)
+            modifier_style = _get_function_modifier_style("materializer")
+            node_style.update(**modifier_style)
+            seen_node_types.add("materializer")
+
         # apply custom styles before node modifiers
         seen_node_type = None
         if custom_style_function:


### PR DESCRIPTION
Related to issue #988 

What was previously two "function nodes" (`load_data.raw_df`, `raw_df`)

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/40753acc-fb77-49c2-b9f9-62ee31d7c48a)

Are now a materializer and a function node

![image](https://github.com/DAGWorks-Inc/hamilton/assets/68975210/fa01e5ce-7fed-4aa1-afde-cbc8beaa285f)
