### PR TITLE
docs: new — reloading of imports in Hamilton Jupyter Magic cells

### DIFF
--- a/docs/how-tos/use-in-jupyter-notebook.md
+++ b/docs/how-tos/use-in-jupyter-notebook.md
@@ -52,6 +52,25 @@ Once you're happy with the functions you've developed, you can then write them o
 %%writefile hello_world.py
 ```
 
+#### Importing specific functions into cell modules
+
+If you import parts of modules in a Hamilton Jupyter Magic cell, these will need to be reloaded when changes are made to their source. This can be done either by restarting the kernel or with the help of importlib.reload:
+
+```python
+%%cell_to_module MODULE_NAME
+
+# first import the module itself, so it can be reloaded
+import my_common_functions
+
+# reload the module
+import importlib
+importlib.reload(my_common_functions)
+# now import the specific function from the module
+from my_common_functions import commonfunction
+
+# use the imported function
+commonfunction()
+```
 
 ### Using ad_hoc_utils to create a temporary module (e.g. use in google colab)
 You have the ability to inline define functions with your driver that can be used to build a DAG. _We strongly recommend only using this approach when absolutely necessary_ — it’s very easy to build spaghetti code this way.


### PR DESCRIPTION
Adds instructions on how to reload modules when using the jupyter magic

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
