### PR TITLE
Change `Parallelizable` and `Collect` to structural subtypes

### DIFF
--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -272,17 +272,27 @@ def get_type_information(some_type: Any) -> Tuple[Type[Type], list]:
 
 
 # Type variables for annotations below
-T = TypeVar("T")
-U = TypeVar("U", covariant=True)
-V = TypeVar("V", covariant=True)
+SequentialElement = TypeVar("SequentialElement", covariant=True)
+ParallelizableElement = TypeVar("ParallelizableElement", covariant=True)
+CollectElement = TypeVar("CollectElement", covariant=True)
 
 
 # TODO -- support sequential operation
-# class Sequential(Generator[T, None, None], ABC):
+# class Sequential(Iterable[SequentialElement], Protocol[SequentialElement]):
 #     pass
 
 
-class Parallelizable(Iterable[U], Protocol[U]):
+class Parallelizable(Iterable[ParallelizableElement], Protocol[ParallelizableElement]):
+    """Marks the output of a function node as parallelizable.
+
+    Parallelizable outputs are expected to be iterable, where each element dynamically
+    generates a node. When using dynamic execution, each of these dynamic nodes can be
+    executed in parallel.
+
+    Because this uses dynamic execution, the builder method `enable_dynamic_execution`
+    must be called with `allow_experimental_mode=True`.
+    """
+
     pass
 
 
@@ -290,8 +300,15 @@ def is_parallelizable_type(type_: Type) -> bool:
     return _get_origin(type_) == Parallelizable
 
 
-class Collect(Iterable[V], Protocol[V]):
-    pass
+class Collect(Iterable[CollectElement], Protocol[CollectElement]):
+    """Marks a function node parameter as collectable.
+
+    Collectable inputs are expected to be iterable, where each element is populated with
+    the results of dynamic nodes derived from parallelizable outputs.
+
+    Because this uses dynamic execution, the builder method `enable_dynamic_execution`
+    must be called with `allow_experimental_mode=True`.
+    """
 
 
 def check_input_type(node_type: Type, input_value: Any) -> bool:

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -1,8 +1,7 @@
 import inspect
 import sys
 import typing
-from abc import ABC
-from typing import Any, Generator, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union
 
 import typing_inspect
 
@@ -270,8 +269,8 @@ def get_type_information(some_type: Any) -> Tuple[Type[Type], list]:
 
 # Type variables for annotations below
 T = TypeVar("T")
-U = TypeVar("U")
-V = TypeVar("V")
+U = TypeVar("U", covariant=True)
+V = TypeVar("V", covariant=True)
 
 
 # TODO -- support sequential operation
@@ -279,16 +278,14 @@ V = TypeVar("V")
 #     pass
 
 
-class Parallelizable(Generator[U, None, None], ABC):
-    pass
+class Parallelizable(Iterable[U], Protocol[U]): ...
 
 
 def is_parallelizable_type(type_: Type) -> bool:
-    return issubclass(type_, Parallelizable)
+    return _get_origin(type_) == Parallelizable
 
 
-class Collect(Generator[V, None, None], ABC):
-    pass
+class Collect(Iterable[V], Protocol[V]): ...
 
 
 def check_input_type(node_type: Type, input_value: Any) -> bool:

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -136,7 +136,11 @@ def types_match(param_type: Type[Type], required_node_type: Any) -> bool:
 
 
 _sys_version_info = sys.version_info
-_version_tuple = (_sys_version_info.major, _sys_version_info.minor, _sys_version_info.micro)
+_version_tuple = (
+    _sys_version_info.major,
+    _sys_version_info.minor,
+    _sys_version_info.micro,
+)
 
 """
 The following is purely for backwards compatibility
@@ -278,14 +282,16 @@ V = TypeVar("V", covariant=True)
 #     pass
 
 
-class Parallelizable(Iterable[U], Protocol[U]): ...
+class Parallelizable(Iterable[U], Protocol[U]):
+    pass
 
 
 def is_parallelizable_type(type_: Type) -> bool:
     return _get_origin(type_) == Parallelizable
 
 
-class Collect(Iterable[V], Protocol[V]): ...
+class Collect(Iterable[V], Protocol[V]):
+    pass
 
 
 def check_input_type(node_type: Type, input_value: Any) -> bool:


### PR DESCRIPTION
Attempts to fix #1114 by introducing structural subtyping for `Parallelizable` and `Collect`.

## Changes

Both  `Parallelizable` and `Collect` were converted to generic protocols (vice abstract classes). The function `is_parallelizable_type` was also updated because generic protocols are not runtime checkable via `issubclass` - the function now checks the origin type via `typing.get_origin`.

## How I tested this
As mentioned in #1114, I was having issues running the full test suite locally on my Windows 11 machine, but I was able to run all the tests where `Parallelizable` is used, that includes the following folders:
- `./tests/execution/`
- `./tests/function_modifiers/`
- `./tests/resources/ `

## Notes
I didn't find any usage of `is_parallelizable_type` in the codebase. Is this intended for a future feature?

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
