### PR TITLE
Pydantic validator

### DIFF
--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -176,6 +176,12 @@ pandera support
 Hamilton has a pandera plugin for data validation that you can install with ``pip install sf-hamilton[pandera]``. Then, you can pass a pandera schema (for DataFrame or Series) to ``@check_output(schema=...)``.
 
 
+pydantic support
+~~~~~~~~~~~~~~~
+
+Hamilton also supports data validation of pydantic models, which can be enabled with ``pip install sf-hamilton[pydantic]``. With pydantic installed, you can pass any subclass of the pydantic base model to ``@check_output(model=...)``. Pydantic validation is performed in strict mode, meaning that raw values will not be coerced to the model's types. For more information on strict mode see the `pydantic docs <https://docs.pydantic.dev/latest/concepts/strict_mode/>`.
+
+
 Split node output into *n* nodes
 --------------------------------
 

--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -179,7 +179,7 @@ Hamilton has a pandera plugin for data validation that you can install with ``pi
 pydantic support
 ~~~~~~~~~~~~~~~~
 
-Hamilton also supports data validation of pydantic models, which can be enabled with ``pip install sf-hamilton[pydantic]``. With pydantic installed, you can pass any subclass of the pydantic base model to ``@check_output(model=...)``. Pydantic validation is performed in strict mode, meaning that raw values will not be coerced to the model's types. For more information on strict mode see the `pydantic docs <https://docs.pydantic.dev/latest/concepts/strict_mode/>`.
+Hamilton also supports data validation of pydantic models, which can be enabled with ``pip install sf-hamilton[pydantic]``. With pydantic installed, you can pass any subclass of the pydantic base model to ``@check_output(model=...)``. Pydantic validation is performed in strict mode, meaning that raw values will not be coerced to the model's types. For more information on strict mode see the `pydantic docs <https://docs.pydantic.dev/latest/concepts/strict_mode/>`_.
 
 
 Split node output into *n* nodes

--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -177,7 +177,7 @@ Hamilton has a pandera plugin for data validation that you can install with ``pi
 
 
 pydantic support
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Hamilton also supports data validation of pydantic models, which can be enabled with ``pip install sf-hamilton[pydantic]``. With pydantic installed, you can pass any subclass of the pydantic base model to ``@check_output(model=...)``. Pydantic validation is performed in strict mode, meaning that raw values will not be coerced to the model's types. For more information on strict mode see the `pydantic docs <https://docs.pydantic.dev/latest/concepts/strict_mode/>`.
 

--- a/docs/reference/decorators/check_output.rst
+++ b/docs/reference/decorators/check_output.rst
@@ -29,8 +29,8 @@ available validators and how to build custom ones.
 
 Note we also have a plugins that allow for validation with the pandera and pydantic libraries. There are two ways to access these:
 
-1. `@check_output(schema=pandera_schema)` or `@check_output(model=pydantic_model)`
-2. `@h_pandera.check_output()` or `@h_pydantic.check_output()` on the function that declares either a typed dataframe or a pydantic model.
+1. ``@check_output(schema=pandera_schema)`` or ``@check_output(model=pydantic_model)``
+2. ``@h_pandera.check_output()`` or ``@h_pydantic.check_output()`` on the function that declares either a typed dataframe or a pydantic model.
 
 ----
 

--- a/docs/reference/decorators/check_output.rst
+++ b/docs/reference/decorators/check_output.rst
@@ -27,9 +27,10 @@ Note that you can also specify custom decorators using the ``@check_output_custo
 See `data_quality <https://github.com/dagworks-inc/hamilton/blob/main/data\_quality.md>`_ for more information on
 available validators and how to build custom ones.
 
