### PR TITLE
added check for default_factory

### DIFF
--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -1,4 +1,3 @@
-import dataclasses
 import inspect
 import logging
 import typing
@@ -54,14 +53,6 @@ class AdapterFactory:
         required_args = self.adapter_cls.get_required_arguments()
         optional_args = self.adapter_cls.get_optional_arguments()
         missing_params = set(required_args.keys()) - set(self.kwargs.keys())
-
-        SENTINEL = object()
-        fields = getattr(self.adapter_cls, "__dataclass_fields__", SENTINEL)
-        if fields is not SENTINEL:
-            for field_name, field in fields.items():
-                if (field.default_factory != dataclasses.MISSING) and field_name in missing_params:
-                    missing_params.remove(field_name)
-
         extra_params = (
             set(self.kwargs.keys()) - set(required_args.keys()) - set(optional_args.keys())
         )

--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -49,7 +49,6 @@ class AdapterFactory:
 
         :raises InvalidDecoratorException: If the arguments are invalid.
         """
-        # get_required_arguments won't catch dataclasses.field(default_factory=...)
         required_args = self.adapter_cls.get_required_arguments()
         optional_args = self.adapter_cls.get_optional_arguments()
         missing_params = set(required_args.keys()) - set(self.kwargs.keys())

--- a/hamilton/io/data_adapters.py
+++ b/hamilton/io/data_adapters.py
@@ -72,7 +72,7 @@ class AdapterCommon(abc.ABC):
         return {
             field.name: type_hints.get(field.name)
             for field in dataclasses.fields(cls)
-            if field.default == dataclasses.MISSING
+            if field.default == dataclasses.MISSING and field.default_factory == dataclasses.MISSING
         }
 
     @classmethod
@@ -87,7 +87,7 @@ class AdapterCommon(abc.ABC):
         return {
             field.name: type_hints.get(field.name)
             for field in dataclasses.fields(cls)
-            if field.default != dataclasses.MISSING
+            if field.default != dataclasses.MISSING or field.default_factory != dataclasses.MISSING
         }
 
     @classmethod

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -573,7 +573,7 @@ def test_loader_default_factory_field():
         ad_hoc_utils.create_temporary_module(foo),
         config={},
     )
-    assert len(fg) == 4
+    assert len(fg) == 3
     assert "foo" in fg
 
 
@@ -605,7 +605,7 @@ def test_saver_default_factory_field():
         ad_hoc_utils.create_temporary_module(foo),
         config={},
     )
-    assert len(fg) == 4
+    assert len(fg) == 3
     assert "foo" in fg
 
 

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -546,6 +546,70 @@ def test_save_to_decorator_with_target():
 
 
 @dataclasses.dataclass
+class DefaultFactoryLoader(DataLoader):
+    field_with_factory: int = dataclasses.field(default_factory=int)
+
+    def __post_init__(self):
+        self.param2 = self.field_with_factory + 1
+
+    def load_data(self, type_: Type[int]) -> Tuple[int, Dict[str, Any]]:
+        return self.param2, {}
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [int]
+
+    @classmethod
+    def name(cls) -> str:
+        return "factory"
+
+
+def test_loader_default_factory_field():
+    @LoadFromDecorator([DefaultFactoryLoader])
+    def foo(param: int) -> int:
+        return param
+
+    fg = graph.create_function_graph(
+        ad_hoc_utils.create_temporary_module(foo),
+        config={},
+    )
+    assert len(fg) == 4
+    assert "foo" in fg
+
+
+@dataclasses.dataclass
+class DefaultFactorySaver(DataSaver):
+    field_with_factory: int = dataclasses.field(default_factory=int)
+
+    def __post_init__(self):
+        self.param2 = self.field_with_factory + 1
+
+    def save_data(self, data: int) -> Dict[str, Any]:
+        return {}
+
+    @classmethod
+    def applicable_types(cls) -> Collection[Type]:
+        return [int]
+
+    @classmethod
+    def name(cls) -> str:
+        return "factory"
+
+
+def test_saver_default_factory_field():
+    @SaveToDecorator([DefaultFactorySaver])
+    def foo(param: int) -> int:
+        return param
+
+    fg = graph.create_function_graph(
+        ad_hoc_utils.create_temporary_module(foo),
+        config={},
+    )
+    assert len(fg) == 4
+    assert "foo" in fg
+
+
+@dataclasses.dataclass
 class OptionalParamDataLoader(DataLoader):
     param: int = 1
 


### PR DESCRIPTION
Related to #1148 

The current check uses `cls.get_required_arguments()` but this misses cases where the `dataclass` has an attribute with `field(default_factory=...)`. 

Now, the validation adds a step to inspect the dataclass's fields and check if a `default_factory` is set or if it's set to the sentinel value `dataclass.MISSING`.


Tests:
- added two tests with mock `DataLoader` and `DataSaver` ensuring that the `Driver` can now be properly built.
- Did a repro of the issue mentioned and now the `Driver` can be built and executed successfully