### PR TITLE
Fixes input dict display in UI

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -44,6 +44,10 @@ def test_node_copy_with_retains_originating_functions():
     assert node_copy_copy.name == "rename_fn_again"
 
 
+np_version = np.__version__
+major, minor, _ = map(int, np_version.split("."))
+
+
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python 3.9 or higher")
 def test_node_handles_annotated():
     from typing import Annotated
@@ -56,15 +60,24 @@ def test_node_handles_annotated():
 
     node = Node.from_fn(annotated_func)
     assert node.name == "annotated_func"
-    expected = {
-        "first": (
-            Annotated[np.ndarray[Any, np.dtype[np.float64]], Literal["N"]],
-            DependencyType.REQUIRED,
-        ),
-        "other": (float, DependencyType.OPTIONAL),
-    }
+    if major == 2 and minor > 1:  # greater that 2.1
+        expected = {
+            "first": (
+                Annotated[np.ndarray[tuple[int, ...], np.dtype[np.float64]], Literal["N"]],
+                DependencyType.REQUIRED,
+            ),
+            "other": (float, DependencyType.OPTIONAL),
+        }
+    else:
+        expected = {
+            "first": (
+                Annotated[np.ndarray[Any, np.dtype[np.float64]], Literal["N"]],
+                DependencyType.REQUIRED,
+            ),
+            "other": (float, DependencyType.OPTIONAL),
+        }
     assert node.input_types == expected
-    assert node.type == Annotated[np.ndarray[Any, np.dtype[np.float64]], Literal["N"]]
+    assert node.type == Annotated[np.ndarray[tuple[int, ...], np.dtype[np.float64]], Literal["N"]]
 
 
 @pytest.mark.parametrize(

--- a/ui/frontend/src/components/dashboard/Runs/Run/Run.tsx
+++ b/ui/frontend/src/components/dashboard/Runs/Run/Run.tsx
@@ -147,6 +147,13 @@ const VariableTable = (props: {
                         <code>{variableKey}</code>
                       </td>
                       {values.map((value, i) => {
+                        let json_string = "";
+                        if (value) {
+                          json_string = JSON.stringify(value, null, 2);
+                          if (json_string.length > 10000) {
+                            json_string = json_string.substring(0, 10000) + " (truncated)";
+                          }
+                        }
                         return (
                           <td
                             onMouseEnter={() => {
@@ -175,7 +182,7 @@ const VariableTable = (props: {
                           >
                             <div className="max-w-64 max-h-48 overflow-scroll scrollbar-hide">
                               <code className="whitespace-pre-wrap truncate">
-                                {value?.toString()}
+                                {json_string}
                               </code>
                             </div>
                           </td>


### PR DESCRIPTION
The UI would display [Object object]. This fixes that and makes any object print nicely. It includes a 10000 char limit just in case someone puts something massive in there.

## Changes
 - UI

## How I tested this
 - locally
 
![Screen Shot 2024-12-10 at 11 45 37 PM](https://github.com/user-attachments/assets/c29bffd0-3cab-4130-9cd7-8a6be8482861)


## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
