### PR TITLE
added --display-cache to jupyter magic

### DIFF
--- a/examples/jupyter_notebook_magic/example.ipynb
+++ b/examples/jupyter_notebook_magic/example.ipynb
@@ -2,10 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "e78e2bc2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/tjean/projects/hamilton/.venv/bin/python: No module named pip\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "# Execute this cell to install dependencies\n",
     "%pip install sf-hamilton[visualization]"
@@ -52,11 +61,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "e3b8a109",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# disable plugin autoloading for faster notebook start time\n",
+    "from hamilton import registry\n",
+    "registry.disable_autoload()\n",
+    "\n",
     "%reload_ext hamilton.plugins.jupyter_magic\n",
     "from hamilton import driver  # we'll need this later"
    ]
@@ -75,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "2a3d64f3",
    "metadata": {},
    "outputs": [
@@ -86,10 +99,10 @@
       "\u001b[0;31mDocstring:\u001b[0m\n",
       "::\n",
       "\n",
-      "  %cell_to_module [-m [MODULE_NAME]] [-d [DISPLAY]] [-x [EXECUTE]]\n",
-      "                      [-b BUILDER] [-c CONFIG] [-i INPUTS] [-o OVERRIDES]\n",
-      "                      [--hide_results] [-w [WRITE_TO_FILE]]\n",
-      "                      [module_name]\n",
+      "  %cell_to_module [-m [MODULE_NAME]] [-d [DISPLAY]] [--display_cache]\n",
+      "                      [-x [EXECUTE]] [-b BUILDER] [-c CONFIG] [-i INPUTS]\n",
+      "                      [-o OVERRIDES] [--show_results] [-w [WRITE_TO_FILE]]\n",
+      "                      [name]\n",
       "\n",
       "Turn a notebook cell into a Hamilton module definition. This allows you to define\n",
       "and execute a dataflow from a single cell.\n",
@@ -105,7 +118,7 @@
       "```\n",
       "\n",
       "positional arguments:\n",
-      "  module_name           Name for the module defined in this cell.\n",
+      "  name                  Name for the module defined in this cell.\n",
       "\n",
       "options:\n",
       "  -m <[MODULE_NAME]>, --module_name <[MODULE_NAME]>\n",
@@ -114,6 +127,8 @@
       "  -d <[DISPLAY]>, --display <[DISPLAY]>\n",
       "                        Display the dataflow. The argument is the variable\n",
       "                        name of a dictionary of visualization kwargs; else {}.\n",
+      "  --display_cache       After execution, display the retrieved results. This\n",
+      "                        uses `dr.cache.view_run()`.\n",
       "  -x <[EXECUTE]>, --execute <[EXECUTE]>\n",
       "                        Execute the dataflow. The argument is the variable\n",
       "                        name of a list of nodes; else execute all nodes.\n",
@@ -130,11 +145,12 @@
       "  -o OVERRIDES, --overrides OVERRIDES\n",
       "                        Execution overrides. The argument is the variable name\n",
       "                        of a dict of overrides; else {}.\n",
-      "  --hide_results        Hides the automatic display of execution results.\n",
+      "  --show_results        Print node values in the output cell after each node\n",
+      "                        is executed.\n",
       "  -w <[WRITE_TO_FILE]>, --write_to_file <[WRITE_TO_FILE]>\n",
       "                        Write cell content to a file. The argument is the file\n",
       "                        path; else write to {module_name}.py\n",
-      "\u001b[0;31mFile:\u001b[0m      ~/projects/dagworks/hamilton/hamilton/plugins/jupyter_magic.py"
+      "\u001b[0;31mFile:\u001b[0m      ~/projects/hamilton/hamilton/plugins/jupyter_magic.py"
      ]
     }
    ],
@@ -161,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "ef73893f",
    "metadata": {},
    "outputs": [
@@ -220,7 +236,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d02d5d0>"
+       "<graphviz.graphs.Digraph at 0x7f471f3f8650>"
       ]
      },
      "metadata": {},
@@ -243,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "4b20538d",
    "metadata": {},
    "outputs": [
@@ -272,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "1117471d",
    "metadata": {},
    "outputs": [],
@@ -295,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "19a7a66e",
    "metadata": {},
    "outputs": [
@@ -354,7 +370,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d09c0d0>"
+       "<graphviz.graphs.Digraph at 0x7f471e2682d0>"
       ]
      },
      "metadata": {},
@@ -369,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "4efeda39",
    "metadata": {},
    "outputs": [],
@@ -379,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "0fc841a4",
    "metadata": {},
    "outputs": [
@@ -438,7 +454,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d0a0290>"
+       "<graphviz.graphs.Digraph at 0x7f471e25bb90>"
       ]
      },
      "metadata": {},
@@ -466,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "a6f6052a",
    "metadata": {},
    "outputs": [],
@@ -478,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "91875c91",
    "metadata": {},
    "outputs": [
@@ -488,7 +504,7 @@
        "\"Knock, knock. Who's there? Cowsays\""
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -515,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "b6f00cdb",
    "metadata": {},
    "outputs": [
@@ -591,7 +607,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d0a2e50>"
+       "<graphviz.graphs.Digraph at 0x7f471e268ed0>"
       ]
      },
      "metadata": {},
@@ -609,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "758b3fbe",
    "metadata": {},
    "outputs": [
@@ -685,7 +701,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d0aa290>"
+       "<graphviz.graphs.Digraph at 0x7f471e268790>"
       ]
      },
      "metadata": {},
@@ -703,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "073225f8",
    "metadata": {},
    "outputs": [],
@@ -713,7 +729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "311f0bad",
    "metadata": {},
    "outputs": [
@@ -789,7 +805,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d08fb10>"
+       "<graphviz.graphs.Digraph at 0x7f471e26bfd0>"
       ]
      },
      "metadata": {},
@@ -825,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "f8fc4d76",
    "metadata": {},
    "outputs": [],
