### PR TITLE
Bug fix when using `HamiltonTracker` with polars dataframes 

### DIFF
--- a/ui/sdk/src/hamilton_sdk/tracking/polars_col_stats.py
+++ b/ui/sdk/src/hamilton_sdk/tracking/polars_col_stats.py
@@ -147,7 +147,7 @@ def datetime_column_stats(
 
 
 def str_len(col: pl.Series) -> pl.Series:
-    return col.str.lengths()
+    return col.str.len_chars()
 
 
 def avg_str_len(str_len: pl.Series) -> float:

--- a/ui/sdk/tests/tracking/test_polars_col_stats.py
+++ b/ui/sdk/tests/tracking/test_polars_col_stats.py
@@ -108,3 +108,6 @@ def test_min_string(example_df_string):
 
 def test_max_string(example_df_string):
     assert pcs.max(example_df_string["a"]) == "e"
+
+def test_str_len(example_df_string):
+    assert pcs.str_len(example_df_string["a"]).to_list() == [1, 1, 1, 1, 1]

--- a/ui/sdk/tests/tracking/test_polars_col_stats.py
+++ b/ui/sdk/tests/tracking/test_polars_col_stats.py
@@ -109,5 +109,6 @@ def test_min_string(example_df_string):
 def test_max_string(example_df_string):
     assert pcs.max(example_df_string["a"]) == "e"
 
+
 def test_str_len(example_df_string):
     assert pcs.str_len(example_df_string["a"]).to_list() == [1, 1, 1, 1, 1]


### PR DESCRIPTION
Fixes an error when tracking in the hamilton ui with polars dataframes:

```
    return col.str.lengths()
           ^^^^^^^^^^^^^^^
AttributeError: 'StringNameSpace' object has no attribute 'lengths'
```

## Changes

Use the [correct polars method](https://docs.pola.rs/api/python/stable/reference/series/api/polars.Series.str.len_chars.html)

## How I tested this

Run the code and it doesn't error anymore

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
