### PR TITLE
Refactor to enable RayGraphAdapter and HamiltonTracker to work well t…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-#      args: [ --diff ]  # Use for previewing changes
+      # args: [ --diff ]  # Use for previewing changes
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/examples/ray/ray_Hamilton_UI_tracking/README
+++ b/examples/ray/ray_Hamilton_UI_tracking/README
@@ -1,0 +1,29 @@
+# Tracking telemetry in Hamilton UI for Ray clusters
+
+We show the ability to combine the [RayGraphAdapter](https://hamilton.dagworks.io/en/latest/reference/graph-adapters/RayGraphAdapter/) and [HamiltonTracker](https://hamilton.dagworks.io/en/latest/concepts/ui/) to run a dummy DAG.
+
+# ray_lineage.py
+Has three dummy functions:
+- waiting 5s
+- waiting 1s
+- raising an error
+
+That represent a basic DAG.
+
+# run_lineage.py
+Is where the driver code lives to create the DAG and exercise it.
+
+To exercise it:
+> Have an open instance of Hamilton UI: https://hamilton.dagworks.io/en/latest/concepts/ui/
+
+```bash
+python -m run_lineage.py
+Usage: python -m run_lineage.py [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  project_id      This command will select the created project in Hamilton UI
+  username  This command will input the correct username to access the selected project_id
+```

--- a/examples/ray/ray_Hamilton_UI_tracking/hamilton_notebook.ipynb
+++ b/examples/ray/ray_Hamilton_UI_tracking/hamilton_notebook.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hamilton UI Adapter\n",
+    "\n",
+    "Needs a running instance of Hamilton UI: https://hamilton.dagworks.io/en/latest/concepts/ui/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hamilton_sdk.adapters import HamiltonTracker\n",
+    "\n",
+    "# Inputs required to track into correct project in the UI\n",
+    "project_id = 2\n",
+    "username = \"admin\"\n",
+    "\n",
+    "tracker_ray = HamiltonTracker(\n",
+    "        project_id=project_id,\n",
+    "        username=username,\n",
+    "        dag_name=\"telemetry_with_ray\",)\n",
+    "\n",
+    "tracker_without_ray = HamiltonTracker(\n",
+    "        project_id=project_id,\n",
+    "        username=username,\n",
+    "        dag_name=\"telemetry_without_ray\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ray adapter\n",
+    "\n",
+    "https://hamilton.dagworks.io/en/latest/reference/graph-adapters/RayGraphAdapter/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hamilton import base\n",
+    "from hamilton.plugins.h_ray import RayGraphAdapter\n",
+    "\n",
+    "rga = RayGraphAdapter(result_builder=base.PandasDataFrameResult())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importing Hamilton and the DAG modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hamilton import driver\n",
+    "import ray_lineage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    dr_ray = driver.Builder().with_modules(ray_lineage).with_adapters(rga, tracker_ray).build()\n",
+    "    result_ray = dr_ray.execute(\n",
+    "        final_vars=[\n",
+    "            \"node_5s\",\n",
+    "            \"node_1s_error\",\n",
+    "            \"add_1_to_previous\",\n",
+    "        ]\n",
+    "    )\n",
+    "    print(result_ray)\n",
+    "\n",
+    "except ValueError:\n",
+    "    print(\"UI should display failure.\")\n",
+    "finally:\n",
+    "    dr_without_ray = driver.Builder().with_modules(ray_lineage).with_adapters(tracker).build()\n",
+    "    result_without_ray = dr_without_ray.execute(final_vars=[\"node_5s\", \"add_1_to_previous\"])\n",
+    "    print(result_without_ray)  \n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/ray/ray_Hamilton_UI_tracking/ray_lineage.py
+++ b/examples/ray/ray_Hamilton_UI_tracking/ray_lineage.py
@@ -1,0 +1,18 @@
+import time
+
+
+def node_5s() -> float:
+    start = time.time()
+    time.sleep(5)
+    return time.time() - start
+
+
+def add_1_to_previous(node_5s: float) -> float:
+    start = time.time()
+    time.sleep(1)
+    return node_5s + (time.time() - start)
+
+
+def node_1s_error(node_5s: float) -> float:
+    time.sleep(1)
+    raise ValueError("Does not break telemetry if executed through ray")

--- a/examples/ray/ray_Hamilton_UI_tracking/requirements.txt
+++ b/examples/ray/ray_Hamilton_UI_tracking/requirements.txt
@@ -1,0 +1,1 @@
+sf-hamilton[ray,sdk,ui]

--- a/examples/ray/ray_Hamilton_UI_tracking/run_lineage.py
+++ b/examples/ray/ray_Hamilton_UI_tracking/run_lineage.py
@@ -1,0 +1,45 @@
+import click
+import ray_lineage
+
+from hamilton import base, driver
+from hamilton.plugins.h_ray import RayGraphAdapter
+from hamilton_sdk import adapters
+
+
+@click.command()
+@click.option("--username", required=True, type=str)
+@click.option("--project_id", default=1, type=int)
+def run(project_id, username):
+    try:
+        tracker_ray = adapters.HamiltonTracker(
+            project_id=project_id,
+            username=username,
+            dag_name="telemetry_with_ray",
+        )
+        rga = RayGraphAdapter(result_builder=base.PandasDataFrameResult())
+        dr_ray = driver.Builder().with_modules(ray_lineage).with_adapters(rga, tracker_ray).build()
+        result_ray = dr_ray.execute(
+            final_vars=[
+                "node_5s",
+                "node_1s_error",
+                "add_1_to_previous",
+            ]
+        )
+        print(result_ray)
+
+    except ValueError:
+        print("UI should display failure.")
+    finally:
+        tracker = adapters.HamiltonTracker(
+            project_id=project_id,  # modify this as needed
+            username=username,
+            dag_name="telemetry_without_ray",
+        )
+        dr_without_ray = driver.Builder().with_modules(ray_lineage).with_adapters(tracker).build()
+
+        result_without_ray = dr_without_ray.execute(final_vars=["node_5s", "add_1_to_previous"])
+        print(result_without_ray)
+
+
+if __name__ == "__main__":
+    run()

--- a/hamilton/dev_utils/deprecation.py
+++ b/hamilton/dev_utils/deprecation.py
@@ -48,8 +48,8 @@ class deprecated:
     @deprecate(
         warn_starting=(1,10,0)
         fail_starting=(2,0,0),
-        use_instead=parameterize_values,
-        reason='We have redefined the parameterization decorators to consist of `parametrize`, `parametrize_inputs`, and `parametrize_values`
+        use_this=parameterize_values,
+        explanation='We have redefined the parameterization decorators to consist of `parametrize`, `parametrize_inputs`, and `parametrize_values`
         migration_guide="https://github.com/dagworks-inc/hamilton/..."
     )
     class parameterized(...):
@@ -66,7 +66,7 @@ class deprecated:
     explanation: str
     migration_guide: Optional[
         str
-    ]  # If this is None, this means that the use_instead is a drop in replacement
+    ]  # If this is None, this means that the use_this is a drop in replacement
     current_version: Union[Tuple[int, int, int], Version] = dataclasses.field(
         default_factory=lambda: CURRENT_VERSION
     )

