### PR TITLE
Sketches possible fix to help #1124

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -784,10 +784,13 @@ def _add_original_function_to_nodes(fn: Callable, nodes: List[node.Node]) -> Lis
     out = []
     for node_ in nodes:
         current_originating_functions = node_.originating_functions
-        new_originating_functions = (
-            current_originating_functions if current_originating_functions is not None else ()
-        ) + (fn,)
-        out.append(node_.copy_with(originating_functions=new_originating_functions))
+        if current_originating_functions and fn not in current_originating_functions:
+            new_originating_functions = (
+                current_originating_functions if current_originating_functions is not None else ()
+            ) + (fn,)
+            out.append(node_.copy_with(originating_functions=new_originating_functions))
+        else:
+            out.append(node_)
     return out
 
 

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -265,16 +265,21 @@ class parameterize(base.NodeExpander):
                     new_input_types[param] = (
                         val  # We just use the standard one, nothing is getting replaced
                     )
+            partial_func = functools.partial(
+                replacement_function,
+                **{parameter: val.value for parameter, val in literal_dependencies.items()},
+            )
             nodes.append(
                 node_.copy_with(
                     name=output_node,
                     doc_string=docstring,  # TODO -- change docstring
-                    callabl=functools.partial(
-                        replacement_function,
-                        **{parameter: val.value for parameter, val in literal_dependencies.items()},
-                    ),
+                    callabl=partial_func,
                     input_types=new_input_types,
                     include_refs=False,  # Include refs is here as this is earlier than compile time
+                    originating_functions=(
+                        fn,
+                        partial_func,
+                    ),
                     # TODO -- figure out why this isn't getting replaced later...
                 )
             )


### PR DESCRIPTION
We're inconsistent as to when originating_functions is populated. So this tries to fix it for expander parameterize decorator at least.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
