### PR TITLE
Handles partials in source code hash

### DIFF
--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -376,7 +376,10 @@ class CacheAdapter(NodeExecutionHook, NodeExecutionMethod, GraphExecutionHook):
         if node_name not in self.cache_vars:
             return node_callable(**node_kwargs)
 
-        node_hash = graph_types.hash_source_code(node_callable, strip=True)
+        source_of_node_callable = node_callable
+        while hasattr(source_of_node_callable, "func"):  # handle partials
+            source_of_node_callable = source_of_node_callable.func
+        node_hash = graph_types.hash_source_code(source_of_node_callable, strip=True)
         cache_key = CacheAdapter.create_key(node_hash, node_kwargs)
 
         from_cache = self.cache.get(cache_key, None)

--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -8,6 +8,7 @@ import pprint
 import random
 import shelve
 import time
+from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from hamilton import graph_types, htypes
@@ -377,7 +378,7 @@ class CacheAdapter(NodeExecutionHook, NodeExecutionMethod, GraphExecutionHook):
             return node_callable(**node_kwargs)
 
         source_of_node_callable = node_callable
-        while hasattr(source_of_node_callable, "func"):  # handle partials
+        while isinstance(source_of_node_callable, partial):  # handle partials
             source_of_node_callable = source_of_node_callable.func
         node_hash = graph_types.hash_source_code(source_of_node_callable, strip=True)
         cache_key = CacheAdapter.create_key(node_hash, node_kwargs)

--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -359,7 +359,7 @@ class CacheAdapter(NodeExecutionHook, NodeExecutionMethod, GraphExecutionHook):
     def run_before_graph_execution(self, *, graph: HamiltonGraph, **kwargs):
         """Set `cache_vars` to all nodes if received None during `__init__`"""
         self.cache = shelve.open(self.cache_path)