--- a/hamilton/lifecycle/base.py
+++ b/hamilton/lifecycle/base.py
@@ -519,6 +519,26 @@ class BaseDoNodeExecute(abc.ABC):
         pass
 
 
+@lifecycle.base_method("do_remote_execute")
+class BaseDoRemoteExecute(abc.ABC):
+    @abc.abstractmethod
+    def do_remote_execute(
+        self,
+        *,
+        node: "node.Node",
+        kwargs: Dict[str, Any],
+        execute_lifecycle_for_node: Callable,
+    ) -> Any:
+        """Method that is called to implement correct remote execution of hooks. This makes sure that all the pre-node and post-node hooks get executed in the remote environment which is necessary for some adapters. Node execution is called the same as before through "do_node_execute".
+
+
+        :param node: Node that is being executed
+        :param kwargs: Keyword arguments that are being passed into the node
+        :param execute_lifecycle_for_node: Function executing lifecycle_hooks and lifecycle_methods
+        """
+        pass
+
+
 @lifecycle.base_method("do_node_execute")
 class BaseDoNodeExecuteAsync(abc.ABC):
     @abc.abstractmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dask-distributed = ["dask[distributed]"]
 datadog = ["ddtrace"]
 dev = [
   "pre-commit",
-  "ruff",
+  "ruff==0.5.7", # this should match `.pre-commit-config.yaml`
 ]
 diskcache = ["diskcache"]
 docs = [

--- a/tests/lifecycle/lifecycle_adapters_for_testing.py
+++ b/tests/lifecycle/lifecycle_adapters_for_testing.py
@@ -9,6 +9,7 @@ from hamilton.graph import FunctionGraph
 from hamilton.lifecycle.base import (
     BaseDoBuildResult,
     BaseDoNodeExecute,
+    BaseDoRemoteExecute,
     BaseDoValidateInput,
     BasePostGraphConstruct,
     BasePostGraphExecute,
@@ -185,6 +186,23 @@ class TrackingDoNodeExecuteHook(ExtendToTrackCalls, BaseDoNodeExecute):
         if node_.type == int and node_.name != "n_iters":
             return node_(**kwargs) + self._additional_value
         return node_(**kwargs)
+
+
+class TrackingDoRemoteExecuteHook(ExtendToTrackCalls, BaseDoRemoteExecute):
+    def __init__(self, name: str, additional_value: int):
+        super().__init__(name)
+        self._additional_value = additional_value
+
+    def do_remote_execute(
+        self,
+        node: "node.Node",
+        execute_lifecycle_for_node: Callable,
+        **kwargs: Dict[str, Any],
+    ) -> Any:
+        node_ = node
+        if node_.type == int and node_.name != "n_iters":
+            return execute_lifecycle_for_node(**kwargs) + self._additional_value
+        return execute_lifecycle_for_node(**kwargs)
 
 
 class TrackingDoBuildResultMethod(ExtendToTrackCalls, BaseDoBuildResult):

--- a/ui/sdk/.pre-commit-config.yaml
+++ b/ui/sdk/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v0.0.265
     hooks:
         - id: ruff
-          args: [ --fix, --exit-non-zero-on-fix ]
+          args: [ --fix , --exit-non-zero-on-fix ]
 -   repo: https://github.com/ambv/black
     rev: 23.3.0
     hooks:

--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -103,6 +103,10 @@ class HamiltonTracker(
         # if you're using a float value.
         self.seed = None
 
+    def stop(self):
+        """Initiates stop if run in remote environment"""
+        self.client.stop()
+
     def post_graph_construct(
         self, graph: h_graph.FunctionGraph, modules: List[ModuleType], config: Dict[str, Any]
     ):

--- a/ui/sdk/src/hamilton_sdk/api/clients.py
+++ b/ui/sdk/src/hamilton_sdk/api/clients.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+import atexit
 import datetime
 import functools
 import logging
@@ -196,6 +197,9 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
         ).start()
         self.worker_thread.start()
 
+        # Makes sure the process stops even if in remote environment
+        atexit.register(self.stop)
+
     def __getstate__(self):
         # Copy the object's state from self.__dict__ which contains
         # all our instance attributes. Always use the dict.copy()
@@ -217,6 +221,7 @@ class BasicSynchronousHamiltonClient(HamiltonClient):
             target=lambda: threading.main_thread().join() or self.data_queue.put(None)
         ).start()
         self.worker_thread.start()
+        atexit.register(self.stop)
 
     def worker(self):
         """Worker thread to process the queue."""


### PR DESCRIPTION
…ogether

This is a squash commit:
- issue=https://github.com/DAGWorks-Inc/hamilton/issues/1079
- PR=https://github.com/DAGWorks-Inc/hamilton/pull/1103

Update graph_functions.py

Describes what to do in `graph_functions.py`

Adds comments to lifecycle base

Update h_ray.py with comments for ray tracking compatibility

Replicate previous error

Inline function, unsure if catching errors and exceptions to be handadled differently

BaseDoRemoteExecute has the added Callable function that snadwisched lifecycle hooks

method fails, says AssertionError about ray.remote decorator

simple script for now to check telemetry, execution yield the ray.remote AssertionError

passing pointer through and arguments to lifecycle wrapper into ray.remote

post-execute hook for node not called

finally executed only when exception occurs, hamilton tracker not executed

atexit.register does not work, node keeps running inui

added stop() method, but doesn't get called

Ray telemtry works for single node, problem with connected nodes

Ray telemtry works for single node, problem with connected nodes

Ray telemtry works for single node, problem with connected nodes

Fixes ray object dereferencing

Ray does not resolve nested arguments:
https://docs.ray.io/en/latest/ray-core/objects.html#passing-object-arguments

So one option is to make them all top level:

- one way to do that is to make the other arguments not clash with any possible user parameters -- hence the `__` prefix. This is what I did.
- another way would be in the ray adapter, wrap the incoming function, and explicitly do a ray.get() on any ray object references in the kwargs arguments. i.e. keep the nested structure, but when the ray task starts way for all inputs... not sure which is best, but this now works correctly.

ray works checkpoint, pre-commit fixed

fixed graph level telemtry proposal

pinned ruff

Correct output, added option to start ray cluster

Unit test mimicks the DoNodeExecute unit test

All commits:
- Update graph_functions.py

Describes what to do in `graph_functions.py`

Adds comments to lifecycle base

Update h_ray.py with comments for ray tracking compatibility

Replicate previous error

Inline function, unsure if catching errors and exceptions to be handadled differently

BaseDoRemoteExecute has the added Callable function that snadwisched lifecycle hooks

method fails, says AssertionError about ray.remote decorator

simple script for now to check telemetry, execution yield the ray.remote AssertionError

passing pointer through and arguments to lifecycle wrapper into ray.remote

post-execute hook for node not called

finally executed only when exception occurs, hamilton tracker not executed

atexit.register does not work, node keeps running inui

added stop() method, but doesn't get called

Ray telemtry works for single node, problem with connected nodes

Ray telemtry works for single node, problem with connected nodes

Ray telemtry works for single node, problem with connected nodes

Fixes ray object dereferencing

Ray does not resolve nested arguments:
https://docs.ray.io/en/latest/ray-core/objects.html#passing-object-arguments

So one option is to make them all top level:

- one way to do that is to make the other arguments not clash with any possible user parameters -- hence the `__` prefix. This is what I did.
- another way would be in the ray adapter, wrap the incoming function, and explicitly do a ray.get() on any ray object references in the kwargs arguments. i.e. keep the nested structure, but when the ray task starts way for all inputs... not sure which is best, but this now works correctly.

ray works checkpoint, pre-commit fixed

fixed graph level telemtry proposal

pinned ruff

Correct output, added option to start ray cluster

Unit test mimicks the DoNodeExecute unit test

Refactored driver so all tests pass

Refactored driver so all tests pass

Refactored driver so all tests pass

Refactored driver so all tests pass

Workaround to not break ray by calling init on an open cluster

raw_execute does not have post_graph_execute and is private now

Correct version for depraction warning

all tests work

this looks better

ruff version comment

Refactored pre- and post-graph-execute hooks outside of raw_execute which now has deprecation warning

added readme, notebook and made script cli interactive

made cluster init optional through inserting config dict

User has option to shutdown ray cluster

--- PR TEMPLATE INSTRUCTIONS (1) ---

Looking to submit a Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
* [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)

Else, if not, please remove this block of text.

--- PR TEMPLATE INSTRUCTIONS (2) ---

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
