### PR TITLE
Add SDK config

### DIFF
--- a/hamilton/telemetry.py
+++ b/hamilton/telemetry.py
@@ -52,8 +52,8 @@ CLI_COMMAND = "os_hamilton_cli_command"
 EXPERIMENT_SERVER = "os_hamilton_experiment_server"
 TIMEOUT = 2
 MAX_COUNT_SESSION = 100  # max number of events collected per python process
-
-DEFAULT_CONFIG_LOCATION = os.path.expanduser("~/.hamilton.conf")
+DEFAULT_CONFIG_URI = os.environ.get("HAMILTON_CONFIG_URI", "~/.hamilton.conf")
+DEFAULT_CONFIG_LOCATION = os.path.expanduser(DEFAULT_CONFIG_URI)
 
 
 def _load_config(config_location: str) -> configparser.ConfigParser:

--- a/ui/sdk/src/hamilton_sdk/tracking/constants.py
+++ b/ui/sdk/src/hamilton_sdk/tracking/constants.py
@@ -1,0 +1,87 @@
+"""This module contains constants for tracking.
+
+We then override these by:
+1. Looking for a configuration file and taking the section under `SDK_CONSTANTS`.
+2. Via environment variables. They should be prefixed with `HAMILTON_`.
+3. Lastly folks can manually adjust these values directly by importing the module and changing the value.
+
+Note: This module cannot import other Hamilton modules.
+"""
+
+import configparser
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The following are the default values for the tracking client
+CAPTURE_DATA_STATISTICS = True
+MAX_LIST_LENGTH_CAPTURE = 50
+MAX_DICT_LENGTH_CAPTURE = 100
+
+# Check for configuration file
+# TODO -- add configuration file support
+DEFAULT_CONFIG_URI = os.environ.get("HAMILTON_CONFIG_URI", "~/.hamilton.conf")
+DEFAULT_CONFIG_LOCATION = os.path.expanduser(DEFAULT_CONFIG_URI)
+
+
+def _load_config(config_location: str) -> configparser.ConfigParser:
+    """Pulls config if it exists.
+
+    :param config_location: location of the config file.
+    """
+    config = configparser.ConfigParser()
+    try:
+        with open(config_location) as f:
+            config.read_file(f)
+    except Exception:
+        pass
+
+    return config
+
+
+_constant_values = globals()
+file_config = _load_config(DEFAULT_CONFIG_LOCATION)
+
+
+def _convert_to_type(val_: str) -> Any:
+    if not isinstance(val_, str):  # guard
+        return val_
+    if val_.isdigit():
+        # convert to int
+        val_ = int(val_)
+    elif val_.lower() in {"true", "false"}:
+        # convert to bool
+        val_ = val_.lower() == "true"
+    else:
+        try:  # check if float
+            val_ = float(val_)
+        except ValueError:
+            pass
+    return val_
+
+
+# loads from config file and overwrites
+if "SDK_CONSTANTS" in file_config:
+    for key, val in file_config["SDK_CONSTANTS"].items():
+        upper_key = key.upper()
+        if upper_key not in _constant_values:
+            continue
+        # convert from string to appropriate type
+        val = _convert_to_type(val)
+        # overwrite value
+        _constant_values[upper_key] = val
+
+# Check for environment variables & overwrites
+# TODO automate this by pulling anything in with a prefix and checking
+# globals here and updating them.
+CAPTURE_DATA_STATISTICS = os.getenv("HAMILTON_CAPTURE_DATA_STATISTICS", CAPTURE_DATA_STATISTICS)
+if isinstance(CAPTURE_DATA_STATISTICS, str):
+    CAPTURE_DATA_STATISTICS = CAPTURE_DATA_STATISTICS.lower() == "true"
+MAX_LIST_LENGTH_CAPTURE = int(
+    os.getenv("HAMILTON_MAX_LIST_LENGTH_CAPTURE", MAX_LIST_LENGTH_CAPTURE)
+)
+MAX_DICT_LENGTH_CAPTURE = int(
+    os.getenv("HAMILTON_MAX_DICT_LENGTH_CAPTURE", MAX_DICT_LENGTH_CAPTURE)
+)

--- a/ui/sdk/src/hamilton_sdk/tracking/utils.py
+++ b/ui/sdk/src/hamilton_sdk/tracking/utils.py
@@ -48,6 +48,8 @@ def make_json_safe(item: Union[dict, list, str, float, int, bool]) -> Any:
         # we convert to json string and then deserialize it so that
         # it's not a string in the UI.
         try:
+            if hasattr(item, "head"):
+                item = item.head()  # truncate to head rows if it's a dataframe
             return json.loads(item.to_json())
         except Exception:
             # pass