-        if self.cache_vars == []:
+        if len(self.cache_vars) == 0:
             self.cache_vars = [n.name for n in graph.nodes]
 
     def run_to_execute_node(

--- a/tests/lifecycle/test_cache_adapter.py
+++ b/tests/lifecycle/test_cache_adapter.py
@@ -1,4 +1,4 @@
-import inspect
+import functools
 import pathlib
 import shelve
 
@@ -8,12 +8,8 @@ from hamilton import graph_types, node
 from hamilton.lifecycle.default import CacheAdapter
 
 
-def _callable_to_node(callable) -> node.Node:
-    return node.Node(
-        name=callable.__name__,
-        typ=inspect.signature(callable).return_annotation,
-        callabl=callable,
-    )
+def _callable_to_node(callable, name=None) -> node.Node:
+    return node.Node.from_fn(callable, name)
 
 
 @pytest.fixture()
@@ -50,6 +46,37 @@ def node_a_docstring():
         return external_input % 7
 
     return _callable_to_node(A)
+
+
+@pytest.fixture()
+def node_a_partial():
+    """The function A() is a partial"""
+
+    def A(external_input: int, remainder: int) -> int:
+        return external_input % remainder
+
+    base_node: node.Node = _callable_to_node(A)
+
+    A = functools.partial(A, remainder=7)
+    base_node._callable = A
+    del base_node.input_types["remainder"]
+    return base_node
+
+
+@pytest.fixture()
+def node_a_nested_partial():
+    """The function A() is a partial"""
+
+    def A(external_input: int, remainder: int, extra: int) -> int:
+        return external_input % remainder
+
+    base_node: node.Node = _callable_to_node(A)
+    A = functools.partial(A, remainder=7)
+    A = functools.partial(A, extra=7)
+    base_node._callable = A
+    del base_node.input_types["remainder"]
+    del base_node.input_types["extra"]
+    return base_node
 
 
 def test_set_result(hook: CacheAdapter, node_a: node.Node):
@@ -138,3 +165,49 @@ def test_commit_nodes_history(hook: CacheAdapter):
     # need to reopen the hook cache
     with shelve.open(hook.cache_path) as cache:
         assert cache.get(CacheAdapter.nodes_history_key) == hook.nodes_history
+
+
+def test_partial_handling(hook: CacheAdapter, node_a_partial: node.Node):
+    """Partial functions are not supported"""
+    hook.cache_vars = [node_a_partial.name]
+    hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
+    node_kwargs = dict(external_input=7)
+    result = hook.run_to_execute_node(
+        node_name=node_a_partial.name,
+        node_kwargs=node_kwargs,
+        node_callable=node_a_partial.callable,
+    )
+    hook.run_after_node_execution(
+        node_name=node_a_partial.name,
+        node_kwargs=node_kwargs,
+        result=result,
+    )
+    result2 = hook.run_to_execute_node(
+        node_name=node_a_partial.name,
+        node_kwargs=node_kwargs,
+        node_callable=node_a_partial.callable,
+    )
+    assert result2 == result
+
+
+def test_nested_partial_handling(hook: CacheAdapter, node_a_nested_partial: node.Node):
+    """Partial functions are not supported"""
+    hook.cache_vars = [node_a_nested_partial.name]
+    hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
+    node_kwargs = dict(external_input=7)
+    result = hook.run_to_execute_node(
+        node_name=node_a_nested_partial.name,
+        node_kwargs=node_kwargs,
+        node_callable=node_a_nested_partial.callable,
+    )
+    hook.run_after_node_execution(
+        node_name=node_a_nested_partial.name,
+        node_kwargs=node_kwargs,
+        result=result,
+    )
+    result2 = hook.run_to_execute_node(
+        node_name=node_a_nested_partial.name,
+        node_kwargs=node_kwargs,
+        node_callable=node_a_nested_partial.callable,
+    )
+    assert result2 == result

--- a/tests/lifecycle/test_cache_adapter.py
+++ b/tests/lifecycle/test_cache_adapter.py
@@ -168,7 +168,7 @@ def test_commit_nodes_history(hook: CacheAdapter):
 
 
 def test_partial_handling(hook: CacheAdapter, node_a_partial: node.Node):
-    """Partial functions are not supported"""
+    """Tests partial functions are handled properly"""
     hook.cache_vars = [node_a_partial.name]
     hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
     node_kwargs = dict(external_input=7)
@@ -191,7 +191,7 @@ def test_partial_handling(hook: CacheAdapter, node_a_partial: node.Node):
 
 
 def test_nested_partial_handling(hook: CacheAdapter, node_a_nested_partial: node.Node):
-    """Partial functions are not supported"""
+    """Tests nested partial functions are handled properly"""
     hook.cache_vars = [node_a_nested_partial.name]
     hook.run_before_graph_execution(graph=graph_types.HamiltonGraph([]))  # needed to open cache
     node_kwargs = dict(external_input=7)


### PR DESCRIPTION
This is a stop gap measure to handle
partials for the CacheAdapter.


## Changes
- adds check for partial functions; they have `.func` attribute on a callable.

## How I tested this
This code now works:

```python
from hamilton.function_modifiers import source, inject
from hamilton.ad_hoc_utils import create_temporary_module
import time

@inject(foo=source("foo"))
def worker(seconds: int, foo: int) -> int:
    print(f"start work {seconds}s")
    start = time.time()
    time.sleep(1)
    # yield {
    #     "job_name": f"sleep_{seconds}",
    #     "cmd": [f"sleep {str(seconds)}"],
    #     "block": True,
    # }
    print(f"foo: {foo}")
    end = time.time()
    print(f"end stop {end - start:.2f}s work")
    return seconds


if __name__ == "__main__":
    from hamilton import driver
    from hamilton.execution import executors
    from hamilton.lifecycle.default import CacheAdapter
    logic = create_temporary_module(
        worker,
    )

    dr = (
        driver.Builder()
        .with_modules(logic)
        .enable_dynamic_execution(allow_experimental_mode=True)
        .with_local_executor(executors.SynchronousLocalTaskExecutor())
        .with_remote_executor(
            executors.MultiThreadingExecutor(max_tasks=4)
        )
        # !!! error when uncomment this line !!!
        # TypeError: module, class, method, function, traceback, frame, or code object was expected, got partial
        .with_adapters(CacheAdapter(cache_path="cache"))
        .with_config({"foo": 42})
        .build()
    )
    start = time.time()
    dr.execute(["worker"], inputs={"seconds": 3})
    print(f"Time taken: {time.time() - start: .2f} seconds")
```

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