@@ -839,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "3b924480",
    "metadata": {},
    "outputs": [
@@ -871,29 +887,15 @@
        "<text text-anchor=\"start\" x=\"17.5\" y=\"-35.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">knock_joke</text>\n",
        "<text text-anchor=\"start\" x=\"46\" y=\"-7.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">true</text>\n",
        "</g>\n",
-       "<!-- topic -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>topic</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"#56e39f\" d=\"M105,-136C105,-136 16,-136 16,-136 10,-136 4,-130 4,-124 4,-124 4,-84 4,-84 4,-78 10,-72 16,-72 16,-72 105,-72 105,-72 111,-72 117,-78 117,-84 117,-84 117,-124 117,-124 117,-130 111,-136 105,-136\"/>\n",
-       "<path fill=\"none\" stroke=\"#56e39f\" d=\"M109,-140C109,-140 12,-140 12,-140 6,-140 0,-134 0,-128 0,-128 0,-80 0,-80 0,-74 6,-68 12,-68 12,-68 109,-68 109,-68 115,-68 121,-74 121,-80 121,-80 121,-128 121,-128 121,-134 115,-140 109,-140\"/>\n",
-       "<text text-anchor=\"start\" x=\"40.5\" y=\"-114.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
-       "<text text-anchor=\"start\" x=\"15\" y=\"-86.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">Parallelizable</text>\n",
-       "</g>\n",
        "<!-- joke_prompt -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>joke_prompt</title>\n",
        "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M353,-136C353,-136 162,-136 162,-136 156,-136 150,-130 150,-124 150,-124 150,-84 150,-84 150,-78 156,-72 162,-72 162,-72 353,-72 353,-72 359,-72 365,-78 365,-84 365,-84 365,-124 365,-124 365,-130 359,-136 353,-136\"/>\n",
        "<text text-anchor=\"start\" x=\"161\" y=\"-114.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt: knock_joke</text>\n",
        "<text text-anchor=\"start\" x=\"248\" y=\"-86.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
-       "<!-- topic&#45;&gt;joke_prompt -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>topic&#45;&gt;joke_prompt</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M121.07,-104C127.09,-104 133.35,-104 139.72,-104\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"139.81,-104 149.81,-108.5 144.81,-104 149.81,-104 149.81,-104 149.81,-104 144.81,-104 149.81,-99.5 139.81,-104 139.81,-104\"/>\n",
-       "</g>\n",
        "<!-- joke_prompt_collection -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node4\" class=\"node\">\n",
        "<title>joke_prompt_collection</title>\n",
        "<path fill=\"#b4d8e4\" stroke=\"#ea5556\" d=\"M588,-136C588,-136 410,-136 410,-136 404,-136 398,-130 398,-124 398,-124 398,-84 398,-84 398,-78 404,-72 410,-72 410,-72 588,-72 588,-72 594,-72 600,-78 600,-84 600,-84 600,-124 600,-124 600,-130 594,-136 588,-136\"/>\n",
        "<path fill=\"none\" stroke=\"#ea5556\" d=\"M592,-140C592,-140 406,-140 406,-140 400,-140 394,-134 394,-128 394,-128 394,-80 394,-80 394,-74 400,-68 406,-68 406,-68 592,-68 592,-68 598,-68 604,-74 604,-80 604,-80 604,-128 604,-128 604,-134 598,-140 592,-140\"/>\n",
@@ -901,11 +903,25 @@
        "<text text-anchor=\"start\" x=\"488.5\" y=\"-86.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">list</text>\n",
        "</g>\n",
        "<!-- joke_prompt&#45;&gt;joke_prompt_collection -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>joke_prompt&#45;&gt;joke_prompt_collection</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M375.54,-104C378.21,-104 380.89,-104 383.56,-104\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"375.29,-104 365.29,-99.5 370.29,-104 365.29,-104 365.29,-104 365.29,-104 370.29,-104 365.29,-108.5 375.29,-104 375.29,-104\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"383.82,-107.5 393.82,-104 383.82,-100.5 383.82,-107.5\"/>\n",
+       "</g>\n",
+       "<!-- topic -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>topic</title>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"#56e39f\" d=\"M105,-136C105,-136 16,-136 16,-136 10,-136 4,-130 4,-124 4,-124 4,-84 4,-84 4,-78 10,-72 16,-72 16,-72 105,-72 105,-72 111,-72 117,-78 117,-84 117,-84 117,-124 117,-124 117,-130 111,-136 105,-136\"/>\n",
+       "<path fill=\"none\" stroke=\"#56e39f\" d=\"M109,-140C109,-140 12,-140 12,-140 6,-140 0,-134 0,-128 0,-128 0,-80 0,-80 0,-74 6,-68 12,-68 12,-68 109,-68 109,-68 115,-68 121,-74 121,-80 121,-80 121,-128 121,-128 121,-134 115,-140 109,-140\"/>\n",
+       "<text text-anchor=\"start\" x=\"40.5\" y=\"-114.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
+       "<text text-anchor=\"start\" x=\"15\" y=\"-86.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">Parallelizable</text>\n",
+       "</g>\n",
+       "<!-- topic&#45;&gt;joke_prompt -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>topic&#45;&gt;joke_prompt</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M121.07,-104C127.09,-104 133.35,-104 139.72,-104\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"139.81,-104 149.81,-108.5 144.81,-104 149.81,-104 149.81,-104 149.81,-104 144.81,-104 149.81,-99.5 139.81,-104 139.81,-104\"/>\n",
        "</g>\n",
        "<!-- config -->\n",
        "<g id=\"node5\" class=\"node\">\n",
@@ -939,7 +955,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8c6449d0>"
+       "<graphviz.graphs.Digraph at 0x7f471e26c350>"
       ]
      },
      "metadata": {},
@@ -974,7 +990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 18,
    "id": "630ff804",
    "metadata": {},
    "outputs": [],
