### PR TITLE
Update the `check_for_changes` job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Check for changes in specific paths
           command: |
             set +e
-            git diff --name-only HEAD^ HEAD | grep '^.ci\|^.circleci\|^graph_adapter_tests\|^hamilton\|^plugin_tests\|^tests\|^requirements\|setup' > /dev/null
+            git diff --name-only origin/main...HEAD | grep '^.ci\|^.circleci\|^graph_adapter_tests\|^hamilton\|^plugin_tests\|^tests\|^requirements\|setup' > /dev/null
             if [ $? -eq 0 ]; then
               echo "Changes found in target paths."
               echo 'true' > /tmp/changes_detected


### PR DESCRIPTION
As per my conversation with @elijahbenizzy in #1121 I have updated the `check_for_changes` job in the CI configuration file so that it compares against `main` (vice the previous commit `HEAD^`). This will hopefully allow CI to detect changes in multi-commit pushes.

## Changes

I updated the `check_for_changes` job in `./circleci/config.yml` to use `git diff --name-only origin/main...HEAD`.

## How I tested this

I made a mulit-commit push where the first commit alters `./circleci/config.yml` and the second commit is empty. The new `check_for_changes` command should detect the changes in `./circleci/config.yml` and run the tests.

## Notes

I will remove all test commits before merging into main!

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
