### PR TITLE
Update PandasExcelWriter to use pd.ExcelWriter

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -1481,7 +1481,8 @@ class PandasExcelReader(DataLoader):
 @dataclasses.dataclass
 class PandasExcelWriter(DataSaver):
     """Class that handles saving Excel files with pandas.
-    Maps to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html
+    Maps to https://pandas.pydata.org/docs/reference/api/pandas.ExcelWriter.html
+    Additional parameters passed to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html
     """
 
     path: Union[str, Path, BytesIO]


### PR DESCRIPTION
Created to fix issue #946 -- PandasExcelWriter overwrites file 

## Changes
Changes to pandas_extensions.py in PandasExcelWriter to implement the pd.ExcelWriter and add appropriate keyword arguments to support this. 

## How I tested this
Locally via existing unit tests

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] ~~New functions are documented (with a description, list of inputs, and expected output)~~
- [ ] ~~Placeholder code is flagged / future TODOs are captured in comments~~
- [ ] ~~Project documentation has been updated if adding/changing functionality.~~