@@ -992,7 +1008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 19,
    "id": "66dccada",
    "metadata": {},
    "outputs": [
@@ -1005,73 +1021,96 @@
        "<!-- Generated by graphviz version 2.43.0 (0)\n",
        " -->\n",
        "<!-- Title: %3 Pages: 1 -->\n",
-       "<svg width=\"417pt\" height=\"208pt\"\n",
-       " viewBox=\"0.00 0.00 417.00 208.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 204)\">\n",
+       "<svg width=\"387pt\" height=\"505pt\"\n",
+       " viewBox=\"0.00 0.00 387.00 505.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 501)\">\n",
        "<title>%3</title>\n",
-       "<polygon fill=\"white\" stroke=\"transparent\" points=\"-4,4 -4,-204 413,-204 413,4 -4,4\"/>\n",
+       "<polygon fill=\"white\" stroke=\"transparent\" points=\"-4,4 -4,-501 383,-501 383,4 -4,4\"/>\n",
        "<g id=\"clust1\" class=\"cluster\">\n",
        "<title>cluster__legend</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"11.5,-115 11.5,-192 107.5,-192 107.5,-115 11.5,-115\"/>\n",
-       "<text text-anchor=\"middle\" x=\"59.5\" y=\"-176.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"21,-231 21,-489 119,-489 119,-231 21,-231\"/>\n",
+       "<text text-anchor=\"middle\" x=\"70\" y=\"-473.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
        "</g>\n",
-       "<!-- reply -->\n",
+       "<!-- topic -->\n",
        "<g id=\"node1\" class=\"node\">\n",
-       "<title>reply</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M234,-146C234,-146 196,-146 196,-146 190,-146 184,-140 184,-134 184,-134 184,-94 184,-94 184,-88 190,-82 196,-82 196,-82 234,-82 234,-82 240,-82 246,-88 246,-94 246,-94 246,-134 246,-134 246,-140 240,-146 234,-146\"/>\n",
-       "<text text-anchor=\"start\" x=\"195\" y=\"-124.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
-       "<text text-anchor=\"start\" x=\"205.5\" y=\"-96.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- punchline -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>punchline</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M397,-146C397,-146 323,-146 323,-146 317,-146 311,-140 311,-134 311,-134 311,-94 311,-94 311,-88 317,-82 323,-82 323,-82 397,-82 397,-82 403,-82 409,-88 409,-94 409,-94 409,-134 409,-134 409,-140 403,-146 397,-146\"/>\n",
-       "<text text-anchor=\"start\" x=\"322\" y=\"-124.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">punchline</text>\n",
-       "<text text-anchor=\"start\" x=\"350.5\" y=\"-96.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- reply&#45;&gt;punchline -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>reply&#45;&gt;punchline</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M246.33,-114C262.17,-114 282.1,-114 300.78,-114\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"300.99,-117.5 310.99,-114 300.99,-110.5 300.99,-117.5\"/>\n",
+       "<title>topic</title>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"#56e39f\" d=\"M114.5,-68C114.5,-68 25.5,-68 25.5,-68 19.5,-68 13.5,-62 13.5,-56 13.5,-56 13.5,-16 13.5,-16 13.5,-10 19.5,-4 25.5,-4 25.5,-4 114.5,-4 114.5,-4 120.5,-4 126.5,-10 126.5,-16 126.5,-16 126.5,-56 126.5,-56 126.5,-62 120.5,-68 114.5,-68\"/>\n",
+       "<path fill=\"none\" stroke=\"#56e39f\" d=\"M118.5,-72C118.5,-72 21.5,-72 21.5,-72 15.5,-72 9.5,-66 9.5,-60 9.5,-60 9.5,-12 9.5,-12 9.5,-6 15.5,0 21.5,0 21.5,0 118.5,0 118.5,0 124.5,0 130.5,-6 130.5,-12 130.5,-12 130.5,-60 130.5,-60 130.5,-66 124.5,-72 118.5,-72\"/>\n",
+       "<text text-anchor=\"start\" x=\"50\" y=\"-46.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
+       "<text text-anchor=\"start\" x=\"24.5\" y=\"-18.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">Parallelizable</text>\n",
        "</g>\n",
        "<!-- joke_response -->\n",
        "<g id=\"node2\" class=\"node\">\n",
        "<title>joke_response</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M270,-64C270,-64 160,-64 160,-64 154,-64 148,-58 148,-52 148,-52 148,-12 148,-12 148,-6 154,0 160,0 160,0 270,0 270,0 276,0 282,-6 282,-12 282,-12 282,-52 282,-52 282,-58 276,-64 270,-64\"/>\n",
-       "<text text-anchor=\"start\" x=\"159\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_response</text>\n",
-       "<text text-anchor=\"start\" x=\"205.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M329,-145C329,-145 219,-145 219,-145 213,-145 207,-139 207,-133 207,-133 207,-93 207,-93 207,-87 213,-81 219,-81 219,-81 329,-81 329,-81 335,-81 341,-87 341,-93 341,-93 341,-133 341,-133 341,-139 335,-145 329,-145\"/>\n",
+       "<text text-anchor=\"start\" x=\"218\" y=\"-123.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_response</text>\n",
+       "<text text-anchor=\"start\" x=\"264.5\" y=\"-95.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
-       "<!-- joke_prompt -->\n",
+       "<!-- joke_prompt_collection -->\n",
        "<g id=\"node3\" class=\"node\">\n",
-       "<title>joke_prompt</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M107,-105C107,-105 12,-105 12,-105 6,-105 0,-99 0,-93 0,-93 0,-53 0,-53 0,-47 6,-41 12,-41 12,-41 107,-41 107,-41 113,-41 119,-47 119,-53 119,-53 119,-93 119,-93 119,-99 113,-105 107,-105\"/>\n",
-       "<text text-anchor=\"start\" x=\"11\" y=\"-83.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
-       "<text text-anchor=\"start\" x=\"50\" y=\"-55.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "<title>joke_prompt_collection</title>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"#ea5556\" d=\"M363,-231C363,-231 185,-231 185,-231 179,-231 173,-225 173,-219 173,-219 173,-179 173,-179 173,-173 179,-167 185,-167 185,-167 363,-167 363,-167 369,-167 375,-173 375,-179 375,-179 375,-219 375,-219 375,-225 369,-231 363,-231\"/>\n",
+       "<path fill=\"none\" stroke=\"#ea5556\" d=\"M367,-235C367,-235 181,-235 181,-235 175,-235 169,-229 169,-223 169,-223 169,-175 169,-175 169,-169 175,-163 181,-163 181,-163 367,-163 367,-163 373,-163 379,-169 379,-175 379,-175 379,-223 379,-223 379,-229 373,-235 367,-235\"/>\n",
+       "<text text-anchor=\"start\" x=\"184\" y=\"-209.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt_collection</text>\n",
+       "<text text-anchor=\"start\" x=\"263.5\" y=\"-181.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">list</text>\n",
        "</g>\n",
-       "<!-- joke_prompt&#45;&gt;reply -->\n",
+       "<!-- _joke_response_inputs -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>_joke_response_inputs</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"140,-135.5 0,-135.5 0,-90.5 140,-90.5 140,-135.5\"/>\n",
+       "<text text-anchor=\"start\" x=\"15\" y=\"-108.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">joke_prompt</text>\n",
+       "<text text-anchor=\"start\" x=\"106\" y=\"-108.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- _joke_response_inputs&#45;&gt;joke_response -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>joke_prompt&#45;&gt;reply</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M119.41,-88.73C137.61,-93.6 157.23,-98.84 173.86,-103.28\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"173.22,-106.73 183.79,-105.93 175.03,-99.97 173.22,-106.73\"/>\n",
+       "<title>_joke_response_inputs&#45;&gt;joke_response</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M140.23,-113C158.45,-113 178.19,-113 196.75,-113\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"196.92,-116.5 206.92,-113 196.92,-109.5 196.92,-116.5\"/>\n",
        "</g>\n",
-       "<!-- joke_prompt&#45;&gt;joke_response -->\n",
+       "<!-- _joke_prompt_collection_inputs -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>_joke_prompt_collection_inputs</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"140,-221.5 0,-221.5 0,-176.5 140,-176.5 140,-221.5\"/>\n",
+       "<text text-anchor=\"start\" x=\"15\" y=\"-194.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">joke_prompt</text>\n",
+       "<text text-anchor=\"start\" x=\"106\" y=\"-194.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- _joke_prompt_collection_inputs&#45;&gt;joke_prompt_collection -->\n",
        "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>joke_prompt&#45;&gt;joke_response</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M119.41,-57.27C125.51,-55.64 131.77,-53.96 138.03,-52.29\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"139.07,-55.64 147.83,-49.67 137.27,-48.87 139.07,-55.64\"/>\n",
+       "<title>_joke_prompt_collection_inputs&#45;&gt;joke_prompt_collection</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M140.23,-199C146.16,-199 152.25,-199 158.41,-199\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"158.82,-202.5 168.82,-199 158.82,-195.5 158.82,-202.5\"/>\n",
+       "</g>\n",
+       "<!-- input -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>input</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"black\" stroke-dasharray=\"5,2\" points=\"99.5,-457.5 40.5,-457.5 40.5,-420.5 99.5,-420.5 99.5,-457.5\"/>\n",
+       "<text text-anchor=\"middle\" x=\"70\" y=\"-435.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">input</text>\n",
        "</g>\n",
        "<!-- function -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
+       "<g id=\"node7\" class=\"node\">\n",
        "<title>function</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M87.5,-160.5C87.5,-160.5 31.5,-160.5 31.5,-160.5 25.5,-160.5 19.5,-154.5 19.5,-148.5 19.5,-148.5 19.5,-135.5 19.5,-135.5 19.5,-129.5 25.5,-123.5 31.5,-123.5 31.5,-123.5 87.5,-123.5 87.5,-123.5 93.5,-123.5 99.5,-129.5 99.5,-135.5 99.5,-135.5 99.5,-148.5 99.5,-148.5 99.5,-154.5 93.5,-160.5 87.5,-160.5\"/>\n",
-       "<text text-anchor=\"middle\" x=\"59.5\" y=\"-138.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">function</text>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M98,-402.5C98,-402.5 42,-402.5 42,-402.5 36,-402.5 30,-396.5 30,-390.5 30,-390.5 30,-377.5 30,-377.5 30,-371.5 36,-365.5 42,-365.5 42,-365.5 98,-365.5 98,-365.5 104,-365.5 110,-371.5 110,-377.5 110,-377.5 110,-390.5 110,-390.5 110,-396.5 104,-402.5 98,-402.5\"/>\n",
+       "<text text-anchor=\"middle\" x=\"70\" y=\"-380.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">function</text>\n",
+       "</g>\n",
+       "<!-- expand -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>expand</title>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"#56e39f\" d=\"M95,-343.5C95,-343.5 45,-343.5 45,-343.5 39,-343.5 33,-337.5 33,-331.5 33,-331.5 33,-318.5 33,-318.5 33,-312.5 39,-306.5 45,-306.5 45,-306.5 95,-306.5 95,-306.5 101,-306.5 107,-312.5 107,-318.5 107,-318.5 107,-331.5 107,-331.5 107,-337.5 101,-343.5 95,-343.5\"/>\n",
+       "<path fill=\"none\" stroke=\"#56e39f\" d=\"M99,-347.5C99,-347.5 41,-347.5 41,-347.5 35,-347.5 29,-341.5 29,-335.5 29,-335.5 29,-314.5 29,-314.5 29,-308.5 35,-302.5 41,-302.5 41,-302.5 99,-302.5 99,-302.5 105,-302.5 111,-308.5 111,-314.5 111,-314.5 111,-335.5 111,-335.5 111,-341.5 105,-347.5 99,-347.5\"/>\n",
+       "<text text-anchor=\"middle\" x=\"70\" y=\"-321.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">expand</text>\n",
+       "</g>\n",
+       "<!-- collect -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>collect</title>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"#ea5556\" d=\"M91.5,-280.5C91.5,-280.5 48.5,-280.5 48.5,-280.5 42.5,-280.5 36.5,-274.5 36.5,-268.5 36.5,-268.5 36.5,-255.5 36.5,-255.5 36.5,-249.5 42.5,-243.5 48.5,-243.5 48.5,-243.5 91.5,-243.5 91.5,-243.5 97.5,-243.5 103.5,-249.5 103.5,-255.5 103.5,-255.5 103.5,-268.5 103.5,-268.5 103.5,-274.5 97.5,-280.5 91.5,-280.5\"/>\n",
+       "<path fill=\"none\" stroke=\"#ea5556\" d=\"M95.5,-284.5C95.5,-284.5 44.5,-284.5 44.5,-284.5 38.5,-284.5 32.5,-278.5 32.5,-272.5 32.5,-272.5 32.5,-251.5 32.5,-251.5 32.5,-245.5 38.5,-239.5 44.5,-239.5 44.5,-239.5 95.5,-239.5 95.5,-239.5 101.5,-239.5 107.5,-245.5 107.5,-251.5 107.5,-251.5 107.5,-272.5 107.5,-272.5 107.5,-278.5 101.5,-284.5 95.5,-284.5\"/>\n",
+       "<text text-anchor=\"middle\" x=\"70\" y=\"-258.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">collect</text>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8c6456d0>"
+       "<graphviz.graphs.Digraph at 0x7f471e25a290>"
       ]
      },
      "metadata": {},
