### PR TITLE
added environment variable to disable extensions autoload

### DIFF
--- a/docs/how-tos/extensions-autoloading.rst
+++ b/docs/how-tos/extensions-autoloading.rst
@@ -1,0 +1,97 @@
+=====================
+Extension autoloading
+=====================
+
+Under ``hamilton.plugins``, there are many modules named ``*_extensions`` (e.g., ``hamilton.plugins.pandas_extensions``, ``hamilton.plugins.mlflow_extensions``). They implement Hamilton features for 3rd party libraries, including ``@extract_columns``, materializers (``to.parquet``, ``from_.mlflow``), and more.
+
+
+Autoloading behavior
+--------------------
+
+By default, Hamilton attempts to load all extensions one-by-one. This means that as you have more Python packages in your environment (e.g., ``pandas``, ``pyspark``, ``mlflow``, ``xgboost``), importing Hamilton appears to become slower because it actually imports many packages.
+
+This behavior can be less desirable when your Hamilton dataflow doesn't use any of these packages, but you need them in your Python environment nonetheless. For example, if only ``pandas`` is needed for your dataflow, but you have ``mlflow`` and ``xgboost`` in your environment their respective extensions will be loaded each time.
+
+
+Disable autoloading
+--------------------
+
+Disabling extension autoloading allows to import Hamilton without any extensions, which can reduce import time from 2-3 sec to less than 0.5 sec. This speedup is welcomed when you need to restart a notebook's kernel often or you're operating in a low RAM environment (some Python packages are larger than 50Mbs).
+
+There are three ways to opt-out: programmatically, environment variables, configuration file. You must opt-out before having any other ``hamilton`` import.
+
+1. Programmatically
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from hamilton import registry
+    registry.disable_autoload()
+
+2. Environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+From the console
+
+.. code-block:: console
+
+    export HAMILTON_AUTOLOAD_EXTENSIONS=0
+
+Programmatically via Python ``os.environ``.
+
+.. code-block:: python
+
+    import os
+    os.environ["HAMILTON_AUTOLOAD_EXTENSIONS"] = "0"
+
+Programmatically in Jupyter notebooks
+
+.. code-block:: python
+
+    %env HAMILTON_AUTOLOAD_EXTENSIONS=0
+
+3. Configuration file
+~~~~~~~~~~~~~~~~~~~~~
+
+Using the following command disables autoloading via the configuration file ``./hamilton.conf``. Hamilton won't autoload extensions anymore (i.e., you won't need to use approach 1 or 2 each time).
+
+.. code-block:: console
+
+    hamilton-disable-autoload-extensions
+
+To revert this configuration use the following command
+
+.. code-block:: console
+
+    hamilton-enable-autoload-extensions
+
+To reenable autoloading in specific files, you can delete the environment variable or use ``registry.enable_autoload()`` before calling ``registry.initialize()``
+
+.. code-block:: python
+
+    from hamilton import registry
+    registry.enable_autoload()
+    registry.initialize()
+
+
+Manually loading extensions
+----------------------------
+
+If you disabled autoloading, extensions need to be loaded manually. You should load them before having any other ``hamilton`` import to avoid hard-to-track bugs. There are two ways.
+
+1. Importing the extension
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from hamilton.plugins import pandas_extensions, mlflow_extensions
+
+2. Registering the extension
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This approach has good IDE support via ``typing.Literal``
+
+.. code-block:: python
+
+    from hamilton import registry
+    registry.load_extensions("mlflow")

--- a/docs/how-tos/index.rst
+++ b/docs/how-tos/index.rst
@@ -18,6 +18,7 @@ directory. If there's an example you want but don't see, reach out or open an is
    cache-nodes
    scale-up
    microservice
+   extensions-autoloading
    wrapping-driver
    cli-reference
    pre-commit-hooks

--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -20,38 +20,7 @@ if not registry.INITIALIZED:
     # Trigger load of extensions here because decorators are the only thing that use the registry
     # right now. Side note: ray serializes things weirdly, so we need to do this here rather than in
     # in the other choice of hamilton/base.py.
-    plugins_modules = [
-        "yaml",
-        "matplotlib",
-        "numpy",
-        "pandas",
-        "plotly",
-        "polars",
-        "polars_lazyframe",
-        "pyspark_pandas",
-        "spark",
-        "dask",
-        "geopandas",
-        "xgboost",
-        "lightgbm",
-        "sklearn_plot",
-        "vaex",
-        "ibis",
-        "dlt",
-        "kedro",
-        "huggingface",
-        "mlflow",
-    ]
-    for plugin_module in plugins_modules:
-        try:
-            registry.load_extension(plugin_module)
-        except NotImplementedError as e:
-            logger.debug(f"Did not load {plugin_module} extension because {str(e)}.")
-        except ModuleNotFoundError as e:
-            logger.debug(f"Did not load {plugin_module} extension because {e.msg}.")
-        except ImportError as e:
-            logger.debug(f"Did not load {plugin_module} extension because {str(e)}.")
-    registry.INITIALIZED = True
+    registry.initialize()
 
 
 def sanitize_function_name(name: str) -> str:

