### PR TITLE
[Async]HamiltonTracker support passing in custom CA cert

### DIFF
--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -45,11 +45,12 @@ class HamiltonTracker(
         dag_name: str,
         tags: Dict[str, str] = None,
         client_factory: Callable[
-            [str, str, str], clients.HamiltonClient
+            [str, str, str, str | bool], clients.HamiltonClient
         ] = clients.BasicSynchronousHamiltonClient,
         api_key: str = None,
         hamilton_api_url=os.environ.get("HAMILTON_API_URL", constants.HAMILTON_API_URL),
         hamilton_ui_url=os.environ.get("HAMILTON_UI_URL", constants.HAMILTON_UI_URL),
+        verify: str | bool = True,
     ):
         """This hooks into Hamilton execution to track DAG runs in Hamilton UI.
 
@@ -61,11 +62,12 @@ class HamiltonTracker(
         :param api_key: the API key to use. See us if you want to use this.
         :param hamilton_api_url: API endpoint.
         :param hamilton_ui_url: UI Endpoint.
+        :param verify: SSL verification to pass-through to requests
         """
         self.project_id = project_id
         self.api_key = api_key
         self.username = username
-        self.client = client_factory(api_key, username, hamilton_api_url)
+        self.client = client_factory(api_key, username, hamilton_api_url, verify=verify)
         self.initialized = False
         self.project_version = None
         self.base_tags = tags if tags is not None else {}
@@ -387,16 +389,17 @@ class AsyncHamiltonTracker(
         dag_name: str,
         tags: Dict[str, str] = None,
         client_factory: Callable[
-            [str, str, str], clients.BasicAsynchronousHamiltonClient
+            [str, str, str, str | bool], clients.BasicAsynchronousHamiltonClient
         ] = clients.BasicAsynchronousHamiltonClient,
         api_key: str = os.environ.get("HAMILTON_API_KEY", ""),
         hamilton_api_url=os.environ.get("HAMILTON_API_URL", constants.HAMILTON_API_URL),
         hamilton_ui_url=os.environ.get("HAMILTON_UI_URL", constants.HAMILTON_UI_URL),
+        verify: str | bool = True,
     ):
         self.project_id = project_id
         self.api_key = api_key
         self.username = username
-        self.client = client_factory(api_key, username, hamilton_api_url)
+        self.client = client_factory(api_key, username, hamilton_api_url, verify=verify)
         self.initialized = False
         self.project_version = None
         self.base_tags = tags if tags is not None else {}

--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -6,7 +6,7 @@ import random
 import traceback
 from datetime import timezone
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from hamilton_sdk import driver
 from hamilton_sdk.api import clients, constants
@@ -50,7 +50,7 @@ class HamiltonTracker(
         api_key: str = None,
         hamilton_api_url=os.environ.get("HAMILTON_API_URL", constants.HAMILTON_API_URL),
         hamilton_ui_url=os.environ.get("HAMILTON_UI_URL", constants.HAMILTON_UI_URL),
-        verify: str | bool = True,
+        verify: Union[str, bool] = True,
     ):
         """This hooks into Hamilton execution to track DAG runs in Hamilton UI.
 
@@ -394,7 +394,7 @@ class AsyncHamiltonTracker(
         api_key: str = os.environ.get("HAMILTON_API_KEY", ""),
         hamilton_api_url=os.environ.get("HAMILTON_API_URL", constants.HAMILTON_API_URL),
         hamilton_ui_url=os.environ.get("HAMILTON_UI_URL", constants.HAMILTON_UI_URL),
-        verify: str | bool = True,
+        verify: Union[str, bool] = True,
     ):
         self.project_id = project_id
         self.api_key = api_key

--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -45,7 +45,7 @@ class HamiltonTracker(
         dag_name: str,
         tags: Dict[str, str] = None,
         client_factory: Callable[
-            [str, str, str, str | bool], clients.HamiltonClient
+            [str, str, str, Union[str, bool]], clients.HamiltonClient
         ] = clients.BasicSynchronousHamiltonClient,
         api_key: str = None,
         hamilton_api_url=os.environ.get("HAMILTON_API_URL", constants.HAMILTON_API_URL),
@@ -389,7 +389,7 @@ class AsyncHamiltonTracker(
         dag_name: str,
         tags: Dict[str, str] = None,
         client_factory: Callable[
-            [str, str, str, str | bool], clients.BasicAsynchronousHamiltonClient
+            [str, str, str, Union[str, bool]], clients.BasicAsynchronousHamiltonClient
         ] = clients.BasicAsynchronousHamiltonClient,
         api_key: str = os.environ.get("HAMILTON_API_KEY", ""),
         hamilton_api_url=os.environ.get("HAMILTON_API_URL", constants.HAMILTON_API_URL),

--- a/ui/sdk/src/hamilton_sdk/api/clients.py
+++ b/ui/sdk/src/hamilton_sdk/api/clients.py
@@ -8,7 +8,7 @@ import ssl
 import threading
 import time
 from collections import defaultdict
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Union
 from urllib.parse import urlencode
 
 import aiohttp
@@ -168,7 +168,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
         username: str,
         h_api_url: str,
         base_path: str = "/api/v1",
-        verify: str | bool = True,
+        verify: Union[str, bool] = True,
     ):
         """Initializes a Hamilton API client
 

