### PR TITLE
Adds extra guards for plugin imports

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -49,6 +49,8 @@ if not registry.INITIALIZED:
             logger.debug(f"Did not load {plugin_module} extension because {str(e)}.")
         except ModuleNotFoundError as e:
             logger.debug(f"Did not load {plugin_module} extension because {e.msg}.")
+        except ImportError as e:
+            logger.debug(f"Did not load {plugin_module} extension because {str(e)}.")
     registry.INITIALIZED = True
 
 

--- a/hamilton/plugins/dlt_extensions.py
+++ b/hamilton/plugins/dlt_extensions.py
@@ -1,13 +1,22 @@
 import dataclasses
 from typing import Any, Collection, Dict, Iterable, Literal, Optional, Sequence, Tuple, Type
 
-import dlt
-import pandas as pd
-from dlt.common.destination.capabilities import TLoaderFileFormat
-from dlt.common.schema import Schema, TColumnSchema
+try:
+    import dlt
+    from dlt.common.destination.capabilities import TLoaderFileFormat
+    from dlt.common.schema import Schema, TColumnSchema
 
-# importing TDestinationReferenceArg fails if Destination isn't imported
-from dlt.extract.resource import DltResource
+    # importing TDestinationReferenceArg fails if Destination isn't imported
+    from dlt.extract.resource import DltResource
+
+except ImportError as e:
+    # raise import error first
+    raise ImportError(f"Failed to import the DLT library. {e}")
+except Exception as e:
+    # raise import error with custom message
+    raise ImportError("Failed to import the DLT library.") from e
+
+import pandas as pd
 
 from hamilton import registry
 from hamilton.io import utils


### PR DESCRIPTION
We should probably just blanket catch all errors -- but not doing that right now. Hamilton fails to be imported in a spark serverless environment because there is some interaction with DLT that databricks doesn't like.

So catching more exceptions -- and shoe horning it into an import error.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