@@ -1097,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "8bcd9ef3",
    "metadata": {},
    "outputs": [
@@ -1157,6 +1196,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "873793f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%cell_to_module joke\n",
+    "def joke_prompt(topic: str) -> str:\n",
+    "    return f\"Knock, knock. Who's there? {topic}\"\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9f9aec0a",
    "metadata": {},
@@ -1177,17 +1228,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "f704fe3f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'joke_prompt': \"Knock, knock. Who's there? Cowsay\"}"
+       "{'joke_prompt': None}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1211,7 +1262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "7eebf289",
    "metadata": {},
    "outputs": [
@@ -1234,45 +1285,45 @@
        "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"13,-156 13,-288 109,-288 109,-156 13,-156\"/>\n",
        "<text text-anchor=\"middle\" x=\"61\" y=\"-272.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
        "</g>\n",
-       "<!-- a_dataframe -->\n",
+       "<!-- joke_prompt -->\n",
        "<g id=\"node1\" class=\"node\">\n",
-       "<title>a_dataframe</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M110,-64C110,-64 12,-64 12,-64 6,-64 0,-58 0,-52 0,-52 0,-12 0,-12 0,-6 6,0 12,0 12,0 110,0 110,0 116,0 122,-6 122,-12 122,-12 122,-52 122,-52 122,-58 116,-64 110,-64\"/>\n",
-       "<text text-anchor=\"start\" x=\"11\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">a_dataframe</text>\n",
-       "<text text-anchor=\"start\" x=\"22.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">DataFrame</text>\n",
+       "<title>joke_prompt</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M108.5,-64C108.5,-64 13.5,-64 13.5,-64 7.5,-64 1.5,-58 1.5,-52 1.5,-52 1.5,-12 1.5,-12 1.5,-6 7.5,0 13.5,0 13.5,0 108.5,0 108.5,0 114.5,0 120.5,-6 120.5,-12 120.5,-12 120.5,-52 120.5,-52 120.5,-58 114.5,-64 108.5,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"12.5\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
+       "<text text-anchor=\"start\" x=\"51.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
        "<!-- reply -->\n",
        "<g id=\"node2\" class=\"node\">\n",
        "<title>reply</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M201,-146C201,-146 163,-146 163,-146 157,-146 151,-140 151,-134 151,-134 151,-94 151,-94 151,-88 157,-82 163,-82 163,-82 201,-82 201,-82 207,-82 213,-88 213,-94 213,-94 213,-134 213,-134 213,-140 207,-146 201,-146\"/>\n",
-       "<text text-anchor=\"start\" x=\"162\" y=\"-124.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
-       "<text text-anchor=\"start\" x=\"172.5\" y=\"-96.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- punchline -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>punchline</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M328,-146C328,-146 254,-146 254,-146 248,-146 242,-140 242,-134 242,-134 242,-94 242,-94 242,-88 248,-82 254,-82 254,-82 328,-82 328,-82 334,-82 340,-88 340,-94 340,-94 340,-134 340,-134 340,-140 334,-146 328,-146\"/>\n",
-       "<text text-anchor=\"start\" x=\"253\" y=\"-124.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">punchline</text>\n",
-       "<text text-anchor=\"start\" x=\"281.5\" y=\"-96.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- reply&#45;&gt;punchline -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>reply&#45;&gt;punchline</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M213.09,-114C218.93,-114 225.24,-114 231.64,-114\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"231.71,-117.5 241.71,-114 231.71,-110.5 231.71,-117.5\"/>\n",
-       "</g>\n",
-       "<!-- joke_prompt -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>joke_prompt</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M108.5,-146C108.5,-146 13.5,-146 13.5,-146 7.5,-146 1.5,-140 1.5,-134 1.5,-134 1.5,-94 1.5,-94 1.5,-88 7.5,-82 13.5,-82 13.5,-82 108.5,-82 108.5,-82 114.5,-82 120.5,-88 120.5,-94 120.5,-94 120.5,-134 120.5,-134 120.5,-140 114.5,-146 108.5,-146\"/>\n",
-       "<text text-anchor=\"start\" x=\"12.5\" y=\"-124.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
-       "<text text-anchor=\"start\" x=\"51.5\" y=\"-96.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M201,-64C201,-64 163,-64 163,-64 157,-64 151,-58 151,-52 151,-52 151,-12 151,-12 151,-6 157,0 163,0 163,0 201,0 201,0 207,0 213,-6 213,-12 213,-12 213,-52 213,-52 213,-58 207,-64 201,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"162\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
+       "<text text-anchor=\"start\" x=\"172.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
        "<!-- joke_prompt&#45;&gt;reply -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
        "<title>joke_prompt&#45;&gt;reply</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M120.8,-114C127.48,-114 134.17,-114 140.53,-114\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"140.88,-117.5 150.88,-114 140.88,-110.5 140.88,-117.5\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M120.8,-32C127.48,-32 134.17,-32 140.53,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"140.88,-35.5 150.88,-32 140.88,-28.5 140.88,-35.5\"/>\n",
+       "</g>\n",
+       "<!-- punchline -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>punchline</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M328,-64C328,-64 254,-64 254,-64 248,-64 242,-58 242,-52 242,-52 242,-12 242,-12 242,-6 248,0 254,0 254,0 328,0 328,0 334,0 340,-6 340,-12 340,-12 340,-52 340,-52 340,-58 334,-64 328,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"253\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">punchline</text>\n",
+       "<text text-anchor=\"start\" x=\"281.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- reply&#45;&gt;punchline -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>reply&#45;&gt;punchline</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M213.09,-32C218.93,-32 225.24,-32 231.64,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"231.71,-35.5 241.71,-32 231.71,-28.5 231.71,-35.5\"/>\n",
+       "</g>\n",
+       "<!-- a_dataframe -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>a_dataframe</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M110,-146C110,-146 12,-146 12,-146 6,-146 0,-140 0,-134 0,-134 0,-94 0,-94 0,-88 6,-82 12,-82 12,-82 110,-82 110,-82 116,-82 122,-88 122,-94 122,-94 122,-134 122,-134 122,-140 116,-146 110,-146\"/>\n",
+       "<text text-anchor=\"start\" x=\"11\" y=\"-124.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">a_dataframe</text>\n",
+       "<text text-anchor=\"start\" x=\"23\" y=\"-96.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">DataFrame</text>\n",
        "</g>\n",
        "<!-- function -->\n",
        "<g id=\"node5\" class=\"node\">\n",
@@ -1290,95 +1341,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8c655810>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>c</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>d</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   a  b\n",
-       "0  0  a\n",
-       "1  1  b\n",
-       "2  2  c\n",
-       "3  3  d"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\"Knock, knock. Who's there? Cowsay\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Cowsay who?'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'No, Cowsay MooOOooo'"
+       "<graphviz.graphs.Digraph at 0x7f471e26ef90>"
       ]
      },
      "metadata": {},
