### PR TITLE
Adds instructions for creating a PDF of the documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,9 @@ sphinx:
   fail_on_warning: true
   configuration: docs/conf.py
 
+formats:
+  - pdf
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:

--- a/README-DOCS.md
+++ b/README-DOCS.md
@@ -24,6 +24,15 @@ Note: readthedocs builds will fail if there are ANY WARNINGs in the build.
 So make sure to check the build log for any warnings, and fix them, else you'll waste time debugging readthedocs
 build failures.
 
+# SimplePDF
+To create a PDF, you can run the following:
+```bash
+sphinx-build -b simplepdf  -W -E -T  -a docs /tmp/mydocs
+# or if you want to auto-rebuild:
+sphinx-autobuild -b simplepdf  -W -E -T  --watch hamilton/ -a docs /tmp/mydocs
+```
+The PDF will be in `/tmp/mydocs` in a few minutes.
+
 # reST vs myST
 We use both! The general breakdown of when to use which is:
 1. For documentation that we want to be viewable in github, use myST.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,21 @@ extensions = [
 
 nb_execution_mode = "off"
 
+# this is required to get simplepdf to work
+nb_mime_priority_overrides = [
+    ["simplepdf", "application/vnd.jupyter.widget-view+json", 10],
+    ["simplepdf", "application/javascript", 20],
+    ["simplepdf", "text/html", 30],
+    ["simplepdf", "image/svg+xml", 40],
+    ["simplepdf", "image/png", 50],
+    ["simplepdf", "image/gif", 60],
+    ["simplepdf", "image/jpeg", 70],
+    ["simplepdf", "text/markdown", 80],
+    ["simplepdf", "text/latex", 90],
+    ["simplepdf", "text/plain", 100],
+]
+
+
 # for the sitemap extension ---
 # check if the current commit is tagged as a release (vX.Y.Z) and set the version
 GIT_TAG_OUTPUT = subprocess.check_output(["git", "tag", "--points-at", "HEAD"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ docs = [
   "sphinx", # unpinned because myst-parser doesn't break anymore
   "sphinx-autobuild",
   "sphinx-rtd-theme", # read the docs pins
+  "sphinx-simplepdf",
   "sphinx-sitemap",
   "tqdm",
   "xgboost",


### PR DESCRIPTION
I believe the docs requirements are correct to get this to work.

i.e. add:

`pip install sphinx-simplepdf`

then

`sphinx-build -b simplepdf  -W -E -T  -a docs /tmp/mydocs`

from the root of the repository. It should take a few minutes then to build a PDF that will turn up under `/tmp/mydocs`.

## Changes
- docs/conf.py

## How I tested this
- locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
