### PR TITLE
Adds NoEdgeAndInputTypeChecking adapter

### DIFF
--- a/docs/reference/lifecycle-hooks/NoEdgeAndInputTypeChecking.rst
+++ b/docs/reference/lifecycle-hooks/NoEdgeAndInputTypeChecking.rst
@@ -1,0 +1,9 @@
+====================================
+lifecycle.NoEdgeAndInputTypeChecking
+====================================
+
+Use this hook turn off edge and input type checking during graph construction and execution
+
+.. autoclass:: hamilton.lifecycle.default.NoEdgeAndInputTypeChecking
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/NoEdgeAndInputTypeChecking.rst
+++ b/docs/reference/lifecycle-hooks/NoEdgeAndInputTypeChecking.rst
@@ -2,7 +2,9 @@
 lifecycle.NoEdgeAndInputTypeChecking
 ====================================
 
-Use this hook turn off edge and input type checking during graph construction and execution
+Use this hook turn off edge and input type checking during graph construction and execution; the only time you'd
+really want this is during some really fast and loose development. Otherwise production use of this
+should be frowned upon.
 
 .. autoclass:: hamilton.lifecycle.default.NoEdgeAndInputTypeChecking
    :members:

--- a/docs/reference/lifecycle-hooks/index.rst
+++ b/docs/reference/lifecycle-hooks/index.rst
@@ -58,3 +58,4 @@ Recall to add lifecycle adapters, you just need to call the ``with_adapters`` me
     SparkInputValidator
     Narwhals
     MLFlowTracker
+    NoEdgeAndInputTypeChecking

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -14,6 +14,7 @@ from .base import LifecycleAdapter  # noqa: F401
 from .default import (  # noqa: F401
     FunctionInputOutputTypeChecker,
     GracefulErrorAdapter,
+    NoEdgeAndInputTypeChecking,
     PDBDebugger,
     PrintLn,
     SlowDownYouMoveTooFast,
@@ -39,4 +40,5 @@ __all__ = [
     "StaticValidator",
     "TaskExecutionHook",
     "FunctionInputOutputTypeChecker",
+    "NoEdgeAndInputTypeChecking",
 ]

--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -12,7 +12,12 @@ from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from hamilton import graph_types, htypes
 from hamilton.graph_types import HamiltonGraph
-from hamilton.lifecycle import GraphExecutionHook, NodeExecutionHook, NodeExecutionMethod
+from hamilton.lifecycle import (
+    EdgeConnectionHook,
+    GraphExecutionHook,
+    NodeExecutionHook,
+    NodeExecutionMethod,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -732,3 +737,34 @@ class GracefulErrorAdapter(NodeExecutionMethod):
             else:
                 results = [self.sentinel_value]
         return results
+
+
+class NoEdgeAndInputTypeChecking(EdgeConnectionHook):
+    """Permissive adapter to help you skip edge and input type checking.
+
+    Useful for development.
+
+    .. code-block:: python
+
+        from hamilton import driver
+        from hamilton.lifecycle import NoEdgeAndInputTypeChecking
+        dr = driver.Builder().with_adapters(NoEdgeAndInputTypeChecking()).build()
+
+        # now driver is built without any type checking
+        dr.execute([...], ...)
+
+    """
+
+    def check_edge_types_match(self, type_from: type, type_to: type, **kwargs: Any) -> bool:
+        """This is run to check if edge types match. Note that this is an OR functionality
+        -- this is run after we do some default checks, so this can only be permissive.
+        Return True - always
+        """
+        return True
+
+    def validate_input(self, node_type: type, input_value: Any, **kwargs: Any) -> bool:
+        """This is run to check if the input is valid for the node type. Note that this is an OR functionality
+        -- this is run after we do some default checks, so this can only be permissive.
+        Returns True - always.
+        """
+        return True

--- a/tests/lifecycle/test_default.py
+++ b/tests/lifecycle/test_default.py
@@ -1,0 +1,22 @@
+import pytest
+
+from hamilton import driver
+from hamilton.lifecycle import default
+
+from tests.resources import mismatched_types
+
+
+def test_noedge_input_type_checking_without_adapter():
+    with pytest.raises(ValueError):
+        driver.Builder().with_modules(mismatched_types).build()
+
+
+def test_noedge_input_type_checking_with_adapter():
+    dr = (
+        driver.Builder()
+        .with_modules(mismatched_types)
+        .with_adapters(default.NoEdgeAndInputTypeChecking())
+        .build()
+    )
+    actual = dr.execute(["baz"], inputs={"a": 1.02, "number": "aaasdfdsf"})
+    assert actual == {"baz": "1.02 2 aaasdfdsf"}

--- a/tests/resources/mismatched_types.py
+++ b/tests/resources/mismatched_types.py
@@ -1,0 +1,10 @@
+def foo(a: int) -> float:
+    return a * 0.5
+
+
+def bar(a: int) -> int:
+    return int(a * 2)
+
+
+def baz(a: int, bar: float, number: str) -> str:
+    return f"{a} {bar} {number}"


### PR DESCRIPTION
 So that people can turn off type checking if they really want to.

This won't necessarily mean you can get away without types -- it just means they don't need to match.

## Changes
 - adds adapter
 - updates docs

## How I tested this
- locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