@@ -1406,10 +1369,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c99854dd",
+   "id": "55b030df",
    "metadata": {},
    "source": [
-    "👆 As you see, node results are automatically displayed in topologically sorted order. You can hide them with `--hide_results`."
+    "Adding the flag `--show_results` will print node results to the cell output after each execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ac13d20a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KeyError: Received `--inputs docs` but variable not found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%cell_to_module joke --execute --inputs docs\n",
+    "import pandas as pd\n",
+    "\n",
+    "def joke_prompt() -> str:\n",
+    "    return f\"Knock, knock. Who's there? Cowsay\"\n",
+    "\n",
+    "def reply(joke_prompt: str) -> str:\n",
+    "    _, _, right = joke_prompt.partition(\"? \")\n",
+    "    return f\"{right} who?\"\n",
+    "\n",
+    "def punchline(reply: str) -> str:\n",
+    "    left, _, _ = reply.partition(\" \")\n",
+    "    return f\"No, {left} MooOOooo\"\n",
+    "\n",
+    "def a_dataframe() -> pd.DataFrame:\n",
+    "    return pd.DataFrame({\"a\": [0, 1, 2, 3], \"b\": [\"a\", \"b\", \"c\", \"d\"]})"
    ]
   },
   {
@@ -1456,38 +1452,38 @@
        "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"8,-74 8,-206 104,-206 104,-74 8,-74\"/>\n",
        "<text text-anchor=\"middle\" x=\"56\" y=\"-190.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
        "</g>\n",
-       "<!-- topic -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>topic</title>\n",
-       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M75,-64C75,-64 37,-64 37,-64 31,-64 25,-58 25,-52 25,-52 25,-12 25,-12 25,-6 31,0 37,0 37,0 75,0 75,0 81,0 87,-6 87,-12 87,-12 87,-52 87,-52 87,-58 81,-64 75,-64\"/>\n",
-       "<text text-anchor=\"start\" x=\"36\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
-       "<text text-anchor=\"start\" x=\"46.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
        "<!-- joke_prompt -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node1\" class=\"node\">\n",
        "<title>joke_prompt</title>\n",
        "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M232,-64C232,-64 137,-64 137,-64 131,-64 125,-58 125,-52 125,-52 125,-12 125,-12 125,-6 131,0 137,0 137,0 232,0 232,0 238,0 244,-6 244,-12 244,-12 244,-52 244,-52 244,-58 238,-64 232,-64\"/>\n",
        "<text text-anchor=\"start\" x=\"136\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
        "<text text-anchor=\"start\" x=\"175\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
-       "<!-- topic&#45;&gt;joke_prompt -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>topic&#45;&gt;joke_prompt</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M87.3,-32C95.71,-32 105.2,-32 114.85,-32\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"114.94,-35.5 124.94,-32 114.94,-28.5 114.94,-35.5\"/>\n",
-       "</g>\n",
        "<!-- reply -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>reply</title>\n",
        "<path fill=\"#ffc857\" stroke=\"black\" d=\"M323,-64C323,-64 285,-64 285,-64 279,-64 273,-58 273,-52 273,-52 273,-12 273,-12 273,-6 279,0 285,0 285,0 323,0 323,0 329,0 335,-6 335,-12 335,-12 335,-52 335,-52 335,-58 329,-64 323,-64\"/>\n",
        "<text text-anchor=\"start\" x=\"284\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
        "<text text-anchor=\"start\" x=\"294.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
        "<!-- joke_prompt&#45;&gt;reply -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>joke_prompt&#45;&gt;reply</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M244.25,-32C250.42,-32 256.59,-32 262.48,-32\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"262.74,-35.5 272.74,-32 262.74,-28.5 262.74,-35.5\"/>\n",
+       "</g>\n",
+       "<!-- topic -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>topic</title>\n",
+       "<path fill=\"#b4d8e4\" stroke=\"black\" d=\"M75,-64C75,-64 37,-64 37,-64 31,-64 25,-58 25,-52 25,-52 25,-12 25,-12 25,-6 31,0 37,0 37,0 75,0 75,0 81,0 87,-6 87,-12 87,-12 87,-52 87,-52 87,-58 81,-64 75,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"36\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
+       "<text text-anchor=\"start\" x=\"46.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- topic&#45;&gt;joke_prompt -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>topic&#45;&gt;joke_prompt</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M87.3,-32C95.71,-32 105.2,-32 114.85,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.94,-35.5 124.94,-32 114.94,-28.5 114.94,-35.5\"/>\n",
        "</g>\n",
        "<!-- function -->\n",
        "<g id=\"node4\" class=\"node\">\n",
@@ -1505,16 +1501,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8d0a2150>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Cowsay who?'"
+       "<graphviz.graphs.Digraph at 0x7f471e26ee90>"
       ]
      },
      "metadata": {},
