### PR TITLE
Add version field to metadata collected from files and dataframes

### DIFF
--- a/hamilton/io/utils.py
+++ b/hamilton/io/utils.py
@@ -47,6 +47,7 @@ def get_file_metadata(path: Union[str, Path, PathLike]) -> Dict[str, Any]:
             "timestamp": timestamp,
             "scheme": scheme,
             "notes": notes,
+            "__version__": "1.0.0",
         }
     }
 
@@ -63,7 +64,7 @@ def get_dataframe_metadata(df: pd.DataFrame) -> Dict[str, Any]:
     - the column names
     - the data types
     """
-    metadata = {}
+    metadata = {"__version__": "1.0.0"}
     try:
         metadata["rows"] = len(df)
     except TypeError:
@@ -133,5 +134,6 @@ def get_sql_metadata(query_or_table: str, results: Union[int, pd.DataFrame]) -> 
             "query": query,
             "table_name": table_name,
             "timestamp": datetime.now().utcnow().timestamp(),
+            "__version__": "1.0.0",
         }
     }

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -133,6 +133,8 @@ def test_pandas_xml_writer(tmp_path: pathlib.Path) -> None:
     assert file_path.exists()
     assert metadata["file_metadata"]["path"] == str(file_path)
     assert metadata["dataframe_metadata"]["column_names"] == ["foo"]
+    assert "__version__" in metadata["file_metadata"]
+    assert "__version__" in metadata["dataframe_metadata"]
 
 
 def test_pandas_html_reader(tmp_path: pathlib.Path) -> None:
@@ -193,6 +195,8 @@ def test_pandas_feather_writer(tmp_path: pathlib.Path) -> None:
     assert file_path.exists()
     assert metadata["file_metadata"]["path"] == str(file_path)
     assert metadata["dataframe_metadata"]["column_names"] == ["col1", "col2"]
+    assert "__version__" in metadata["file_metadata"]
+    assert "__version__" in metadata["dataframe_metadata"]
 
 
 def test_pandas_csv_reader(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
Adds version field to metadata collected for files and dataframes.

Implements https://github.com/DAGWorks-Inc/hamilton/issues/751.

This is to formalize schema at a Hamilton level.

We can always extend this to have someone provide
their own callback function to produce this.

We use the __ syntax to help show that this is internal.

## Changes
io/utils metadata functions.

## How I tested this
 - locally via unit tests

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
