### PR TITLE
Adds setstate getstate to driver and fixes 1093

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1,5 +1,7 @@
 import abc
 import functools
+import importlib
+import importlib.util
 import json
 import logging
 import operator
@@ -259,6 +261,23 @@ class Driver:
         # These all feed into creating the driver & thus DAG.
         dr = driver.Driver(config, module, adapter=adapter)
     """
+
+    def __getstate__(self):
+        # Copy the object's state from self.__dict__
+        state = self.__dict__.copy()
+        # Remove the unpicklable entries -- right now it's the modules tracked.
+        state["graph_module_names"] = [
+            importlib.util.find_spec(m.__name__).name for m in state["graph_modules"]
+        ]
+        del state["graph_modules"]  # remove from state
+        return state
+
+    def __setstate__(self, state):
+        # Restore instance attributes
+        self.__dict__.update(state)
+        # Reinitialize the unpicklable entries
+        # assumption is that the modules are importable in the new process
+        self.graph_modules = [importlib.import_module(n) for n in state["graph_module_names"]]
 
     @staticmethod
     def normalize_adapter_input(

--- a/tests/resources/test_driver_serde_mapper.py
+++ b/tests/resources/test_driver_serde_mapper.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from hamilton.htypes import Collect, Parallelizable
+
+
+def mapper(
+    drivers: list,
+    inputs: list,
+    final_vars: list = None,
+) -> Parallelizable[dict]:
+    if final_vars is None:
+        final_vars = []
+    for dr, input_ in zip(drivers, inputs):
+        yield {
+            "dr": dr,
+            "final_vars": final_vars or dr.list_available_variables(),
+            "input": input_,
+        }
+
+
+def inside(mapper: dict) -> dict:
+    _dr = mapper["dr"]
+    _inputs = mapper["input"]
+    _final_var = mapper["final_vars"]
+    return _dr.execute(final_vars=_final_var, inputs=_inputs)
+
+
+def passthrough(inside: dict) -> dict:
+    return inside
+
+
+def reducer(passthrough: Collect[dict]) -> Any:
+    return passthrough

--- a/tests/resources/test_driver_serde_worker.py
+++ b/tests/resources/test_driver_serde_worker.py
@@ -1,0 +1,2 @@
+def double(a: int) -> int:
+    return a * 2

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -684,8 +684,7 @@ def test_driver_setstate_getstate():
         Builder()
         .with_modules(tests.resources.test_driver_serde_mapper)
         .enable_dynamic_execution(allow_experimental_mode=True)
-        # .with_local_executor(executors.SynchronousLocalTaskExecutor())
-        .with_remote_executor(executors.MultiProcessingExecutor(8))
+        .with_remote_executor(executors.MultiProcessingExecutor(4))
         .build()
     )
     r = dr.execute(


### PR DESCRIPTION
This fixes #1093.

Modules were not picklable. So this fixes that by serializing their fully qualified names, and then when the driver object is deserialized, they are reinstantiated as module objects.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