--- a/hamilton/registry.py
+++ b/hamilton/registry.py
@@ -35,7 +35,6 @@ ExtensionName = Literal[
     "mlflow",
 ]
 HAMILTON_EXTENSIONS: Tuple[ExtensionName, ...] = get_args(ExtensionName)
-HAMILTON_AUTOLOAD_CONFIG_KEY = "autoload_extensions"
 HAMILTON_AUTOLOAD_ENV = "HAMILTON_AUTOLOAD_EXTENSIONS"
 DEFAULT_CONFIG_LOCATION = pathlib.Path("~/.hamilton.conf").expanduser()
 
@@ -100,8 +99,8 @@ def load_autoload_config() -> configparser.ConfigParser:
     config = configparser.ConfigParser()
     config.read(DEFAULT_CONFIG_LOCATION)
 
-    if config.has_option("DEFAULT", HAMILTON_AUTOLOAD_CONFIG_KEY):
-        os.environ[HAMILTON_AUTOLOAD_ENV] = config.get("DEFAULT", HAMILTON_AUTOLOAD_CONFIG_KEY)
+    if config.has_option("DEFAULT", HAMILTON_AUTOLOAD_ENV):
+        os.environ[HAMILTON_AUTOLOAD_ENV] = config.get("DEFAULT", HAMILTON_AUTOLOAD_ENV)
 
     return config
 
@@ -111,7 +110,7 @@ def _config_enable_autoload():
     if "DEFAULT" not in config:
         config.add_section("DEFAULT")
 
-    config.remove_option("DEFAULT", HAMILTON_AUTOLOAD_CONFIG_KEY)
+    config.remove_option("DEFAULT", HAMILTON_AUTOLOAD_ENV)
     with DEFAULT_CONFIG_LOCATION.open("w") as f:
         config.write(f)
 
@@ -121,7 +120,7 @@ def _config_disable_autoload():
     if "DEFAULT" not in config:
         config.add_section("DEFAULT")
 
-    config.set("DEFAULT", HAMILTON_AUTOLOAD_CONFIG_KEY, "0")
+    config.set("DEFAULT", HAMILTON_AUTOLOAD_ENV, "0")
     with DEFAULT_CONFIG_LOCATION.open("w") as f:
         config.write(f)
 

--- a/hamilton/registry.py
+++ b/hamilton/registry.py
@@ -46,6 +46,20 @@ COLUMN_TYPE = "column_type"
 DATAFRAME_TYPE = "dataframe_type"
 
 
+def load_autoload_config() -> configparser.ConfigParser:
+    """Load the Hamilton config file and set the autoloading environment variable"""
+    config = configparser.ConfigParser()
+    config.read(DEFAULT_CONFIG_LOCATION)
+
+    if config.has_option("DEFAULT", HAMILTON_AUTOLOAD_ENV):
+        os.environ[HAMILTON_AUTOLOAD_ENV] = config.get("DEFAULT", HAMILTON_AUTOLOAD_ENV)
+
+    return config
+
+
+load_autoload_config()
+
+
 def load_extension(plugin_module: ExtensionName):
     """Given a module name, loads it for Hamilton to use.
 
@@ -69,11 +83,10 @@ def load_extension(plugin_module: ExtensionName):
 
 def initialize():
     """Iterate over all extensions and try to load them"""
-    load_autoload_config()
     logger.debug(f"{HAMILTON_AUTOLOAD_ENV}={os.environ.get(HAMILTON_AUTOLOAD_ENV)}")
     for extension_name in HAMILTON_EXTENSIONS:
         # skip modules that aren't explicitly imported by the user
-        if os.environ.get(HAMILTON_AUTOLOAD_ENV) == "0":
+        if str(os.environ.get(HAMILTON_AUTOLOAD_ENV)) == "0":
             continue
 
         try:
@@ -101,17 +114,6 @@ def enable_autoload():
     This needs to be done before hamilton.driver is imported.
     """
     del os.environ[HAMILTON_AUTOLOAD_ENV]
-
-
-def load_autoload_config() -> configparser.ConfigParser:
-    """Load the Hamilton config file and set the autoloading environment variable"""
-    config = configparser.ConfigParser()
-    config.read(DEFAULT_CONFIG_LOCATION)
-
-    if config.has_option("DEFAULT", HAMILTON_AUTOLOAD_ENV):
-        os.environ[HAMILTON_AUTOLOAD_ENV] = config.get("DEFAULT", HAMILTON_AUTOLOAD_ENV)
-
-    return config
 
 
 def config_enable_autoload():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,8 @@ h_experiments = "hamilton.plugins.h_experiments.__main__:main"
 hamilton = "hamilton.cli.__main__:cli"
 hamilton-admin-build-ui = "hamilton.admin:build_ui"
 hamilton-admin-build-and-publish = "hamilton.admin:build_and_publish"
