### PR TITLE
amend `pipe_input` example in docstring

### DIFF
--- a/hamilton/function_modifiers/macros.py
+++ b/hamilton/function_modifiers/macros.py
@@ -845,7 +845,7 @@ class pipe_input(base.NodeInjector):
                     step(_add_two, y=source("upstream_node")).on_input("p2")
                 )
                 def final_result(p1: int, p2: int, p3: int) -> int:
-                    return upstream_int
+                    return p1 + p2 + p3
 
             We can also do this on the global level to set for all transforms a target parameter.
 


### PR DESCRIPTION
Documentation example discontinuity fixed for `pipe_input`.
The example would have failed if executed.

## Changes
fixed the docstring example

## How I tested this
I did not test this

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
