### PR TITLE
fix: caching `SQLiteMetadataStore.get_run_ids()`

### DIFF
--- a/hamilton/caching/stores/base.py
+++ b/hamilton/caching/stores/base.py
@@ -95,7 +95,7 @@ class MetadataStore(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get(self, cache_key: str) -> Optional[str]:
+    def get(self, cache_key: str, **kwargs) -> Optional[str]:
         """Try to retrieve ``data_version`` keyed by ``cache_key``.
         If retrieval misses return ``None``.
         """
@@ -118,15 +118,19 @@ class MetadataStore(abc.ABC):
     def get_run_ids(self) -> Sequence[str]:
         """Return a list of run ids, sorted from oldest to newest start time.
         A ``run_id`` is registered when the metadata_store ``.initialize()`` is called.
-
-        NOTE because of race conditions, the order could theoretically differ from the
-        order stored on the SmartCacheAdapter `._run_ids` attribute.
         """
 
     @abc.abstractmethod
-    def get_run(self, run_id: str) -> Any:
-        """Return all the metadata associated with a run.
-        The metadata content may differ across MetadataStore implementations
+    def get_run(self, run_id: str) -> Sequence[dict]:
+        """Return a list of node metadata associated with a run.
+        For each node, the metadata should include:
+            - ``cache_key`` (created or used)
+            - ``data_version``
+        This is to allow users to manually query the MetadataStore or ResultStore.
+
+        Decoding the ``cache_key`` gives the ``node_name``, ``code_version``, and
+        ``dependencies_data_versions``. Individual implementations may add more
+        information or decode the ``cache_key`` before returning metadata.
         """
 
     @property

--- a/hamilton/caching/stores/base.py
+++ b/hamilton/caching/stores/base.py
@@ -123,10 +123,10 @@ class MetadataStore(abc.ABC):
     @abc.abstractmethod
     def get_run(self, run_id: str) -> Sequence[dict]:
         """Return a list of node metadata associated with a run.
-        For each node, the metadata should include:
-            - ``cache_key`` (created or used)
-            - ``data_version``
-        This is to allow users to manually query the MetadataStore or ResultStore.
+
+        For each node, the metadata should include ``cache_key`` (created or used)
+        and ``data_version``. These values allow to manually query the MetadataStore
+        or ResultStore.
 
         Decoding the ``cache_key`` gives the ``node_name``, ``code_version``, and
         ``dependencies_data_versions``. Individual implementations may add more

--- a/hamilton/caching/stores/sqlite.py
+++ b/hamilton/caching/stores/sqlite.py
@@ -210,10 +210,10 @@ class SQLiteMetadataStore(MetadataStore):
 
         :param run_id: ID of the run to retrieve
         :return: List of node metadata which includes ``cache_key``, ``data_version``,
-        ``node_name``, and ``code_version``. The list can be empty if a run was initialized
-        but no nodes were executed.
+            ``node_name``, and ``code_version``. The list can be empty if a run was initialized
+            but no nodes were executed.
 
-        Raises an ``IndexError`` if the ``run_id`` is not found in metadata store.
+        :raises IndexError: if the ``run_id`` is not found in metadata store.
         """
         cur = self.connection.cursor()
         if self._run_exists(run_id) is False:


### PR DESCRIPTION
This PR follows issue #1204 

It includes a few changes to the `MetadataStore` base class and sets a clearer contract for `.get_run()` and `.get_run_ids()`.

- `.get_run_ids()` should return a list of runs sorted by their start time, i.e., when `.initialize()` is called. This order may differ from the order of the first recorded node execution. An empty list will be returned if no run were initialized.

- `.get_run()` should return a list of dictionaries, where each `dict` is associated with a particular node execution. Each `dict` must minimally return the `data_version` and the `cache_key` (which can be decoded to retrieve the `node_name`, `code_version`,  and `dependencies_data_versions`), but may include more information. An `IndexError` is raised if `run_id` doesn't exist. An empty list is returned if the run was initialized, but recorded no node execution.

Tests were added to catch the bug reported in the original issue.