--- a/ui/sdk/tests/tracking/test_constants.py
+++ b/ui/sdk/tests/tracking/test_constants.py
@@ -1,0 +1,21 @@
+import configparser
+from hamilton_sdk.tracking import constants
+
+
+def test__convert_to_type():
+    # using configparser to make it more realistic
+    config = configparser.ConfigParser()
+    config["SDK_CONSTANTS"] = {
+        "CAPTURE_DATA_STATISTICS": "true",
+        "MAX_LIST_LENGTH_CAPTURE": "5",
+        "MAX_DICT_LENGTH_CAPTURE": "10",
+        "SOMETHING_ELSE": "11.0",
+        "Another_thing": "1asdfasdf",
+    }
+    assert constants._convert_to_type(config["SDK_CONSTANTS"]["CAPTURE_DATA_STATISTICS"]) is True
+    assert constants._convert_to_type(config["SDK_CONSTANTS"]["MAX_LIST_LENGTH_CAPTURE"]) == 5
+    assert constants._convert_to_type(config["SDK_CONSTANTS"]["MAX_DICT_LENGTH_CAPTURE"]) == 10
+    assert constants._convert_to_type(config["SDK_CONSTANTS"]["SOMETHING_ELSE"]) == 11.0
+    assert constants._convert_to_type(config["SDK_CONSTANTS"]["Another_thing"]) == "1asdfasdf"
+    o = object()
+    assert constants._convert_to_type(o) == o

--- a/ui/sdk/tests/tracking/test_runs.py
+++ b/ui/sdk/tests/tracking/test_runs.py
@@ -534,3 +534,13 @@ def test_process_result_happy(test_result, test_node, observability_type, stats)
     if schema is not None:
         json.dumps(schema)
     [json.dumps(add) for add in additional]
+
+
+def test_disable_capturing_data_stats(monkeypatch):
+    monkeypatch.setattr("hamilton_sdk.tracking.constants.CAPTURE_DATA_STATISTICS", False)
+    stats, schema, additional = runs.process_result([1, 2, 3, 4], create_node("a", list))
+    assert stats["observability_type"] == "primitive"
+    assert stats["observability_value"] == {
+        "type": "str",
+        "value": "RESULT SUMMARY DISABLED",
+    }

--- a/ui/sdk/tests/tracking/test_stats.py
+++ b/ui/sdk/tests/tracking/test_stats.py
@@ -32,6 +32,35 @@ def test_compute_stats_dict():
     }
 
 
+def test_compute_stats_dict_truncated(monkeypatch):
+    monkeypatch.setattr("hamilton_sdk.tracking.constants.MAX_DICT_LENGTH_CAPTURE", 1)
+    actual = data_observation.compute_stats({"a": 1, "b": 2}, "test_node", {})
+    assert actual == {
+        "observability_type": "dict",
+        "observability_value": {
+            "type": str(type(dict())),
+            "value": {
+                "__truncated__": "... values truncated ...",
+                "a": 1,
+            },
+        },
+        "observability_schema_version": "0.0.2",
+    }
+
+
+def test_compute_stats_list_truncated(monkeypatch):
+    monkeypatch.setattr("hamilton_sdk.tracking.constants.MAX_LIST_LENGTH_CAPTURE", 1)
+    actual = data_observation.compute_stats([1, 2, 3, 4], "test_node", {})
+    assert actual == {
+        "observability_type": "dict",
+        "observability_value": {
+            "type": str(type(list())),
+            "value": [1, "... truncated ..."],
+        },
+        "observability_schema_version": "0.0.2",
+    }
+
+
 def test_compute_stats_tuple_dataloader():
     """tests case of a dataloader"""
     actual = data_observation.compute_stats(

--- a/ui/sdk/tests/tracking/test_utils.py
+++ b/ui/sdk/tests/tracking/test_utils.py
@@ -139,7 +139,7 @@ def test_make_json_safe_with_pandas_series():
         "1642291200000": 50,
         "1642896000000": 100,
         "1643500800000": 200,
-        "1644105600000": 400,
+        # "1644105600000": 400, -- skipped due to `.head()` being called
     }
 
 


### PR DESCRIPTION
This adds a few things to enable one to more
easily customize what is captured via the SDK.

1. Should you capture any data statistics at all?
2. Max lengths of dicts and lists -> so they don't get too big.

You can configure this via three means:
1. python constants
2. config file variables
3. environment variables

There is a prescedence order. So there are default values in the module.
You can then override them via config file variables.
Which then can in turn be overriden by environment variables.
Lastly the user can always modify the constants by directly
changing the module variables.

Note: we also skip logging metadata from datasavers and loaders if
the CAPTURE_DATA_STATISTICS = False. We can fix this by special
casing it, but for now I don't think people would complain with
the current functionality.

We should still enable #921 but I think this is a simpler route for now.

## Changes
- telemetry.py
- sdk related files

## How I tested this
- locally

## Notes
This is related to:
 - #921 this still leaves that on the table, but a different implementation
 - #1228 this would give people an option to not log too much

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
