### PR TITLE
Add AsyncDDOGTracer

### DIFF
--- a/docs/reference/lifecycle-hooks/DDOGTracer.rst
+++ b/docs/reference/lifecycle-hooks/DDOGTracer.rst
@@ -7,3 +7,8 @@ plugins.h_ddog.DDOGTracer
    :special-members: __init__
    :members:
    :inherited-members:
+
+.. autoclass:: hamilton.plugins.h_ddog.AsyncDDOGTracer
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/hamilton/plugins/h_ddog.py
+++ b/hamilton/plugins/h_ddog.py
@@ -155,7 +155,7 @@ class _DDOGTracerImpl:
                     )
         tags = node_tags.copy()
         tags["hamilton.node_name"] = node_name
-        new_span.set_tags(DDOGTracer._sanitize_tags(tags=tags))
+        new_span.set_tags(self._sanitize_tags(tags=tags))
         self.node_span_cache[run_id][(task_id, node_name)] = new_span
 
     def run_after_node_execution(

--- a/hamilton/plugins/h_ddog.py
+++ b/hamilton/plugins/h_ddog.py
@@ -20,6 +20,15 @@ except ImportError as e:
 
 
 class _DDOGTracerImpl:
+    """Implementation class for DDOGTracer and AsyncDDOGTracer functionality.
+
+    This class encapsulates the core logic for Datadog tracing within Hamilton's lifecycle hooks.
+    It provides methods to handle the tracing operations required before and after the execution
+    of graphs, nodes, and tasks. The DDOGTracer and AsyncDDOGTracer classes are composed of this implementation class,
+    due to the differences in their base lifecycle classes (sync vs async). This class allows sharing logic between the
+    two without duplicating code or interfering with the base classes they inherit from.
+    """
+
     def __init__(self, root_name: str, include_causal_links: bool = False, service: str = None):
         self.root_name = root_name
         self.service = service
@@ -106,6 +115,7 @@ class _DDOGTracerImpl:
         :param run_id: ID of the run
         :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
         """
+        # This returns None if there's no active context and works as a no-op, otherwise we tie this span to a parent.
         current_context = tracer.current_trace_context()
         span = tracer.start_span(
             name=self.root_name, child_of=current_context, activate=True, service=self.service

--- a/hamilton/plugins/h_ddog.py
+++ b/hamilton/plugins/h_ddog.py
@@ -19,35 +19,8 @@ except ImportError as e:
     raise
 
 
-class DDOGTracer(
-    lifecycle.NodeExecutionHook, lifecycle.GraphExecutionHook, lifecycle.TaskExecutionHook
-):
-    """Lifecycle adapter to use datadog to run tracing on node execution. This works with the following execution environments:
-    1. Vanilla Hamilton -- no task-based computation, just nodes
-    2. Task-based, synchronous
-    3. Task-based with Multithreading, Ray, and Dask
-    It will likely work with others, although we have not yet tested them. This does not work with async (yet).
-
-    Note that this is not a typical use of Datadog if you're not using hamilton for a microservice. It does work quite nicely, however!
-    Monitoring ETLs is not a typical datadog case (you can't see relationships between nodes/tasks or data summaries),
-    but it is easy enough to work with and gives some basic information.
-
-    This tracer bypasses context management so we can more accurately track relationships between nodes/tags. Also, we plan to
-    get this working with OpenTelemetry, and use that for datadog integration.
-
-    To use this, you'll want to run `pip install sf-hamilton[ddog]` (or `pip install "sf-hamilton[ddog]"` if using zsh)
-    """
-
+class _DDOGTracerImpl:
     def __init__(self, root_name: str, include_causal_links: bool = False, service: str = None):
-        """Creates a DDOGTracer. This has the option to specify some parameters.
-
-        :param root_name: Name of the root trace/span. Due to the way datadog inherits, this will inherit an active span.
-        :param include_causal_links: Whether or not to include span causal links. Note that there are some edge-cases here, and
-            This is in beta for datadog, and actually broken in the current client, but it has been fixed and will be released shortly:
-            https://github.com/DataDog/dd-trace-py/issues/8049. Furthermore, the query on datadog is slow for displaying causal links.
-            We've disabled this by default, but feel free to test it out -- its likely they'll be improving the docum
-        :param service: Service name -- will pick it up from the environment through DDOG if not available.
-        """
         self.root_name = root_name
         self.service = service
         self.include_causal_links = include_causal_links
@@ -133,7 +106,10 @@ class DDOGTracer(
         :param run_id: ID of the run
         :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
         """
-        span = tracer.start_span(name=self.root_name, activate=True, service=self.service)
+        current_context = tracer.current_trace_context()
+        span = tracer.start_span(
+            name=self.root_name, child_of=current_context, activate=True, service=self.service
+        )
         self.run_span_cache[run_id] = span  # we save this as a root span
         self.node_span_cache[run_id] = {}
         self.task_span_cache[run_id] = {}
@@ -272,6 +248,136 @@ class DDOGTracer(
         span.__exit__(exc_type, exc_value, tb)
 
 
+class DDOGTracer(
+    lifecycle.NodeExecutionHook, lifecycle.GraphExecutionHook, lifecycle.TaskExecutionHook
+):
+    """Lifecycle adapter to use datadog to run tracing on node execution. This works with the following execution environments:
+    1. Vanilla Hamilton -- no task-based computation, just nodes
+    2. Task-based, synchronous
+    3. Task-based with Multithreading, Ray, and Dask
+    It will likely work with others, although we have not yet tested them. This does not work with async (yet).
+
+    Note that this is not a typical use of Datadog if you're not using hamilton for a microservice. It does work quite nicely, however!
+    Monitoring ETLs is not a typical datadog case (you can't see relationships between nodes/tasks or data summaries),
+    but it is easy enough to work with and gives some basic information.
+
+    This tracer bypasses context management so we can more accurately track relationships between nodes/tags. Also, we plan to
+    get this working with OpenTelemetry, and use that for datadog integration.
+
+    To use this, you'll want to run `pip install sf-hamilton[ddog]` (or `pip install "sf-hamilton[ddog]"` if using zsh)
+    """
+
+    def __init__(self, root_name: str, include_causal_links: bool = False, service: str = None):
+        """Creates a DDOGTracer. This has the option to specify some parameters.
+
+        :param root_name: Name of the root trace/span. Due to the way datadog inherits, this will inherit an active span.
+        :param include_causal_links: Whether or not to include span causal links. Note that there are some edge-cases here, and
+            This is in beta for datadog, and actually broken in the current client, but it has been fixed and will be released shortly:
+            https://github.com/DataDog/dd-trace-py/issues/8049. Furthermore, the query on datadog is slow for displaying causal links.
+            We've disabled this by default, but feel free to test it out -- its likely they'll be improving the docum
+        :param service: Service name -- will pick it up from the environment through DDOG if not available.
+        """
+        self._impl = _DDOGTracerImpl(
+            root_name=root_name, include_causal_links=include_causal_links, service=service
+        )
+
+    def run_before_graph_execution(self, *, run_id: str, **future_kwargs: Any):
+        """Runs before graph execution -- sets the state so future ones can reference it.
+
+        :param run_id: ID of the run
+        :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
+        """
+        self._impl.run_before_graph_execution(run_id=run_id, **future_kwargs)
+
+    def run_before_node_execution(
+        self,
+        *,
+        node_name: str,
+        node_kwargs: Dict[str, Any],
+        node_tags: Dict[str, Any],
+        task_id: Optional[str],
+        run_id: str,
+        **future_kwargs: Any,
+    ):
+        """Runs before a node's execution. Sets up/stores spans.
+
+        :param node_name: Name of the node.
+        :param node_kwargs: Keyword arguments of the node.
+        :param node_tags: Tags of the node (they'll get stored as datadog tags)
+        :param task_id: Task ID that spawned the node
+        :param run_id: ID of the run.
+        :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
+        """
+        self._impl.run_before_node_execution(
+            node_name=node_name,
+            node_kwargs=node_kwargs,
+            node_tags=node_tags,
+            task_id=task_id,
+            run_id=run_id,
+            **future_kwargs,
+        )
+
+    def run_after_node_execution(
+        self,
+        *,
+        node_name: str,
+        error: Optional[Exception],
+        task_id: Optional[str],
+        run_id: str,
+        **future_kwargs: Any,
+    ):
+        """Runs after a node's execution -- completes the span.
+
+        :param node_name: Name of the node
+        :param error: Error that the node raised, if any
+        :param task_id: Task ID that spawned the node
+        :param run_id: ID of the run.
+        :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
+        """
+        self._impl.run_after_node_execution(
+            node_name=node_name, error=error, task_id=task_id, run_id=run_id, **future_kwargs
+        )
+
+    def run_after_graph_execution(
+        self, *, error: Optional[Exception], run_id: str, **future_kwargs: Any
+    ):
+        """Runs after graph execution. Garbage collects + finishes the root span.
+
+        :param error: Error the graph raised when running, if any
+        :param run_id: ID of the run
+        :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
+        """
+        self._impl.run_after_graph_execution(error=error, run_id=run_id, **future_kwargs)
+
+    def run_before_task_execution(self, *, task_id: str, run_id: str, **future_kwargs):
+        """Runs before task execution. Sets up the task span.
+
+        :param task_id: ID of the task
+        :param run_id: ID of the run,
+        :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
+        """
+        self._impl.run_before_task_execution(task_id=task_id, run_id=run_id, **future_kwargs)
+
+    def run_after_task_execution(
+        self,
+        *,
+        task_id: str,
+        run_id: str,
+        error: Exception,
+        **future_kwargs,
+    ):
+        """Rusn after task execution. Finishes task-level spans.
+
+        :param task_id: ID of the task, ID of the run.
+        :param run_id: ID of the run
+        :param error: Error the graph raised when running, if any
+        :param future_kwargs: Future keyword arguments for backwards compatibility
+        """
+        self._impl.run_after_task_execution(
+            task_id=task_id, run_id=run_id, error=error, **future_kwargs
+        )
+
+
 class AsyncDDOGTracer(
     base.BasePostGraphConstructAsync,
     base.BasePreGraphExecuteAsync,
@@ -282,7 +388,9 @@ class AsyncDDOGTracer(
     def __init__(
         self, root_name: str, include_causal_links: bool = False, service: str | None = None
     ):
-        """Creates a AsyncDDOGTracer. This has the option to specify some parameters.
+        """Creates a AsyncDDOGTracer, the asyncio-friendly version of DDOGTracer.
+
+        This has the option to specify some parameters:
 
         :param root_name: Name of the root trace/span. Due to the way datadog inherits, this will inherit an active span.
         :param include_causal_links: Whether or not to include span causal links. Note that there are some edge-cases here, and
@@ -291,92 +399,19 @@ class AsyncDDOGTracer(
             We've disabled this by default, but feel free to test it out -- its likely they'll be improving the docum
         :param service: Service name -- will pick it up from the environment through DDOG if not available.
         """
-        self.root_name = root_name
-        self.service = service
-        self.include_causal_links = include_causal_links
-        self.run_span_cache: dict[str, Any] = {}  # Cache of run_id -> span tuples
-        self.task_span_cache: dict[
-            str, Any
-        ] = {}  # cache of run_iod -> task_id -> span. Note that we will prune this after task execution
-        self.node_span_cache: dict[
-            str, Any
-        ] = {}  # Cache of run_id -> [task_id, node_id] -> span. We use this to open/close general traces
-
-    @staticmethod
-    def _serialize_span_dict(span_dict: Dict[str, Span]) -> Dict[str, dict]:
-        """Serializes to a readable format. We're not propogating span links (see note above on causal links),
-        but that's fine (for now). We have to do this as passing spans back and forth is frowned upon.
-
-        :param span_dict: A key -> span dictionary
-        :return: The serialized representation.
-        """
-        # For some reason this doesn't use the right ser/deser for dask
-        # Or for some reason it has contexts instead of spans. Well, we can serialize them both!
-        return {
-            key: {
-                "trace_id": span.context.trace_id if isinstance(span, Span) else span.trace_id,
-                "span_id": span.context.span_id if isinstance(span, Span) else span.span_id,
-            }
-            for key, span in span_dict.items()
-        }
-
-    @staticmethod
-    def _deserialize_span_dict(serialized_repr: Dict[str, dict]) -> Dict[str, context.Context]:
-        """Note that we deserialize as contexts, as passing spans is not supported
-        (the child should never terminate the parent span).
-
-        :param span_dict: Dict of str -> dict params for contexts
-        :return: A dictionary of contexts
-        """
-        return {key: context.Context(**params) for key, params in serialized_repr.items()}
-
-    def __getstate__(self) -> dict[str, Any]:
-        """Gets the state for serialization."""
-        return dict(
-            root_trace_name=self.root_name,
-            service=self.service,
-            include_causal_links=self.include_causal_links,
-            run_span_cache=self._serialize_span_dict(self.run_span_cache),
-            task_span_cache={
-                key: self._serialize_span_dict(value) for key, value in self.task_span_cache.items()
-            },
-            # this is unnecessary, but leaving it here for now
-            # to remove it, we need to add a default check in the one that adds to the nodes
-            node_span_cache={
-                key: self._serialize_span_dict(value) for key, value in self.task_span_cache.items()
-            },  # Nothing here, we can just wipe it for a new task
+        self._impl = _DDOGTracerImpl(
+            root_name=root_name, include_causal_links=include_causal_links, service=service
         )
-
-    def __setstate__(self, state: dict) -> None:
-        """Sets the state for serialization."""
-        self.service = state["service"]
-        self.root_name = state["root_trace_name"]
-        self.include_causal_links = state["include_causal_links"]
-        # TODO -- move this out/consider doing it to the others
-        self.run_span_cache = self._deserialize_span_dict(state["run_span_cache"])
-        # We only really need this if we log the stuff before submitting...
-        # This shouldn't happen but it leaves flexibility for the future
-        self.task_span_cache = {
-            key: self._deserialize_span_dict(value)
-            for key, value in state["task_span_cache"].items()
-        }
-        self.node_span_cache = {
-            key: self._deserialize_span_dict(value)
-            for key, value in state["node_span_cache"].items()
-        }
-
-    @staticmethod
-    def _sanitize_tags(tags: Dict[str, Any]) -> Dict[str, str]:
-        """Sanitizes tags to be strings, just in case.
-
-        :param tags: Node tags.
-        :return: The string -> string representation of tags
-        """
-        return {f"hamilton.{key}": str(value) for key, value in tags.items()}
 
     async def post_graph_construct(
         self, graph: h_graph.FunctionGraph, modules: List[ModuleType], config: Dict[str, Any]
     ) -> None:
+        """Runs after graph construction. This is a no-op for this plugin.
+
+        :param graph: Graph that has been constructed.
+        :param modules: Modules passed into the graph
+        :param config: Config passed into the graph
+        """
         pass
 
     async def pre_graph_execute(
@@ -387,50 +422,33 @@ class AsyncDDOGTracer(
         inputs: Dict[str, Any],
         overrides: Dict[str, Any],
     ) -> None:
-        current_context = (
-            tracer.current_trace_context()
-        )  # Get the current ctx, if available, otherwise returns None
-        span = tracer.start_span(
-            name=self.root_name, child_of=current_context, activate=True, service=self.service
-        )
-        self.run_span_cache[run_id] = span  # we save this as a root span
-        self.node_span_cache[run_id] = {}
-        self.task_span_cache[run_id] = {}
+        """Runs before graph execution -- sets the state so future ones can reference it.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param graph:  Graph that is being executed
+        :param final_vars: Variables we are extracting from the graph
+        :param inputs: Inputs to the graph
+        :param overrides: Overrides to graph execution
+        """
+        self._impl.run_before_graph_execution(run_id=run_id)
 
     async def pre_node_execute(
         self, run_id: str, node_: node.Node, kwargs: Dict[str, Any], task_id: Optional[str] = None
     ) -> None:
         """Runs before a node's execution. Sets up/stores spans.
 
-        :param node_name: Name of the node.
-        :param node_kwargs: Keyword arguments of the node.
-        :param node_tags: Tags of the node (they'll get stored as datadog tags)
-        :param task_id: Task ID that spawned the node
-        :param run_id: ID of the run.
-        :param future_kwargs: reserved for future keyword arguments/backwards compatibility.
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param node_: Node that is being executed
+        :param kwargs: Keyword arguments that are being passed into the node
+        :param task_id: ID of the task, defaults to None if not in a task setting
         """
-        # We need to do this on launching tasks and we have not yet exposed it.
-        # TODO -- do pre-task and post-task execution.
-        parent_span = self.task_span_cache[run_id].get(task_id) or self.run_span_cache[run_id]
-        new_span_name = f"{task_id}:" if task_id is not None else ""
-        new_span_name += node_.name
-        new_span = tracer.start_span(
-            name=new_span_name, child_of=parent_span, activate=True, service=self.service
+        self._impl.run_before_node_execution(
+            node_name=node_.name,
+            node_kwargs=kwargs,
+            node_tags=node_.tags,
+            task_id=task_id,
+            run_id=run_id,
         )
-        if self.include_causal_links:
-            prior_spans = {key: self.node_span_cache[run_id].get((task_id, key)) for key in kwargs}
-            for input_node, span in prior_spans.items():
-                if span is not None:
-                    new_span.link_span(
-                        context=span.context,
-                        attributes={
-                            "link.name": f"{input_node}_to_{node_.name}",
-                        },
-                    )
-        tags = node_.tags.copy()
-        tags["hamilton.node_name"] = node_.name
-        new_span.set_tags(AsyncDDOGTracer._sanitize_tags(tags=tags))  # type: ignore[arg-type]
-        self.node_span_cache[run_id][(task_id, node_.name)] = new_span
 
     async def post_node_execute(
         self,
@@ -442,15 +460,19 @@ class AsyncDDOGTracer(
         task_id: Optional[str] = None,
         **future_kwargs: dict,
     ) -> None:
-        span = self.node_span_cache[run_id][(task_id, node_.name)]
-        exc_type = None
-        exc_value = None
-        tb = None
-        if error is not None:
-            exc_type = type(error)
-            exc_value = error
-            tb = error.__traceback__
-        span.__exit__(exc_type, exc_value, tb)
+        """Runs after a node's execution -- completes the span.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param node_: Node that is being executed
+        :param kwargs: Keyword arguments that are being passed into the node
+        :param success: Whether or not the node executed successfully
+        :param error: The error that was raised, if any
+        :param result: The result of the node execution, if no error was raised
+        :param task_id: ID of the task, defaults to None if not in a task-based execution
+        """
+        self._impl.run_after_node_execution(
+            node_name=node_.name, error=error, task_id=task_id, run_id=run_id
+        )
 
     async def post_graph_execute(
         self,
@@ -460,15 +482,12 @@ class AsyncDDOGTracer(
         error: Optional[Exception],
         results: Optional[Dict[str, Any]],
     ) -> None:
-        span = self.run_span_cache[run_id]
-        exc_type = None
-        exc_value = None
-        tb = None
-        if error is not None:
-            exc_type = type(error)
-            exc_value = error
-            tb = error.__traceback__
-        span.__exit__(exc_type, exc_value, tb)
-        del self.run_span_cache[run_id]
-        del self.node_span_cache[run_id]
-        del self.task_span_cache[run_id]
+        """Runs after graph execution. Garbage collects + finishes the root span.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param graph: Graph that was executed
+        :param success: Whether or not the graph executed successfully
+        :param error: Error that was raised, if any
+        :param results: Results of the graph execution
+        """
+        self._impl.run_after_graph_execution(error=error, run_id=run_id)


### PR DESCRIPTION
Adds `AsyncDDOGTracer`, which has all the same functionality of `DDOGTracer` but inherits from the base async lifecycle classes to make it work with the AsyncDriver. Fixes #1236. 

## Changes
* Add `AsyncDDOGTracer`
* Refactor `DDOGTracer` functionality into private `_DDOGTracerImpl`, which allows sharing logic between the sync & async versions
* Added check for current trace context so Hamilton DAG run gets properly nested under any open parent spans. This fixed the issue I had where my FastAPI route and Hamilton run were 2 independent traces in DDOG. It will be a no-op if there is no current trace. 
* Update docs to add `AsyncDDOGTracer` reference

## How I tested this
- Tested 1.83.3 to verify behavior of all nodes showing executed quickly at the beginning:
![hamilton_ddog_sync_prev](https://github.com/user-attachments/assets/fcca85ed-0878-4f34-86a4-83d9b11bab9b)
 
- Tested new implementation of standard DDOGTracer to ensure it works as expected (notice Hamilton is now nested under the FastAPI parent span):
![hamilton_ddog_sync_new](https://github.com/user-attachments/assets/ec2be816-8dd9-41bc-afbb-cefbecf3be76)

- Tested new async implementation: 
![hamilton_ddog_async_new](https://github.com/user-attachments/assets/ac632fba-0dac-4400-85e0-03431128292c)


## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