@@ -1554,6 +1541,13 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DeprecationWarning: `--hide_results` is no longer required when using `--execute`. Now, results are hidden by default. Use `--show_results` if you want them automatically printed to cell output.\n"
+     ]
+    },
+    {
      "data": {
       "image/svg+xml": [
        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
@@ -1572,12 +1566,38 @@
        "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"8,-74 8,-206 104,-206 104,-74 8,-74\"/>\n",
        "<text text-anchor=\"middle\" x=\"56\" y=\"-190.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
        "</g>\n",
-       "<!-- reply -->\n",
+       "<!-- joke_prompt -->\n",
        "<g id=\"node1\" class=\"node\">\n",
+       "<title>joke_prompt</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M232,-64C232,-64 137,-64 137,-64 131,-64 125,-58 125,-52 125,-52 125,-12 125,-12 125,-6 131,0 137,0 137,0 232,0 232,0 238,0 244,-6 244,-12 244,-12 244,-52 244,-52 244,-58 238,-64 232,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"136\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
+       "<text text-anchor=\"start\" x=\"175\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- reply -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>reply</title>\n",
        "<path fill=\"#ffc857\" stroke=\"black\" d=\"M323,-64C323,-64 285,-64 285,-64 279,-64 273,-58 273,-52 273,-52 273,-12 273,-12 273,-6 279,0 285,0 285,0 323,0 323,0 329,0 335,-6 335,-12 335,-12 335,-52 335,-52 335,-58 329,-64 323,-64\"/>\n",
        "<text text-anchor=\"start\" x=\"284\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
        "<text text-anchor=\"start\" x=\"294.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- joke_prompt&#45;&gt;reply -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>joke_prompt&#45;&gt;reply</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M244.25,-32C250.42,-32 256.59,-32 262.48,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"262.74,-35.5 272.74,-32 262.74,-28.5 262.74,-35.5\"/>\n",
+       "</g>\n",
+       "<!-- topic -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>topic</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M75,-64C75,-64 37,-64 37,-64 31,-64 25,-58 25,-52 25,-52 25,-12 25,-12 25,-6 31,0 37,0 37,0 75,0 75,0 81,0 87,-6 87,-12 87,-12 87,-52 87,-52 87,-58 81,-64 75,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"36\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
+       "<text text-anchor=\"start\" x=\"46.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- topic&#45;&gt;joke_prompt -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>topic&#45;&gt;joke_prompt</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M87.3,-32C95.71,-32 105.2,-32 114.85,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.94,-35.5 124.94,-32 114.94,-28.5 114.94,-35.5\"/>\n",
        "</g>\n",
        "<!-- punchline -->\n",
        "<g id=\"node4\" class=\"node\">\n",
@@ -1591,32 +1611,6 @@
        "<title>reply&#45;&gt;punchline</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M335.09,-32C340.93,-32 347.24,-32 353.64,-32\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"353.71,-35.5 363.71,-32 353.71,-28.5 353.71,-35.5\"/>\n",
-       "</g>\n",
-       "<!-- topic -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>topic</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M75,-64C75,-64 37,-64 37,-64 31,-64 25,-58 25,-52 25,-52 25,-12 25,-12 25,-6 31,0 37,0 37,0 75,0 75,0 81,0 87,-6 87,-12 87,-12 87,-52 87,-52 87,-58 81,-64 75,-64\"/>\n",
-       "<text text-anchor=\"start\" x=\"36\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">topic</text>\n",
-       "<text text-anchor=\"start\" x=\"46.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- joke_prompt -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>joke_prompt</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M232,-64C232,-64 137,-64 137,-64 131,-64 125,-58 125,-52 125,-52 125,-12 125,-12 125,-6 131,0 137,0 137,0 232,0 232,0 238,0 244,-6 244,-12 244,-12 244,-52 244,-52 244,-58 238,-64 232,-64\"/>\n",
-       "<text text-anchor=\"start\" x=\"136\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
-       "<text text-anchor=\"start\" x=\"175\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- topic&#45;&gt;joke_prompt -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>topic&#45;&gt;joke_prompt</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M87.3,-32C95.71,-32 105.2,-32 114.85,-32\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"114.94,-35.5 124.94,-32 114.94,-28.5 114.94,-35.5\"/>\n",
-       "</g>\n",
-       "<!-- joke_prompt&#45;&gt;reply -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>joke_prompt&#45;&gt;reply</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M244.25,-32C250.42,-32 256.59,-32 262.48,-32\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"262.74,-35.5 272.74,-32 262.74,-28.5 262.74,-35.5\"/>\n",
        "</g>\n",
        "<!-- function -->\n",
        "<g id=\"node5\" class=\"node\">\n",
@@ -1634,7 +1628,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8c65de50>"
+       "<graphviz.graphs.Digraph at 0x7f471f6c3190>"
       ]
      },
      "metadata": {},
@@ -1771,7 +1765,7 @@
        "<text text-anchor=\"start\" x=\"299\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
        "<!-- punchline -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>punchline</title>\n",
        "<polygon fill=\"#ffc857\" stroke=\"black\" points=\"466.5,-64 368.5,-64 368.5,0 466.5,0 466.5,-64\"/>\n",
        "<polyline fill=\"none\" stroke=\"black\" points=\"380.5,-64 368.5,-52 \"/>\n",
@@ -1782,13 +1776,13 @@
        "<text text-anchor=\"start\" x=\"408\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
        "<!-- reply&#45;&gt;punchline -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>reply&#45;&gt;punchline</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M339.59,-32C345.43,-32 351.74,-32 358.14,-32\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"358.21,-35.5 368.21,-32 358.21,-28.5 358.21,-35.5\"/>\n",
        "</g>\n",
        "<!-- joke_prompt -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>joke_prompt</title>\n",
        "<path fill=\"#ffc857\" stroke=\"black\" d=\"M236.5,-64C236.5,-64 141.5,-64 141.5,-64 135.5,-64 129.5,-58 129.5,-52 129.5,-52 129.5,-12 129.5,-12 129.5,-6 135.5,0 141.5,0 141.5,0 236.5,0 236.5,0 242.5,0 248.5,-6 248.5,-12 248.5,-12 248.5,-52 248.5,-52 248.5,-58 242.5,-64 236.5,-64\"/>\n",
        "<text text-anchor=\"start\" x=\"140.5\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
@@ -1808,7 +1802,7 @@
        "<text text-anchor=\"start\" x=\"67\" y=\"-27.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">str</text>\n",
        "</g>\n",
        "<!-- _joke_prompt_inputs&#45;&gt;joke_prompt -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>_joke_prompt_inputs&#45;&gt;joke_prompt</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M100.62,-32C106.68,-32 113.02,-32 119.39,-32\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"119.41,-35.5 129.41,-32 119.41,-28.5 119.41,-35.5\"/>\n",
@@ -1845,43 +1839,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8c65c690>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'monday'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\"Knock, knock. Who's there? monday\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'monday who?'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Bingo bongo!'"
+       "<graphviz.graphs.Digraph at 0x7f471e26e3d0>"
       ]
      },
      "metadata": {},
