### PR TITLE
Remove print statements when reading/writing cache values.

### DIFF
--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -172,7 +172,6 @@ def read_json_dict(data: dict, filepath: str) -> dict:
 @write_pickle.register(object)
 def write_pickle_object(data: object, filepath: str, name: str) -> None:
     if isinstance(data, object):
-        print(filepath)
         with open(filepath, "wb") as file:
             pickle.dump(data, file)
     else:
@@ -182,7 +181,6 @@ def write_pickle_object(data: object, filepath: str, name: str) -> None:
 @read_pickle.register(object)
 def read_pickle_object(data: object, filepath: str) -> object:
     """Reads a pickle file"""
-    print(filepath)
     with open(filepath, "rb") as file:
         return pickle.load(file)
 


### PR DESCRIPTION
Remove print statements in `write_pickle_object` and `read_pickle_object`.

When running a large pipeline with multiple cached values, it's a lot of unnecessary noise on screen. Also, when using the `ProgressBar` adapter, the print statements interfere with the progress bar.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
