### PR TITLE
fix example notebook

### DIFF
--- a/examples/pandas/with_columns/notebook.ipynb
+++ b/examples/pandas/with_columns/notebook.ipynb
@@ -1,10 +1,20 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute this cell to install dependencies\n",
+    "%pip install sf-hamilton[visualization]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example of using with_columns for Pandas\n",
+    "# Example of using with_columns for Pandas [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dagworks-inc/hamilton/blob/main/examples/pandas/with_columns/notebook.ipynb) [![GitHub badge](https://img.shields.io/badge/github-view_source-2b3137?logo=github)](https://github.com/dagworks-inc/hamilton/blob/main/examples/pandas/with_columns/notebook.ipynb)\n",
     "\n",
     "This allows you to efficiently run groups of map operations on a dataframe.\n",
     "Here's an example of calling it -- if you've seen `@subdag`, you should be familiar with the concepts."


### PR DESCRIPTION
Because of the forking, the CI check added in #1220 wasn't tested against the `with_columns` notebook from #1209 until merging to main