@@ -1955,12 +1913,25 @@
        "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"11.5,-74 11.5,-206 107.5,-206 107.5,-74 11.5,-74\"/>\n",
        "<text text-anchor=\"middle\" x=\"59.5\" y=\"-190.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
        "</g>\n",
-       "<!-- reply -->\n",
+       "<!-- joke_prompt -->\n",
        "<g id=\"node1\" class=\"node\">\n",
+       "<title>joke_prompt</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M107,-64C107,-64 12,-64 12,-64 6,-64 0,-58 0,-52 0,-52 0,-12 0,-12 0,-6 6,0 12,0 12,0 107,0 107,0 113,0 119,-6 119,-12 119,-12 119,-52 119,-52 119,-58 113,-64 107,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"11\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
+       "<text text-anchor=\"start\" x=\"50\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- reply -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>reply</title>\n",
        "<path fill=\"#ffc857\" stroke=\"black\" d=\"M198,-64C198,-64 160,-64 160,-64 154,-64 148,-58 148,-52 148,-52 148,-12 148,-12 148,-6 154,0 160,0 160,0 198,0 198,0 204,0 210,-6 210,-12 210,-12 210,-52 210,-52 210,-58 204,-64 198,-64\"/>\n",
        "<text text-anchor=\"start\" x=\"159\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
        "<text text-anchor=\"start\" x=\"169.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- joke_prompt&#45;&gt;reply -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>joke_prompt&#45;&gt;reply</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M119.25,-32C125.42,-32 131.59,-32 137.48,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"137.74,-35.5 147.74,-32 137.74,-28.5 137.74,-35.5\"/>\n",
        "</g>\n",
        "<!-- punchline -->\n",
        "<g id=\"node3\" class=\"node\">\n",
@@ -1974,19 +1945,6 @@
        "<title>reply&#45;&gt;punchline</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M210.09,-32C215.93,-32 222.24,-32 228.64,-32\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"228.71,-35.5 238.71,-32 228.71,-28.5 228.71,-35.5\"/>\n",
-       "</g>\n",
-       "<!-- joke_prompt -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>joke_prompt</title>\n",
-       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M107,-64C107,-64 12,-64 12,-64 6,-64 0,-58 0,-52 0,-52 0,-12 0,-12 0,-6 6,0 12,0 12,0 107,0 107,0 113,0 119,-6 119,-12 119,-12 119,-52 119,-52 119,-58 113,-64 107,-64\"/>\n",
-       "<text text-anchor=\"start\" x=\"11\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
-       "<text text-anchor=\"start\" x=\"50\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
-       "</g>\n",
-       "<!-- joke_prompt&#45;&gt;reply -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>joke_prompt&#45;&gt;reply</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M119.25,-32C125.42,-32 131.59,-32 137.48,-32\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"137.74,-35.5 147.74,-32 137.74,-28.5 137.74,-35.5\"/>\n",
        "</g>\n",
        "<!-- function -->\n",
        "<g id=\"node4\" class=\"node\">\n",
@@ -2004,7 +1962,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x7f9a8c646690>"
+       "<graphviz.graphs.Digraph at 0x7f471e279210>"
       ]
      },
      "metadata": {},
