### PR TITLE
fix: updated imports for polars extension 1.0­.0

### DIFF
--- a/hamilton/plugins/polars_extensions.py
+++ b/hamilton/plugins/polars_extensions.py
@@ -26,7 +26,7 @@ if pl_version < version.Version("1.0.0"):
         f"Current version: {pl_version}, minimum required version: 1.0.0."
     )
 else:
-    from hamilton.plugins.polars_post_1_0_0_extension import register_data_loaders
+    from hamilton.plugins.polars_post_1_0_0_extensions import register_data_loaders
 
 register_data_loaders()
 

--- a/hamilton/plugins/polars_post_1_0_0_extensions.py
+++ b/hamilton/plugins/polars_post_1_0_0_extensions.py
@@ -593,8 +593,8 @@ class PolarsSpreadsheetWriter(DataSaver):
     # importing here because this is where it's used. Can move later.
     # but yeah the polars type aliases weren't resolving well in python 3.9
     # so stripped/reduced them appropriately.
+    from polars._typing import ColumnTotalsDefinition, RowTotalsDefinition
     from polars.datatypes import DataType, DataTypeClass
-    from polars.type_aliases import ColumnTotalsDefinition, RowTotalsDefinition
 
     workbook: Union[Workbook, BytesIO, Path, str]
     worksheet: Union[str, None] = None

--- a/tests/plugins/test_polars_extensions.py
+++ b/tests/plugins/test_polars_extensions.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 import polars as pl  # isort: skip
 import pytest  # isort: skip
 
-from hamilton.plugins.polars_post_1_0_0_extension import (  # isort: skip
+from hamilton.plugins.polars_post_1_0_0_extensions import (  # isort: skip
     PolarsAvroReader,
     PolarsAvroWriter,
     PolarsCSVReader,

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -11,7 +11,7 @@ from hamilton.plugins.polars_lazyframe_extensions import (
     PolarsScanFeatherReader,
     PolarsScanParquetReader,
 )
-from hamilton.plugins.polars_post_1_0_0_extension import (
+from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsAvroReader,
     PolarsAvroWriter,
     PolarsCSVWriter,


### PR DESCRIPTION
Polars upgrading to `>= 1.0.0` introduced breaking changes, in particular going from `polars.typing_aliases` to `polars._typing`.

> venv/lib/python3.11/site-packages/hamilton/plugins/polars_post_1_0_0_extension.py:597: DeprecationWarning: The `polars.type_aliases` module is deprecated. The type aliases have moved to the `polars._typing` module to explicitly mark them as private. Please define your own type aliases, or temporarily import from the `polars._typing` module. A public `polars.typing` module will be added in the future.
    from polars.type_aliases import ColumnTotalsDefinition, RowTotalsDefinition


We made changes accordingly, but missed two imports that were within a materializer definition. The warning is triggered when the materializer is registered during extension loading. This explains why we missed it and it wasn't covered by our tests.

Also, I renamed `polars_post_1_0_0_extension.py` to the plural `polars_post_1_0_0_extensions.py` to match convention.
