### PR TITLE
Adds spark input type validator

### DIFF
--- a/docs/reference/lifecycle-hooks/SparkInputValidator.rst
+++ b/docs/reference/lifecycle-hooks/SparkInputValidator.rst
@@ -1,0 +1,9 @@
+===================================
+plugins.h_spark.SparkInputValidator
+===================================
+
+
+.. autoclass:: hamilton.plugins.h_spark.SparkInputValidator
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/index.rst
+++ b/docs/reference/lifecycle-hooks/index.rst
@@ -55,3 +55,4 @@ Recall to add lifecycle adapters, you just need to call the ``with_adapters`` me
     FunctionInputOutputTypeChecker
     SlackNotifierHook
     GracefulErrorAdapter
+    SparkInputValidator

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -18,3 +18,16 @@ See the example in `pyspark_udfs`.
 
 Note: we're looking to expand coverage and support for more Spark use cases. Please come find us, or open an issue,
 if you have a use case that you'd like to see supported!
+
+## Caveats
+
+Hamilton's type-checking doesn't inherently work with spark connect, which can swap out different types of dataframes that
+are not part of the same subclass. Thus when you are passing in a spark session or spark dataframe as an input,
+you can use the `SparkInputValidator` (available by instantiation or access of the static field `h_spark.SPARK_INPUT_CHECK`).
+
+```python
+from hamilton import driver
+from hamilton.plugins import h_spark
+
+dr = driver.Builder().with_modules(...).with_adapters(h_spark.SPARK_INPUT_CHECK).build()
+```

--- a/plugin_tests/h_spark/test_h_spark.py
+++ b/plugin_tests/h_spark/test_h_spark.py
@@ -6,10 +6,13 @@ import pyspark.pandas as ps
 import pytest
 from pyspark import Row
 from pyspark.sql import Column, DataFrame, SparkSession, types
+from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
+from pyspark.sql.connect.session import SparkSession as CSparkSession
 from pyspark.sql.functions import column
 
 from hamilton import base, driver, htypes, node
 from hamilton.plugins import h_spark
+from hamilton.plugins.h_spark import SparkInputValidator
 
 from .resources import example_module, smoke_screen_module
 from .resources.spark import (
@@ -858,4 +861,30 @@ def test_create_selector_node(spark_session):
     transformed = selector_node(foo=df).toPandas()
     pd.testing.assert_frame_equal(
         transformed, pandas_df[["a", "b"]], check_names=False, check_dtype=False
+    )
+
+
+def test_spark_input_adapter_dataframe():
+    # We have to do these at is is very difficult to mock out connect.x objects
+
+    class ConnectDataFrame(CDataFrame):
+        def __init__(self):
+            pass
+
+        def __repr__(self):
+            return "df"
+
+    assert SparkInputValidator().do_validate_input(
+        node_type=DataFrame, input_value=ConnectDataFrame()
+    )
+
+
+def test_spark_input_adapter_connector():
+    # We have to do these at is is very difficult to mock out connect.x objects
+    class ConnectSparkSession(CSparkSession):
+        def __init__(self):
+            pass
+
+    assert SparkInputValidator().do_validate_input(
+        node_type=SparkSession, input_value=ConnectSparkSession()
     )

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,8 @@ setup(
         "ray": ["ray>=2.0.0", "pyarrow"],
         "pyspark": [
             # we have to run these dependencies cause Spark does not check to ensure the right target was called
-            "pyspark[pandas_on_spark,sql]",
+            "pyspark[pandas_on_spark,sql,connect]",
             # This is problematic, see https://stackoverflow.com/questions/76072664/convert-pyspark-dataframe-to-pandas-dataframe-fails-on-timestamp-column
-            "pandas<2.0",
         ],  # I'm sure they'll add support soon,
         # but for now its not compatible
         "pandera": ["pandera"],


### PR DESCRIPTION
Spark chosees between the "connect" and the "classic" sessions -- this makes the type-checker in hamilton unhappy because spark has not set the proper subclass relationships.

Here is why it is necessary
    - https://community.databricks.com/t5/data-engineering/pyspark-sql-connect-dataframe-dataframe-vs-pyspark-sql-dataframe/td-p/71055
    - https://issues.apache.org/jira/browse/SPARK-47909

This provides an adapter + an instance of this adapter for easy use.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