@@ -2015,39 +1973,12 @@
      "output_type": "stream",
      "text": [
       "Executing node: joke_prompt.\n",
-      "Finished debugging node: joke_prompt in 53.4μs. Status: Success.\n",
+      "Finished debugging node: joke_prompt in 80.3μs. Status: Success.\n",
       "Executing node: reply.\n",
-      "Finished debugging node: reply in 10.5μs. Status: Success.\n",
+      "Finished debugging node: reply in 44.8μs. Status: Success.\n",
       "Executing node: punchline.\n",
-      "Finished debugging node: punchline in 9.78μs. Status: Success.\n"
+      "Finished debugging node: punchline in 42.7μs. Status: Success.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\"Knock, knock. Who's there? Cowsay\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Cowsay who?'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'No, Cowsay MooOOooo'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2071,19 +2002,133 @@
    "source": [
     "There are ton of awesome adapters that can help you with your notebook experience. Here are a few notable mentions:\n",
     "\n",
-    "1. `hamilton.lifecycle.default.CacheAdapter()` will automatically version the node's code and input values and store its result on disk. When running the same node (code, inputs) pair, it will read the value from disk instead of recomputing. This can help save LLM API costs!\n",
-    "2. `hamilton.plugins.h_diskcache.DiskCacheAdapter()` same core features as `CacheAdapter()`, but more utilities around cache management\n",
-    "3. `hamilton.lifecycle.default.PrintLn()` print execution status.\n",
-    "4. `hamilton.plugins.h_tqdm.ProgressBar()` add a progress bar for execution.\n",
-    "5. `hamilton.lifecycle.default.PDBDebugger()` allows you to step into a node with a Python debugger, allowing you to execute code line by line.\n",
+    "1. `hamilton.lifecycle.default.PrintLn()` print execution status (this is similar to the `--show_results` flag).\n",
+    "2. `hamilton.plugins.h_tqdm.ProgressBar()` add a progress bar for execution.\n",
+    "3. `hamilton.lifecycle.default.PDBDebugger()` allows you to step into a node with a Python debugger, allowing you to execute code line by line.\n",
     "\n",
     "Note that all of these adapters work with Hamilton outside notebooks too!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80779b60",
+   "metadata": {},
+   "source": [
+    "## 3.6 Caching\n",
+    "The next builder include the `.with_cache()` clause. This will store results on disks. Adding the `--display_cache` flag will print a visualization of what results were retrieved from cache once execution is completed.\n",
+    "\n",
+    "To view it, execute the cell twice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "2a43046b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder_with_cache = driver.Builder().with_cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "0ec9d3bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 2.43.0 (0)\n",
+       " -->\n",
+       "<!-- Title: %3 Pages: 1 -->\n",
+       "<svg width=\"352pt\" height=\"222pt\"\n",
+       " viewBox=\"0.00 0.00 351.50 222.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 218)\">\n",
+       "<title>%3</title>\n",
+       "<polygon fill=\"white\" stroke=\"transparent\" points=\"-4,4 -4,-218 347.5,-218 347.5,4 -4,4\"/>\n",
+       "<g id=\"clust1\" class=\"cluster\">\n",
+       "<title>cluster__legend</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"black\" points=\"8,-74 8,-206 124,-206 124,-74 8,-74\"/>\n",
+       "<text text-anchor=\"middle\" x=\"66\" y=\"-190.8\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Legend</text>\n",
+       "</g>\n",
+       "<!-- joke_prompt -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>joke_prompt</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"#f06449\" stroke-width=\"3\" d=\"M113.5,-64C113.5,-64 18.5,-64 18.5,-64 12.5,-64 6.5,-58 6.5,-52 6.5,-52 6.5,-12 6.5,-12 6.5,-6 12.5,0 18.5,0 18.5,0 113.5,0 113.5,0 119.5,0 125.5,-6 125.5,-12 125.5,-12 125.5,-52 125.5,-52 125.5,-58 119.5,-64 113.5,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"17.5\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">joke_prompt</text>\n",
+       "<text text-anchor=\"start\" x=\"56.5\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- reply -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>reply</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"#f06449\" stroke-width=\"3\" d=\"M204.5,-64C204.5,-64 166.5,-64 166.5,-64 160.5,-64 154.5,-58 154.5,-52 154.5,-52 154.5,-12 154.5,-12 154.5,-6 160.5,0 166.5,0 166.5,0 204.5,0 204.5,0 210.5,0 216.5,-6 216.5,-12 216.5,-12 216.5,-52 216.5,-52 216.5,-58 210.5,-64 204.5,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"165.5\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">reply</text>\n",
+       "<text text-anchor=\"start\" x=\"176\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- joke_prompt&#45;&gt;reply -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>joke_prompt&#45;&gt;reply</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M125.75,-32C131.92,-32 138.09,-32 143.98,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"144.24,-35.5 154.24,-32 144.24,-28.5 144.24,-35.5\"/>\n",
+       "</g>\n",
+       "<!-- punchline -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>punchline</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"#f06449\" stroke-width=\"3\" d=\"M331.5,-64C331.5,-64 257.5,-64 257.5,-64 251.5,-64 245.5,-58 245.5,-52 245.5,-52 245.5,-12 245.5,-12 245.5,-6 251.5,0 257.5,0 257.5,0 331.5,0 331.5,0 337.5,0 343.5,-6 343.5,-12 343.5,-12 343.5,-52 343.5,-52 343.5,-58 337.5,-64 331.5,-64\"/>\n",
+       "<text text-anchor=\"start\" x=\"256.5\" y=\"-42.8\" font-family=\"Helvetica,sans-Serif\" font-weight=\"bold\" font-size=\"14.00\">punchline</text>\n",
+       "<text text-anchor=\"start\" x=\"285\" y=\"-14.8\" font-family=\"Helvetica,sans-Serif\" font-style=\"italic\" font-size=\"14.00\">str</text>\n",
+       "</g>\n",
+       "<!-- reply&#45;&gt;punchline -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>reply&#45;&gt;punchline</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M216.59,-32C222.43,-32 228.74,-32 235.14,-32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"235.21,-35.5 245.21,-32 235.21,-28.5 235.21,-35.5\"/>\n",
+       "</g>\n",
+       "<!-- output -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>output</title>\n",
+       "<path fill=\"#ffc857\" stroke=\"black\" d=\"M88,-174.5C88,-174.5 44,-174.5 44,-174.5 38,-174.5 32,-168.5 32,-162.5 32,-162.5 32,-149.5 32,-149.5 32,-143.5 38,-137.5 44,-137.5 44,-137.5 88,-137.5 88,-137.5 94,-137.5 100,-143.5 100,-149.5 100,-149.5 100,-162.5 100,-162.5 100,-168.5 94,-174.5 88,-174.5\"/>\n",
+       "<text text-anchor=\"middle\" x=\"66\" y=\"-152.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">output</text>\n",
+       "</g>\n",
+       "<!-- from cache -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>from cache</title>\n",
+       "<path fill=\"#ffffff\" stroke=\"#f06449\" stroke-width=\"3\" d=\"M104,-119.5C104,-119.5 28,-119.5 28,-119.5 22,-119.5 16,-113.5 16,-107.5 16,-107.5 16,-94.5 16,-94.5 16,-88.5 22,-82.5 28,-82.5 28,-82.5 104,-82.5 104,-82.5 110,-82.5 116,-88.5 116,-94.5 116,-94.5 116,-107.5 116,-107.5 116,-113.5 110,-119.5 104,-119.5\"/>\n",
+       "<text text-anchor=\"middle\" x=\"66\" y=\"-97.3\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">from cache</text>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ],
+      "text/plain": [
+       "<graphviz.graphs.Digraph at 0x7f47433eeb10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%cell_to_module joke --builder builder_with_cache --execute --display_cache\n",
+    "def joke_prompt() -> str:\n",
+    "    return f\"Knock, knock. Who's there? Cowsay\"\n",
+    "\n",
+    "def reply(joke_prompt: str) -> str:\n",
+    "    _, _, right = joke_prompt.partition(\"? \")\n",
+    "    return f\"{right} who?\"\n",
+    "\n",
+    "def punchline(reply: str) -> str:\n",
+    "    left, _, _ = reply.partition(\" \")\n",
+    "    return f\"No, {left} MooOOooo\""
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -2097,7 +2142,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Follows #1183. Also it switched the default of `--execute` to not show the execution results. The flag `--hide_results` was changed to  `--show_results` in a backwards compatible way. The example notebook was updated accordingly.  