### PR TITLE
Updates async adapter to handle new process_result

### DIFF
--- a/ui/backend/setup.py
+++ b/ui/backend/setup.py
@@ -18,7 +18,7 @@ def load_requirements():
 
 setup(
     name="sf-hamilton-ui",  # there's already a hamilton in pypi
-    version="0.0.9",
+    version="0.0.10",
     description="Hamilton, the micro-framework for creating dataframes.",
     long_description="""Hamilton tracking server, see [the docs for more](https://github.com/dagworks-inc/hamilton/tree/main/ui/)""",
     long_description_content_type="text/markdown",

--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -254,6 +254,7 @@ class HamiltonTracker(
         logger.debug("post_node_execute %s %s", run_id, task_id)
         task_run: TaskRun = self.task_runs[run_id][node_.name]
         tracking_state = self.tracking_states[run_id]
+        task_run.end_time = datetime.datetime.now(timezone.utc)
 
         other_results = []
         if success:
@@ -326,8 +327,6 @@ class HamiltonTracker(
                 attribute_role="result_summary",
             )
             attributes.append(other_attr)
-
-        task_run.end_time = datetime.datetime.now(timezone.utc)
         tracking_state.update_task(node_.name, task_run)
         task_update = dict(
             node_template_name=node_.name,
@@ -547,10 +546,35 @@ class AsyncHamiltonTracker(
         task_run = self.task_runs[run_id][node_.name]
         tracking_state = self.tracking_states[run_id]
         task_run.end_time = datetime.datetime.now(timezone.utc)
+
+        other_results = []
         if success:
             task_run.status = Status.SUCCESS
             task_run.result_type = type(result)
-            task_run.result_summary = runs.process_result(result, node_)  # add node
+            result_summary = runs.process_result(result, node_)  # add node
+            if result_summary is None:
+                result_summary = {
+                    "observability_type": "observability_failure",
+                    "observability_schema_version": "0.0.3",
+                    "observability_value": {
+                        "type": str(str),
+                        "value": "Failed to process result.",
+                    },
+                }
+            # NOTE This is a temporary hack to make process_result() able to return
+            # more than one object that will be used as UI "task attributes".
+            # There's a conflict between `TaskRun.result_summary` that expect a single
+            # dict from process_result() and the `HamiltonTracker.post_node_execute()`
+            # that can more freely handle "stats" to create multiple "task attributes"
+            elif isinstance(result_summary, dict):
+                result_summary = result_summary
+            elif isinstance(result_summary, list):
+                other_results = [obj for obj in result_summary[1:]]
+                result_summary = result_summary[0]
+            else:
+                raise TypeError("`process_result()` needs to return a dict or sequence of dict")
+
+            task_run.result_summary = result_summary
             task_attr = dict(
                 node_name=get_node_name(node_, task_id),
                 name="result_summary",
@@ -578,6 +602,20 @@ class AsyncHamiltonTracker(
                 },
                 attribute_role="error",
             )
+
+        # `result_summary` or "error" is first because the order influences UI display order
+        attributes = [task_attr]
+        for i, other_result in enumerate(other_results):
+            other_attr = dict(
+                node_name=get_node_name(node_, task_id),
+                name=other_result.get("name", f"Attribute {i + 1}"),  # retrieve name if specified
+                type=other_result["observability_type"],
+                # 0.0.3 -> 3
+                schema_version=int(other_result["observability_schema_version"].split(".")[-1]),
+                value=other_result["observability_value"],
+                attribute_role="result_summary",
+            )
+            attributes.append(other_attr)
         tracking_state.update_task(get_node_name(node_, task_id), task_run)
         task_update = dict(
             node_template_name=node_.name,
@@ -589,9 +627,9 @@ class AsyncHamiltonTracker(
         )
         await self.client.update_tasks(
             self.dw_run_ids[run_id],
-            attributes=[task_attr],
-            task_updates=[task_update],
-            in_samples=[task_run.is_in_sample],
+            attributes=attributes,
+            task_updates=[task_update for _ in attributes],
+            in_samples=[task_run.is_in_sample for _ in attributes],
         )
 
     async def post_graph_execute(


### PR DESCRIPTION
The process result now can return multiple things. So this change ensure the async adapter can
handle that. This mirrors the sync adapter.

## Changes
- AsyncTracker

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