--- a/ui/sdk/src/hamilton_sdk/api/clients.py
+++ b/ui/sdk/src/hamilton_sdk/api/clients.py
@@ -4,6 +4,7 @@ import datetime
 import functools
 import logging
 import queue
+import ssl
 import threading
 import time
 from collections import defaultdict
@@ -167,6 +168,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
         username: str,
         h_api_url: str,
         base_path: str = "/api/v1",
+        verify: str | bool = True,
     ):
         """Initializes a Hamilton API client
 
@@ -174,10 +176,13 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
         :param api_key: API key to save to
         :param username: Username to authenticate against
         :param h_api_url: API URL for Hamilton API.
+        :param base_path:
+        :param verify: SSL verification to pass-through to requests
         """
         self.api_key = api_key
         self.username = username
         self.base_url = h_api_url + base_path
+        self.verify = verify
 
         self.max_batch_size = 100
         self.flush_interval = 5
@@ -256,6 +261,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
                     "task_updates": make_json_safe(task_updates_list),
                 },
                 headers=self._common_headers(),
+                verify=self.verify,
             )
             try:
                 response.raise_for_status()
@@ -290,7 +296,9 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
 
     def validate_auth(self):
         logger.debug(f"Validating auth against {self.base_url}/phone_home")
-        response = requests.get(f"{self.base_url}/phone_home", headers=self._common_headers())
+        response = requests.get(
+            f"{self.base_url}/phone_home", headers=self._common_headers(), verify=self.verify
+        )
         try:
             response.raise_for_status()
             logger.debug(f"Successfully validated auth against {self.base_url}/phone_home")
@@ -311,6 +319,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
         response = requests.get(
             f"{self.base_url}/project_versions/exists?project_id={project_id}&code_hash={code_hash}",
             headers=self._common_headers(),
+            verify=self.verify,
         )
         try:
             response.raise_for_status()
@@ -343,6 +352,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
                 "version_info_schema": 1,  # TODO -- wire this through appropriately
                 "code_log": {"files": code_slurped},
             },
+            verify=self.verify,
         )
         try:
             code_version_created.raise_for_status()
@@ -358,7 +368,9 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
     def project_exists(self, project_id: int) -> bool:
         logger.debug(f"Checking if project {project_id} exists")
         response = requests.get(
-            f"{self.base_url}/projects/{project_id}", headers=self._common_headers()
+            f"{self.base_url}/projects/{project_id}",
+            headers=self._common_headers(),
+            verify=self.verify,
         )
         try:
             response.raise_for_status()
@@ -401,6 +413,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
         response = requests.get(
             f"{self.base_url}/dag_templates/exists/?dag_hash={dag_hash}&{params}",
             headers=self._common_headers(),
+            verify=self.verify,
         )
         response.raise_for_status()
         logger.debug(f"DAG template {dag_hash} exists for project {project_id}")
@@ -430,6 +443,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
                 "code_version_info_schema": 1,
             },
             headers=self._common_headers(),
+            verify=self.verify,
         )
         try:
             dag_template_created.raise_for_status()
@@ -458,6 +472,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
                     "run_status": "RUNNING",
                 }
             ),
+            verify=self.verify,
         )
         try:
             response.raise_for_status()
