### PR TITLE
fix: added polars to extension list

### DIFF
--- a/hamilton/data_quality/pandera_validators.py
+++ b/hamilton/data_quality/pandera_validators.py
@@ -6,7 +6,7 @@ from hamilton import registry
 from hamilton.data_quality import base
 from hamilton.htypes import custom_subclass_check
 
-pandera_supported_extensions = frozenset(["pandas", "dask", "pyspark_pandas"])
+pandera_supported_extensions = frozenset(["pandas", "dask", "pyspark_pandas", "polars"])
 
 
 class PanderaDataFrameValidator(base.BaseDefaultValidator):


### PR DESCRIPTION
User reported an issue where using `pandera` with `polars` raised the error. As identified by the user, this is because `polars` wasn't added to the list of supported extension.

> Actual error: No registered subclass of BaseDefaultValidator is available for arg: schema and type <class 'polars.dataframe.frame.DataFrame'>. This either means (a) this arg-type contribution isn't supported or (b) this has not been added yet (but should be). In the case of (b), we welcome contributions. Get started at [github.com/dagworks-inc/hamilton](http://github.com/dagworks-inc/hamilton).