### PR TITLE
fingerprinting base case handles empty __dict__

### DIFF
--- a/hamilton/caching/fingerprinting.py
+++ b/hamilton/caching/fingerprinting.py
@@ -71,7 +71,11 @@ def hash_value(obj, *args, depth=0, **kwargs) -> str:
     if depth > MAX_DEPTH:
         return UNHASHABLE
 
-    if hasattr(obj, "__dict__"):
+    # __dict__ attribute contains the instance attributes of the object.
+    # this is typically sufficient to define the object and its behavior, so it's a good target
+    # for a hash in the default case.
+    # Objects that return an empty dict should be skipped (very odd behavior, happens with pandas type)
+    if getattr(obj, "__dict__", {}) != {}:
         return hash_value(obj.__dict__, depth=depth + 1)
 
     # check if the object comes from a module part of the standard library

--- a/tests/caching/test_fingerprinting.py
+++ b/tests/caching/test_fingerprinting.py
@@ -23,12 +23,24 @@ def test_hash_no_dict_attribute():
     class Foo:
         __slots__ = ()
 
-        def __init__(self):
-            pass
+    obj = Foo()
+    assert not hasattr(obj, "__dict__")
+
+    fingerprint = fingerprinting.hash_value(obj)
+
+    assert fingerprint == fingerprinting.UNHASHABLE
+
+
+def test_empty_dict_attr_is_unhashable():
+    """Classes with an empty __dict__ can't be hashed during the base case."""
+
+    class Foo: ...  # noqa: E701
 
     obj = Foo()
+    assert obj.__dict__ == {}
+
     fingerprint = fingerprinting.hash_value(obj)
-    assert not hasattr(obj, "__dict__")
+
     assert fingerprint == fingerprinting.UNHASHABLE
 
 


### PR DESCRIPTION
Fixes #1242; copying reply from the issues thread
# Problem
Using the cache with these two functions would create a collision and both would return `pd.Timestamp("2021-01-01")` on the 2nd execution (i.e., when retrieving values from cache)

```python
import pandas as pd

def first() -> pd.Timestamp:
  return pd.Timestamp("2021-01-01")
  
def second() -> pd.Timestamp:
  return pd.Timestamp("2021-01-02")
```

# Solution
The source of the bug is an oddity of `pandas`. Some objects have an empty `__dict__` attached. A one line condition check now properly displays the intended warning messages. 

When encountering this case, Hamilton gives a random UUID instead of hashing the value. Caching can still work because the cache key is `NODE_NAME-CODE_VERSION-DATA_VERSION` where data version is now a random UUID

![image](https://github.com/user-attachments/assets/38f69122-40d4-468b-a98c-3c967405e325)

# Investigation
- the reproduction worked on my machine
- `dr.cache.code_versions` show that `first()` and `second()` are produce different `code_version` hash
- `dr.cache.data_versions` produce the same `data_version` hash (source of the bug)
- Lets look at the per-type hashing functions in `hamilton.caching.fingerprinting`
- `hash_pandas_obj()` expects `pd.Series` or `pd.DataFrame` and doesn't handle `pd.Timestamp` (it would handle a series of `pd.Timestamp` values without collisions though)
- The `data_versions` match the result of the default implementation `hash_value()` and falls under `hash_value(pd.Timestamp(...).__dict__)`
- It seems that `pd.Timestamp(...).__dict__ == {}`, which is an odd behavior by pandas (it shouldn't be defined instead of empty)
- Currently, `hash_value()` handles objects without a `__dict__` (i.e., uses slots), but doesn't account for empty `.__dict__` attribute

## side notes
- Warnings are only shown when hashing the value, meaning it's typically only displayed on first execution (value is retrieved on subsequent executions). This is a desirable behavior.
- it's important to clear the on-disk cache when debugging this; can use in-memory caching for simplicity