### PR TITLE
dev: gitignored data file formats common in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,12 @@ examples/**/hamilton-env
 
 # vxcode
 .vscode
+
+# data formats
+**.dir
+**.bak
+**.dat
+**.dot
+**.pkl
+**.lance
+**.txn


### PR DESCRIPTION
Added to `.gitignore` data formats produced by `shelve`, `dbm`, `lancedb`, the caching features, and more. Otherwise, they clutter and slowdown the IDE file diff 

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
