### PR TITLE
Marks xfail xgboost test due to scikit lib issue

### DIFF
--- a/tests/plugins/test_xgboost_extensions.py
+++ b/tests/plugins/test_xgboost_extensions.py
@@ -34,6 +34,7 @@ def test_xgboost_model_json_writer(
     assert metadata[FILE_METADATA]["path"] == str(model_path)
 
 
+@pytest.mark.xfail(condition=True, reason="scikitlearn library incompatibility issue", strict=False)
 def test_xgboost_model_json_reader(
     fitted_xgboost_model: xgboost.XGBModel, tmp_path: pathlib.Path
 ) -> None:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -60,7 +60,7 @@ def test_node_handles_annotated():
 
     node = Node.from_fn(annotated_func)
     assert node.name == "annotated_func"
-    if major == 2 and minor > 1:  # greater that 2.1
+    if major == 2 and minor > 1 and sys.version_info > (3, 9):  # greater that 2.1
         expected = {
             "first": (
                 Annotated[np.ndarray[tuple[int, ...], np.dtype[np.float64]], Literal["N"]],
@@ -68,6 +68,7 @@ def test_node_handles_annotated():
             ),
             "other": (float, DependencyType.OPTIONAL),
         }
+        expected_type = Annotated[np.ndarray[tuple[int, ...], np.dtype[np.float64]], Literal["N"]]
     else:
         expected = {
             "first": (
@@ -76,8 +77,9 @@ def test_node_handles_annotated():
             ),
             "other": (float, DependencyType.OPTIONAL),
         }
+        expected_type = Annotated[np.ndarray[Any, np.dtype[np.float64]], Literal["N"]]
     assert node.input_types == expected
-    assert node.type == Annotated[np.ndarray[tuple[int, ...], np.dtype[np.float64]], Literal["N"]]
+    assert node.type == expected_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Skips because we're seeing:
 > AttributeError: 'super' object has no attribute '__sklearn_tags__'
due to new library version rolling out and xgboost not being updated yet.

## Changes
 - mark xfail for flaky test

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
