### PR TITLE
Fix `keep_dot` propagation in `Driver` display functions

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -1200,6 +1200,7 @@ class Driver:
                 display_fields=show_schema,
                 custom_style_function=custom_style_function,
                 config=self.graph._config,
+                keep_dot=keep_dot,
             )
         except ImportError as e:
             logger.warning(f"Unable to import {e}", exc_info=True)
@@ -1263,6 +1264,7 @@ class Driver:
                 display_fields=show_schema,
                 custom_style_function=custom_style_function,
                 config=self.graph._config,
+                keep_dot=keep_dot,
             )
         except ImportError as e:
             logger.warning(f"Unable to import {e}", exc_info=True)


### PR DESCRIPTION
When investigating #1200 I noticed, that `keep_dot` parameters weren't propagated to the render function. 

## Changes

The previous non-functional parameters are now passed on.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.

These are not applicable

- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