+hamilton-disable-autoload-extensions = "hamilton.registry:_config_disable_autoload"
+hamilton-enable-autoload-extensions = "hamilton.registry:_config_enable_autoload"
 
 [project.urls]
 homepage = "https://www.tryhamilton.dev/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,8 +153,8 @@ h_experiments = "hamilton.plugins.h_experiments.__main__:main"
 hamilton = "hamilton.cli.__main__:cli"
 hamilton-admin-build-ui = "hamilton.admin:build_ui"
 hamilton-admin-build-and-publish = "hamilton.admin:build_and_publish"
-hamilton-disable-autoload-extensions = "hamilton.registry:_config_disable_autoload"
-hamilton-enable-autoload-extensions = "hamilton.registry:_config_enable_autoload"
+hamilton-disable-autoload-extensions = "hamilton.registry:config_disable_autoload"
+hamilton-enable-autoload-extensions = "hamilton.registry:config_enable_autoload"
 
 [project.urls]
 homepage = "https://www.tryhamilton.dev/"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,27 +1,6 @@
-import os
-import sys
-
 import pytest
 
 from hamilton import registry
-
-
-def test_disable_autoload_then_reenable():
-    os.environ[registry.HAMILTON_AUTOLOAD_ENV] = "0"
-    # remove pandas from the loaded modules
-    # pandas is both a Hamilton dependency and it has pandas_extensions.py
-    pandas_modules = [module_name for module_name in sys.modules if "pandas" in module_name]
-    for module_name in pandas_modules:
-        sys.modules.pop(module_name)
-
-    # pandas shouldn't be autoloaded
-    registry.initialize()
-    assert "pandas" not in sys.modules
-
-    # pandas should be autoloaded
-    registry.enable_autoload()
-    registry.initialize()
-    assert "pandas" in sys.modules
 
 
 @pytest.mark.parametrize("entrypoint", ["config_disable_autoload", "config_enable_autoload"])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+import pytest
+
+from hamilton import registry
+
+
+def test_disable_autoload_then_reenable():
+    os.environ[registry.HAMILTON_AUTOLOAD_ENV] = "0"
+    # remove pandas from the loaded modules
+    # pandas is both a Hamilton dependency and it has pandas_extensions.py
+    pandas_modules = [module_name for module_name in sys.modules if "pandas" in module_name]
+    for module_name in pandas_modules:
+        sys.modules.pop(module_name)
+
+    # pandas shouldn't be autoloaded
+    registry.initialize()
+    assert "pandas" not in sys.modules
+
+    # pandas should be autoloaded
+    registry.enable_autoload()
+    registry.initialize()
+    assert "pandas" in sys.modules
+
+
+@pytest.mark.parametrize("entrypoint", ["config_disable_autoload", "config_enable_autoload"])
+def test_command_entrypoints_arent_renamed(entrypoint: str):
+    """Ensures that functions associated with an entrypoint in
+    pyproject.toml aren't renamed.
+
+    This doesn't prevent the entrypoints from being renamed
+    """
+    assert hasattr(registry, entrypoint)


### PR DESCRIPTION
The current approach to loading plugins is greedy. When doing `import hamilton.driver`, it tries to import all the extension modules available to the users (e.g., pandas, matplotlib, mlflow, pyspark) even if these libraries aren't used in the dataflow.

This can introduce slowdowns, memory usage (many Mbs), and warning messages by 3rd party libraries (e.g., `PYARROW_TIMEZONE` by pyspark).

Since many features (`@extract_columns`, materializers, and more) rely on this extension registry, changing the default behavior would introduce many hard-to-track breaking changes. 

Instead, we'll adopt an opt-out approach. Users can now do:
1. disable autoload programmatically
  ```python
  from hamilton import registry
  registry.disable_autoload()
  ```
2. set an environment variable
  ```bash
  export HAMILTON_AUTOLOAD_EXTENSIONS=0
  ```
  or (note that this is a string)
  ```python
  import os
  os.environ["HAMILTON_AUTOLOAD_EXTENSIONS"] = "0"
  ```
  or in jupyter notebooks
  ```python
  %env HAMILTON_AUTOLOAD_EXTENSIONS=0
  ```
3. set a config value that will persist and be used whenever Hamilton is used via the command line
  ```bash
  hamilton-disable-autoload-extensions
  ```
  and re-enable it via
  ```bash
  hamilton-enable-autoload-extensions
  ```
  
Then, users that disabled autoload would need to either:
1. directly import hamilton plugins anywhere in their code
  ```python
  from hamilton.plugins import mlflow_extensions
  ```
2. directly register extensions in the registry (has good IDE support via `typing.Literal`)
  ```python
  from hamilton import registry
  registry.load_extension("mlflow")
  ```
  
Relates to #1059.

## Changes
- moved the content of `hamilton.function_modifiers.base` to `hamilton.registry`
- added entrypoints to  `pyproject.toml`
- added functions to `hamilton.registry` to interact with the `~/.hamilton.conf`

## How I tested this
- tested some code path manually in a notebook and enabling/disabling via the CLI

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
