### PR TITLE
Add allow_module_overrides to AsyncDriver

### DIFF
--- a/hamilton/async_driver.py
+++ b/hamilton/async_driver.py
@@ -198,6 +198,7 @@ class AsyncDriver(driver.Driver):
         *modules,
         result_builder: Optional[base.ResultMixin] = None,
         adapters: typing.List[lifecycle.LifecycleAdapter] = None,
+        allow_module_overrides: bool = False,
     ):
         """Instantiates an asynchronous driver.
 
@@ -210,8 +211,12 @@ class AsyncDriver(driver.Driver):
 
         :param config: Config to build the graph
         :param modules: Modules to crawl for fns/graph nodes
-        :param adapters: Adapters to use for lifecycle methods.
         :param result_builder: Results mixin to compile the graph's final results. TBD whether this should be included in the long run.
+        :param adapters: Adapters to use for lifecycle methods.
+        :param allow_module_overrides: Optional. Same named functions get overridden by later modules.
+            The order of listing the modules is important, since later ones will overwrite the previous ones.
+            This is a global call affecting all imported modules.
+            See https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/module_overrides for more info.
         """
         if adapters is None:
             adapters = []
@@ -243,6 +248,7 @@ class AsyncDriver(driver.Driver):
                 *sync_adapters,
                 *async_adapters,  # note async adapters will not be called during synchronous execution -- this is for access later
             ],
+            allow_module_overrides=allow_module_overrides,
         )
         self.initialized = False
 
@@ -492,6 +498,7 @@ class Builder(driver.Builder):
             *self.modules,
             adapters=self.adapters,
             result_builder=specified_result_builder,
+            allow_module_overrides=self._allow_module_overrides,
         )
 
     async def build(self):

--- a/tests/test_async_driver.py
+++ b/tests/test_async_driver.py
@@ -344,6 +344,21 @@ async def test_async_builder_allow_module_overrides():
 
     assert "Cannot define function foo more than once." in str(e.value)
 
+    # build_without_init should also raise
+    with pytest.raises(ValueError) as e:
+        async_driver.Builder().with_modules(mod1, mod2).build_without_init()
+
+    assert "Cannot define function foo more than once." in str(e.value)
+
     # Should not raise with .allow_module_overrides()
     dr = await async_driver.Builder().with_modules(mod1, mod2).allow_module_overrides().build()
+    assert (await dr.execute(final_vars=["foo"])) == {"foo": 2}
+
+    # Same with build_without_init
+    dr = (
+        async_driver.Builder()
+        .with_modules(mod1, mod2)
+        .allow_module_overrides()
+        .build_without_init()
+    )
     assert (await dr.execute(final_vars=["foo"])) == {"foo": 2}


### PR DESCRIPTION
AsyncDriver got left out of the `.allow_module_overrides` feature. Adding support for it . 
Fixes #1216 

## Changes
* Pass `allow_module_overrides` from AsyncBuilder -> AsyncDriver -> Driver

## How I tested this
* Added new unit test to cover functionality
* Verified in my own project & DAG that it works

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
