### PR TITLE
Adds configurable hosts for hamilton ui

### DIFF
--- a/ui/backend/server/server/settings_mini.py
+++ b/ui/backend/server/server/settings_mini.py
@@ -1,5 +1,9 @@
+import logging
 import os
+import socket
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def get_from_env(
@@ -34,7 +38,19 @@ SECRET_KEY = "test_do_not_use_in_production"
 
 HAMILTON_AUTH_MODE = "permissive"
 
-ALLOWED_HOSTS = ["localhost", "backend", "0.0.0.0", "127.0.0.1"]
+# set up allowed hosts
+try:
+    hostname = socket.gethostname()
+    local_ip = socket.gethostbyname(hostname)
+    hosts_to_add = [local_ip, hostname]
+except Exception:
+    logger.warning("Could not get hostname or local IP")
+    hosts_to_add = []
+ALLOWED_HOSTS = ["localhost", "backend", "0.0.0.0", "127.0.0.1", "colab.research.google.com"]
+ALLOWED_HOSTS = (
+    ALLOWED_HOSTS + hosts_to_add + os.environ.get("HAMILTON_ALLOWED_HOSTS", "").split(",")
+)
+logger.debug(f"ALLOWED_HOSTS: {ALLOWED_HOSTS}")
 
 HAMILTON_BLOB_STORE = "local"
 


### PR DESCRIPTION
Settings mini is used by default by the Hamilton UI command. This changes it to enable changing
ALLOWED_HOSTS by passing in some environment variables.

It then automatically adds a few of them, like the current IP, etc.

## Changes
 - settings_mini.py

## How I tested this
 - locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