@@ -498,6 +513,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
             f"{self.base_url}/dag_runs/{dag_run_id}/",
             json=make_json_safe({"run_status": status, "run_end_time": datetime.datetime.utcnow()}),
             headers=self._common_headers(),
+            verify=self.verify,
         )
         try:
             response.raise_for_status()
@@ -508,17 +524,32 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
 
 
 class BasicAsynchronousHamiltonClient(HamiltonClient):
-    def __init__(self, api_key: str, username: str, h_api_url: str, base_path: str = "/api/v1"):
+    def __init__(
+        self,
+        api_key: str,
+        username: str,
+        h_api_url: str,
+        base_path: str = "/api/v1",
+        verify: str | bool = True,
+    ):
         """Initializes an async Hamilton API client
 
          project: Project to save to
         :param api_key: API key to save to
         :param username: Username to authenticate against
         :param h_api_url: API URL for Hamilton API.
+        :param base_path:
+        :param verify: SSL verification options in requests format
         """
         self.api_key = api_key
         self.username = username
         self.base_url = h_api_url + base_path
+        if verify is True:
+            self.ssl = True
+        elif verify is False:
+            self.ssl = False
+        else:
+            self.ssl = ssl.create_default_context(cafile=verify)
         self.flush_interval = 5
         self.data_queue = asyncio.Queue()
         self.running = True
@@ -542,6 +573,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
                         "task_updates": make_json_safe(task_updates_list),
                     },
                     headers=self._common_headers(),
+                    ssl=self.ssl,
                 ) as response:
                     try:
                         response.raise_for_status()
@@ -590,7 +622,9 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
         logger.debug(f"Validating auth against {self.base_url}/phone_home")
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"{self.base_url}/phone_home", headers=self._common_headers()
+                f"{self.base_url}/phone_home",
+                headers=self._common_headers(),
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -613,6 +647,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
             async with session.get(
                 f"{self.base_url}/project_versions/exists?project_id={project_id}&code_hash={code_hash}",
                 headers=self._common_headers(),
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -648,6 +683,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
                     "version_info_schema": 1,  # TODO -- wire this through appropriately
                     "code_log": {"files": code_slurped},
                 },
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -664,7 +700,9 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
         logger.debug(f"Checking if project {project_id} exists")
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"{self.base_url}/projects/{project_id}", headers=self._common_headers()
+                f"{self.base_url}/projects/{project_id}",
+                headers=self._common_headers(),
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -706,6 +744,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
             async with session.get(
                 f"{self.base_url}/dag_templates/exists/?dag_hash={dag_hash}&{params}",
                 headers=self._common_headers(),
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -741,6 +780,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
                     "code_version_info_schema": 1,
                 },
                 headers=self._common_headers(),
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -770,6 +810,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
                     }
                 ),
                 headers=self._common_headers(),
+                ssl=self.ssl,
             ) as response:
                 try:
                     response.raise_for_status()
@@ -802,7 +843,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
         data = make_json_safe({"run_status": status, "run_end_time": datetime.datetime.utcnow()})
         headers = self._common_headers()
         async with aiohttp.ClientSession() as session:
-            async with session.put(url, json=data, headers=headers) as response:
+            async with session.put(url, json=data, headers=headers, ssl=self.ssl) as response:
                 try:
                     response.raise_for_status()
                     logger.debug(f"Logged end of DAG run {dag_run_id}")

--- a/ui/sdk/src/hamilton_sdk/api/clients.py
+++ b/ui/sdk/src/hamilton_sdk/api/clients.py
@@ -530,7 +530,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
         username: str,
         h_api_url: str,
         base_path: str = "/api/v1",
-        verify: str | bool = True,
+        verify: Union[str, bool] = True,
     ):
         """Initializes an async Hamilton API client
 


### PR DESCRIPTION
Our Hamilton UI server is fronted by an SSL using an internal CA, which isn't supported by Hamilton SDK without this PR.

The standard synchronous `HamiltonTracker` can be worked around by using `os.environ["REQUESTS_CA_BUNDLE"]` but that's not ideal. The `AsyncHamiltonTracker` has no such workaround available & we are switching to  using that.

## Changes

Trackers take a new optional `verify` arg which mimics the `requests` arg of the same name.

## How I tested this

Both adapters tested on our internal network

## Notes

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