-Note we also have a plugin that allows you to use pandera. There are two ways to access it:
-1. `@check_output(schema=pandera_schema)`
-2. `@h_pandera.check_output()` on a function that declares a typed pandera dataframe as an output
+Note we also have a plugins that allow for validation with the pandera and pydantic libraries. There are two ways to access these:
+
+1. `@check_output(schema=pandera_schema)` or `@check_output(model=pydantic_model)`
+2. `@h_pandera.check_output()` or `@h_pydantic.check_output()` on the function that declares either a typed dataframe or a pydantic model.
 
 ----
 
@@ -42,4 +43,7 @@ Note we also have a plugin that allows you to use pandera. There are two ways to
    :special-members: __init__
 
 .. autoclass:: hamilton.plugins.h_pandera.check_output
+   :special-members: __init__
+
+.. autoclass:: hamilton.plugins.h_pydantic.check_output
    :special-members: __init__

--- a/hamilton/data_quality/default_validators.py
+++ b/hamilton/data_quality/default_validators.py
@@ -511,9 +511,9 @@ _append_pandera_to_default_validators()
 def _append_pydantic_to_default_validators():
     """Utility method to append pydantic validators as needed"""
     try:
-        from pydantic import BaseModel  # noqa: F401
+        import pydantic  # noqa: F401
     except ModuleNotFoundError:
-        logger.info(
+        logger.debug(
             "Cannot import pydantic from pydantic_validators. Run pip install sf-hamilton[pydantic] if needed."
         )
         return

--- a/hamilton/data_quality/default_validators.py
+++ b/hamilton/data_quality/default_validators.py
@@ -508,6 +508,23 @@ def _append_pandera_to_default_validators():
 _append_pandera_to_default_validators()
 
 
+def _append_pydantic_to_default_validators():
+    """Utility method to append pydantic validators as needed"""
+    try:
+        from pydantic import BaseModel  # noqa: F401
+    except ModuleNotFoundError:
+        logger.info(
+            "Cannot import pydantic from pydantic_validators. Run pip install sf-hamilton[pydantic] if needed."
+        )
+        return
+    from hamilton.data_quality import pydantic_validators
+
+    AVAILABLE_DEFAULT_VALIDATORS.extend(pydantic_validators.PYDANTIC_VALIDATORS)
+
+
+_append_pydantic_to_default_validators()
+
+
 def resolve_default_validators(
     output_type: Type[Type],
     importance: str,

--- a/hamilton/data_quality/pydantic_validators.py
+++ b/hamilton/data_quality/pydantic_validators.py
@@ -1,0 +1,61 @@
+from typing import Any, Type
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from hamilton.data_quality import base
+from hamilton.htypes import custom_subclass_check
+
+
+class PydanticModelValidator(base.BaseDefaultValidator):
+    """Pydantic model compatibility validator
+
+    Note that this validator uses pydantic's strict mode, which does not allow for
+    coercion of data. This means that if an object does not exactly match the reference
+    type, it will fail validation, regardless of whether it could be coerced into the
+    correct type.
+
+    :param model: Pydantic model to validate against
+    :param importance: Importance of the validator, possible values "warn" and "fail"
+    :param arbitrary_types_allowed: Whether arbitrary types are allowed in the model
+    """
+
+    def __init__(self, model: type[BaseModel], importance: str):
+        super(PydanticModelValidator, self).__init__(importance)
+        self.model = model
+
+        self._model_adapter = TypeAdapter(model)
+
+    @classmethod
+    def applies_to(cls, datatype: Type[Type]) -> bool:
+        # In addition to checking for a subclass of BaseModel, we also check for dict
+        # as this is the standard 'de-serialized' format of pydantic models in python
+        return custom_subclass_check(datatype, BaseModel) or custom_subclass_check(datatype, dict)
+
+    def description(self) -> str:
+        return "Validates that the returned object is compatible with a pydantic model"
+
+    def validate(self, data: Any) -> base.ValidationResult:
+        try:
+            # Currently, validate can not alter the output data, so we must use
+            # strict=True. The downside to this is that data that could be coerced
+            # into the correct type will fail validation.
+            self._model_adapter.validate_python(data, strict=True)
+        except ValidationError as e:
+            return base.ValidationResult(
+                passes=False, message=str(e), diagnostics={"model_errors": e.errors()}
+            )
+        return base.ValidationResult(
+            passes=True,
+            message=f"Data passes pydantic check for model {str(self.model)}",
+        )
+
+    @classmethod
+    def arg(cls) -> str:
+        return "model"
+
+    @classmethod
+    def name(cls) -> str:
+        return "pydantic_validator"
+
+
+PYDANTIC_VALIDATORS = [PydanticModelValidator]

--- a/hamilton/data_quality/pydantic_validators.py
+++ b/hamilton/data_quality/pydantic_validators.py
@@ -19,10 +19,9 @@ class PydanticModelValidator(base.BaseDefaultValidator):
     :param arbitrary_types_allowed: Whether arbitrary types are allowed in the model
     """
 
-    def __init__(self, model: type[BaseModel], importance: str):
+    def __init__(self, model: Type[BaseModel], importance: str):
         super(PydanticModelValidator, self).__init__(importance)
         self.model = model
-
         self._model_adapter = TypeAdapter(model)
 
     @classmethod
@@ -32,7 +31,7 @@ class PydanticModelValidator(base.BaseDefaultValidator):
         return custom_subclass_check(datatype, BaseModel) or custom_subclass_check(datatype, dict)
 
     def description(self) -> str:
-        return "Validates that the returned object is compatible with a pydantic model"
+        return "Validates that the returned object is compatible with the specified pydantic model"
 
     def validate(self, data: Any) -> base.ValidationResult:
         try:

--- a/hamilton/plugins/h_pydantic.py
+++ b/hamilton/plugins/h_pydantic.py
@@ -28,6 +28,7 @@ class check_output(BaseDataValidationDecorator):
         Here is an example of how to use this decorator with a function that returns a pydantic model:
 
         .. code-block:: python
+
             :name: "@check_output using pydantic model output"
 
             from pydantic import BaseModel
@@ -46,6 +47,7 @@ class check_output(BaseDataValidationDecorator):
         complain about this):
 
         .. code-block:: python
+
             :name: "@check_output using dict output"
 
             from pydantic import BaseModel
@@ -65,6 +67,7 @@ class check_output(BaseDataValidationDecorator):
         following function will *fail* validation:
 
         .. code-block:: python
+
             :name: "@check_output invalid output in strict mode"
 
             from pydantic import BaseModel

--- a/hamilton/plugins/h_pydantic.py
+++ b/hamilton/plugins/h_pydantic.py
@@ -29,8 +29,6 @@ class check_output(BaseDataValidationDecorator):
 
         .. code-block:: python
 
-            :name: "@check_output using pydantic model output"
-
             from pydantic import BaseModel
             from hamilton.plugins import h_pydantic
 
@@ -47,8 +45,6 @@ class check_output(BaseDataValidationDecorator):
         complain about this):
 
         .. code-block:: python
-
-            :name: "@check_output using dict output"
 
             from pydantic import BaseModel
             from hamilton.plugins import h_pydantic
@@ -67,8 +63,6 @@ class check_output(BaseDataValidationDecorator):
         following function will *fail* validation:
 
         .. code-block:: python
-
-            :name: "@check_output invalid output in strict mode"
 
             from pydantic import BaseModel
             from hamilton.plugins import h_pydantic

--- a/hamilton/plugins/h_pydantic.py
+++ b/hamilton/plugins/h_pydantic.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from pydantic import BaseModel
+
+from hamilton import node
+from hamilton.data_quality import base as dq_base
+from hamilton.function_modifiers import InvalidDecoratorException
+from hamilton.function_modifiers import base as fm_base
+from hamilton.function_modifiers import check_output as base_check_output
+from hamilton.function_modifiers.validation import BaseDataValidationDecorator
+from hamilton.htypes import custom_subclass_check
+
+
+class check_output(BaseDataValidationDecorator):
+    def __init__(
+        self,
+        importance: str = dq_base.DataValidationLevel.WARN.value,
+        target: fm_base.TargetType = None,
+    ):
+        super(check_output, self).__init__(target)
+        self.importance = importance
+        self.target = target
+
+    def get_validators(self, node_to_validate: node.Node) -> List[dq_base.DataValidator]:
+        output_type = node_to_validate.type
+        if not custom_subclass_check(output_type, BaseModel):
+            raise InvalidDecoratorException(
+                f"Output of function {node_to_validate.name} must be a Pydantic model"
+            )
+        return base_check_output(
+            importance=self.importance, model=output_type, target_=self.target
+        ).get_validators(node_to_validate)

--- a/hamilton/plugins/h_pydantic.py
+++ b/hamilton/plugins/h_pydantic.py
@@ -29,8 +29,8 @@ class check_output(BaseDataValidationDecorator):
 
         .. code-block:: python
 
-            from pydantic import BaseModel
             from hamilton.plugins import h_pydantic
+            from pydantic import BaseModel
 
             class MyModel(BaseModel):
                 a: int
@@ -46,8 +46,8 @@ class check_output(BaseDataValidationDecorator):
 
         .. code-block:: python
 
-            from pydantic import BaseModel
             from hamilton.plugins import h_pydantic
+            from pydantic import BaseModel
 
             class MyModel(BaseModel):
                 a: int
@@ -58,14 +58,33 @@ class check_output(BaseDataValidationDecorator):
             def foo() -> MyModel:
                 return {"a": 1, "b": 2.0, "c": "hello"}
 
+        You can also use pydantic validation through ``function_modifiers.check_output`` by
+        providing the model as an argument:
+
+        .. code-block:: python
+
+            from typing import Any
+
+            from hamilton import function_modifiers
+            from pydantic import BaseModel
+
+            class MyModel(BaseModel):
+                a: int
+                b: float
+                c: str
+
+            @function_modifiers.check_output(model=MyModel)
+            def foo() -> dict[str, Any]:
+                return {"a": 1, "b": 2.0, "c": "hello"}
+
         Note, that because we do not (yet) support modification of the output, the validation is
         performed in strict mode, meaning that no data coercion is performed. For example, the
         following function will *fail* validation:
 
         .. code-block:: python
 
-            from pydantic import BaseModel
             from hamilton.plugins import h_pydantic
+            from pydantic import BaseModel
 
             class MyModel(BaseModel):
                 a: int  # Defined as an int

--- a/hamilton/plugins/h_pydantic.py
+++ b/hamilton/plugins/h_pydantic.py
@@ -17,6 +17,69 @@ class check_output(BaseDataValidationDecorator):
         importance: str = dq_base.DataValidationLevel.WARN.value,
         target: fm_base.TargetType = None,
     ):
+        """Specific output-checker for pydantic models. This decorator utilizes the output type of
+        the function, which can be any subclass of pydantic.BaseModel. The function output must
+        be declared with a type hint.
+
+        :param model: The pydantic model to use for validation. If this is not provided, then the output type of the function is used.
+        :param importance: Importance level (either "warn" or "fail") -- see documentation for check_output for more details.
+        :param target: The target of the decorator -- see documentation for check_output for more details.
+
+        Here is an example of how to use this decorator with a function that returns a pydantic model:
+
+        .. code-block:: python
+            :name: "@check_output using pydantic model output"
+
+            from pydantic import BaseModel
+            from hamilton.plugins import h_pydantic
+
+            class MyModel(BaseModel):
+                a: int
+                b: float
+                c: str
+
+            @h_pydantic.check_output()
+            def foo() -> MyModel:
+                return MyModel(a=1, b=2.0, c="hello")
+
+        Alternatively, you can return a dictionary from the function (type checkers will probably
+        complain about this):
+
+        .. code-block:: python
+            :name: "@check_output using dict output"
+
+            from pydantic import BaseModel
+            from hamilton.plugins import h_pydantic
+
+            class MyModel(BaseModel):
+                a: int
+                b: float
+                c: str
+
+            @h_pydantic.check_output()
+            def foo() -> MyModel:
+                return {"a": 1, "b": 2.0, "c": "hello"}
+
+        Note, that because we do not (yet) support modification of the output, the validation is
+        performed in strict mode, meaning that no data coercion is performed. For example, the
+        following function will *fail* validation:
+
+        .. code-block:: python
+            :name: "@check_output invalid output in strict mode"
+
+            from pydantic import BaseModel
+            from hamilton.plugins import h_pydantic
+
+            class MyModel(BaseModel):
+                a: int  # Defined as an int
+
+            @h_pydantic.check_output()  # This will fail validation!
+            def foo() -> MyModel:
+                return MyModel(a="1")  # Assigned as a string
+
+        For more information about strict mode see the pydantic docs: https://docs.pydantic.dev/latest/concepts/strict_mode/
+
+        """
         super(check_output, self).__init__(target)
         self.importance = importance
         self.target = target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,10 +147,7 @@ test = [
 ]
 tqdm = ["tqdm"]
 ui = ["sf-hamilton-ui"]
-vaex = [
-  "pydantic<2.0", # because of https://github.com/vaexio/vaex/issues/2384
-  "vaex"
-]
+vaex = ["vaex"]
 visualization = ["graphviz", "networkx"]
 
 [project.entry-points.console_scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ docs = [
   "pillow",
   "polars",
   "pyarrow >= 1.0.0",
+  "pydantic >=2.0",
   "pyspark",
     "openlineage-python",
   "PyYAML",
@@ -99,6 +100,7 @@ packaging = [
   "build",
 ]
 pandera = ["pandera"]
+pydantic = ["pydantic>=2.0"]
 pyspark = [
   # we have to run these dependencies because Spark does not check to ensure the right target was called
   "pyspark[pandas_on_spark,sql]"
@@ -129,6 +131,7 @@ test = [
   "plotly",
   "polars",
   "pyarrow",
+  "pydantic >=2.0",
   "pyreadstat", # for SPSS data loader
   "pytest",
   "pytest-asyncio",

--- a/tests/integrations/pydantic/requirements.txt
+++ b/tests/integrations/pydantic/requirements.txt
@@ -1,0 +1,1 @@
+# Additional requirements on top of hamilton...pydantic

--- a/tests/integrations/pydantic/test_pydantic_data_quality.py
+++ b/tests/integrations/pydantic/test_pydantic_data_quality.py
@@ -1,0 +1,271 @@
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from hamilton.data_quality.pydantic_validators import PydanticModelValidator
+from hamilton.function_modifiers import check_output
+from hamilton.node import Node
+from hamilton.plugins import h_pydantic
+
+
+def test_basic_pydantic_validator_passes():
+    class DummyModel(BaseModel):
+        value: float
+
+    validator = PydanticModelValidator(model=DummyModel, importance="warn")
+    validation_result = validator.validate({"value": 15.0})
+    assert validation_result.passes
+
+
+def test_basic_pydantic_check_output_passes():
+    class DummyModel(BaseModel):
+        value: float
+
+    @check_output(model=DummyModel, importance="warn")
+    def dummy() -> dict[str, float]:
+        return {"value": 15.0}
+
+    node = Node.from_fn(dummy)
+    validators = check_output(model=DummyModel).get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+    result_success = validator.validate(node())
+    assert result_success.passes
+
+
+def test_basic_pydantic_validator_fails():
+    class DummyModel(BaseModel):
+        value: float
+
+    validator = PydanticModelValidator(model=DummyModel, importance="warn")
+    validation_result = validator.validate({"value": "15.0"})
+    assert not validation_result.passes
+    assert "value" in validation_result.diagnostics["model_errors"][0]["loc"]
+
+
+def test_basic_pydantic_check_output_fails():
+    class DummyModel(BaseModel):
+        value: float
+
+    @check_output(model=DummyModel, importance="warn")
+    def dummy() -> dict[str, float]:
+        return {"value": "fifteen"}  # type: ignore
+
+    node = Node.from_fn(dummy)
+    validators = check_output(model=DummyModel).get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+    result = validator.validate(node())
+    assert not result.passes
+
+
+def test_pydantic_validator_is_strict():
+    class DummyModel(BaseModel):
+        value: float
+
+    validator = PydanticModelValidator(model=DummyModel, importance="warn")
+    validation_result = validator.validate({"value": "15"})
+    assert not validation_result.passes
+
+
+def test_complex_pydantic_validator_passes():
+    class Owner(BaseModel):
+        name: str
+
+    class Version(BaseModel):
+        name: str
+        id: int
+
+    class Repo(BaseModel):
+        name: str
+        owner: Owner
+        versions: list[Version]
+
+    data = {
+        "name": "hamilton",
+        "owner": {"name": "DAGWorks-Inc"},
+        "versions": [{"name": "0.1.0", "id": 1}, {"name": "0.2.0", "id": 2}],
+    }
+
+    validator = PydanticModelValidator(model=Repo, importance="warn")
+    validation_result = validator.validate(data)
+    assert validation_result.passes
+
+
+def test_complex_pydantic_validator_fails():
+    class Owner(BaseModel):
+        name: str
+
+    class Version(BaseModel):
+        name: str
+        id: int
+
+    class Repo(BaseModel):
+        name: str
+        owner: Owner
+        versions: list[Version]
+
+    data = {
+        "name": "hamilton",
+        "owner": {"name": "DAGWorks-Inc"},
+        "versions": [{"name": "0.1.0", "id": 1}, {"name": "0.2.0", "id": "2"}],
+    }
+
+    validator = PydanticModelValidator(model=Repo, importance="warn")
+    validation_result = validator.validate(data)
+    assert not validation_result.passes
+
+
+def test_complex_pydantic_check_output_passes():
+    class Owner(BaseModel):
+        name: str
+
+    class Version(BaseModel):
+        name: str
+        id: int
+
+    class Repo(BaseModel):
+        name: str
+        owner: Owner
+        versions: list[Version]
+
+    @check_output(model=Repo, importance="warn")
+    def dummy() -> dict[str, Any]:
+        return {
+            "name": "hamilton",
+            "owner": {"name": "DAGWorks-Inc"},
+            "versions": [{"name": "0.1.0", "id": 1}, {"name": "0.2.0", "id": 2}],
+        }
+
+    node = Node.from_fn(dummy)
+    validators = check_output(model=Repo).get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+    result_success = validator.validate(node())
+    assert result_success.passes
+
+
+def test_complex_pydantic_check_output_fails():
+    class Owner(BaseModel):
+        name: str
+
+    class Version(BaseModel):
+        name: str
+        id: int
+
+    class Repo(BaseModel):
+        name: str
+        owner: Owner
+        versions: list[Version]
+
+    @check_output(model=Repo, importance="warn")
+    def dummy() -> dict[str, Any]:
+        return {
+            "name": "hamilton",
+            "owner": {"name": "DAGWorks-Inc"},
+            "versions": [
+                {"name": "0.1.0", "id": "one"},  # id should be an int
+                {"name": "0.2.0", "id": "two"},  # id should be an int
+            ],
+        }
+
+    node = Node.from_fn(dummy)
+    validators = check_output(model=Repo).get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+    result = validator.validate(node())
+    assert not result.passes
+
+
+def test_basic_pydantic_plugin_check_output_passes():
+    class DummyModel(BaseModel):
+        value: float
+
+    def dummy() -> DummyModel:
+        return DummyModel(value=15.0)
+
+    node = Node.from_fn(dummy)
+    validators = h_pydantic.check_output().get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+    result_success = validator.validate(node())
+    assert result_success.passes
+
+
+def test_basic_pydantic_plugin_check_output_fails():
+    class DummyModel(BaseModel):
+        value: float
+
+    def dummy() -> DummyModel:
+        return DummyModel(value="fifteen")  # type: ignore
+
+    node = Node.from_fn(dummy)
+    validators = h_pydantic.check_output().get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+
+    with pytest.raises(ValidationError):
+        result = validator.validate(node())
+        assert not result.passes
+
+
+def test_complex_pydantic_plugin_check_output_passes():
+    class Owner(BaseModel):
+        name: str
+
+    class Version(BaseModel):
+        name: str
+        id: int
+
+    class Repo(BaseModel):
+        name: str
+        owner: Owner
+        versions: list[Version]
+
+    def dummy() -> Repo:
+        return Repo(
+            name="hamilton",
+            owner=Owner(name="DAGWorks-Inc"),
+            versions=[Version(name="0.1.0", id=1), Version(name="0.2.0", id=2)],
+        )
+
+    node = Node.from_fn(dummy)
+    validators = h_pydantic.check_output().get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+    result_success = validator.validate(node())
+    assert result_success.passes
+
+
+def test_complex_pydantic_plugin_check_output_fails():
+    class Owner(BaseModel):
+        name: str
+
+    class Version(BaseModel):
+        name: str
+        id: int
+
+    class Repo(BaseModel):
+        name: str
+        owner: Owner
+        versions: list[Version]
+
+    def dummy() -> Repo:
+        return Repo(
+            name="hamilton",
+            owner=Owner(name="DAGWorks-Inc"),
+            versions=[
+                Version(name="0.1.0", id=1),
+                Version(name="0.2.0", id="two"),  # type: ignore
+            ],
+        )
+
+    node = Node.from_fn(dummy)
+    validators = h_pydantic.check_output().get_validators(node)
+    assert len(validators) == 1
+    validator = validators[0]
+
+    with pytest.raises(ValidationError):
+        result = validator.validate(node())
+        assert not result.passes

--- a/tests/integrations/pydantic/test_pydantic_data_quality.py
+++ b/tests/integrations/pydantic/test_pydantic_data_quality.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict, List
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -23,7 +23,7 @@ def test_basic_pydantic_check_output_passes():
         value: float
 
     @check_output(model=DummyModel, importance="warn")
-    def dummy() -> dict[str, float]:
+    def dummy() -> Dict[str, float]:
         return {"value": 15.0}
 
     node = Node.from_fn(dummy)
@@ -49,7 +49,7 @@ def test_basic_pydantic_check_output_fails():
         value: float
 
     @check_output(model=DummyModel, importance="warn")
-    def dummy() -> dict[str, float]:
+    def dummy() -> Dict[str, float]:
         return {"value": "fifteen"}  # type: ignore
 
     node = Node.from_fn(dummy)
@@ -80,7 +80,7 @@ def test_complex_pydantic_validator_passes():
     class Repo(BaseModel):
         name: str
         owner: Owner
-        versions: list[Version]
+        versions: List[Version]
 
     data = {
         "name": "hamilton",
@@ -104,7 +104,7 @@ def test_complex_pydantic_validator_fails():
     class Repo(BaseModel):
         name: str
         owner: Owner
-        versions: list[Version]
+        versions: List[Version]
 
     data = {
         "name": "hamilton",
@@ -128,10 +128,10 @@ def test_complex_pydantic_check_output_passes():
     class Repo(BaseModel):
         name: str
         owner: Owner
-        versions: list[Version]
+        versions: List[Version]
 
     @check_output(model=Repo, importance="warn")
-    def dummy() -> dict[str, Any]:
+    def dummy() -> Dict[str, Any]:
         return {
             "name": "hamilton",
             "owner": {"name": "DAGWorks-Inc"},
@@ -157,10 +157,10 @@ def test_complex_pydantic_check_output_fails():
     class Repo(BaseModel):
         name: str
         owner: Owner
-        versions: list[Version]
+        versions: List[Version]
 
     @check_output(model=Repo, importance="warn")
-    def dummy() -> dict[str, Any]:
+    def dummy() -> Dict[str, Any]:
         return {
             "name": "hamilton",
             "owner": {"name": "DAGWorks-Inc"},
@@ -221,7 +221,7 @@ def test_complex_pydantic_plugin_check_output_passes():
     class Repo(BaseModel):
         name: str
         owner: Owner
-        versions: list[Version]
+        versions: List[Version]
 
     def dummy() -> Repo:
         return Repo(
@@ -249,7 +249,7 @@ def test_complex_pydantic_plugin_check_output_fails():
     class Repo(BaseModel):
         name: str
         owner: Owner
-        versions: list[Version]
+        versions: List[Version]
 
     def dummy() -> Repo:
         return Repo(


### PR DESCRIPTION
This PR adds pydantic integration via a new data validator and plugin. Resolves #473.

## Changes

I added a file called `data_quality/pydantic_validators.py` with a new default validator `PydanticModelValidator`. This validator is dynamically added to the list of available default validators if pydantic is available - very similar, some would say identical 😄, to how the pandera validators are added. The pydantic validator is passed a `model` parameter that is then used to validated the output of the decorated function:

```python
class MyModel(BaseModel):
    name: str

@check_output(model=MyModel)
def foo() -> dict:
    return {"name": "hamilton"}
```

I also added a plugin file `plugins/h_pydantic.py` with a variant of the `check_output` decorator that uses the return type annotation to establish the pydantic model to validate:

```python
class MyModel(BaseModel):
    name: str

@h_pydantic.check_output()
def foo() -> MyModel:
    return MyModel(name="hamilton")
```

My implementation uses the pydantic [`TypeAdapter`](https://docs.pydantic.dev/latest/concepts/type_adapter/) - mainly because [`pydantic.validate_call`](https://docs.pydantic.dev/latest/api/validate_call/) does not have an option to *only* check the return value. `TypeAdapter` allows you to specify a `strict` mode where type coercion is turned off, since modifying the outputs is not currently allowed (that is correct, right?). I have enabled `strict` mode for both the validator and the plugin.

Although I think that it is idiomatic to pydantic, I should point out that `strict`mode  does *not* stop you from doing this (i.e. this passes validation):

```python
class MyModel(BaseModel):
    name: str

@h_pydantic.check_output()
def foo() -> MyModel:
    return {name: "hamilton"}
```

One last thing to mention is that `h_pydantic.check_output` currently checks that the return type annotation is a subclass of `pydantic.BaseModel`. In theory, you could use pydantic to check all kinds of things (builtins, `Annotated` types, ...), however I was having trouble getting it to play nicely with validator resolution so I scraped it.

## How I tested this

I added a file to the testing suite `test_pydantic_data_quality.py` that tests the validator and the `check_out` plugin decorator for both basic and complex cases.

## Notes

There are a couple of points I wanted to bring up:
-  `TypeAdapter` is a pydantic 2.0 feature and in conflict with the `[vaex]` extra dependency 😞. I didn't notice this until I was updating `pyproject.toml`, let me know if this is a deal breaker and I will come up with an alternative implementation
- I deviated from the spec in #473 and used `model` (vice `schema`) and `pydantic.check_output` (vice `pydantic.check_output_schema`) - I can change them back if desired, I just thought they fit better with the terminology of pydantic and the ergonomics of the pandera plugin, respectively.
- I will update the documentation and the plugin docstring if you are good with the above notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

Thanks for the opportunity to dig into this!
