### PR TITLE
Fixes `resolve` decorator docs

### DIFF
--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -87,13 +87,16 @@ class resolve(DynamicResolver):
             return s1 + s2
 
     Note how this works:
+    
     1. The `decorate_with` argument is a function that gives you the decorator you want to apply.
     Currently its "hamilton-esque" -- while we do not require it to be typed, you can use a separate
     configuration-reoslver function (and include type information). This lambda function must return
     a decorator.
+    
     2. The `when` argument is the point at which you want to resolve the decorator. Currently, we
     only support `ResolveAt.CONFIG_AVAILABLE`, which means that the decorator will be resolved at compile
     time, E.G. when the driver is instantiated.
+    
     3. This is then run and dynamically resolved.
 
     This is powerful, but the code is uglier. It's meant to be used in some very specific cases,
@@ -112,7 +115,7 @@ class resolve(DynamicResolver):
         """Initializes a delayed decorator that gets called at some specific resolution time.
 
         :param decorate_with: Function that takes required and optional parameters/returns a decorator.
-        :param until: When to resolve the decorator. Currently only supports `ResolveAt.CONFIG_AVAILABLE`.
+        :param when: When to resolve the decorator. Currently only supports `ResolveAt.CONFIG_AVAILABLE`.
         """
         if when != ResolveAt.CONFIG_AVAILABLE:
             raise ValueError("Dynamic functions must be configured at config time!")

--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -87,13 +87,16 @@ class resolve(DynamicResolver):
             return s1 + s2
 
     Note how this works:
+
     1. The `decorate_with` argument is a function that gives you the decorator you want to apply.
     Currently its "hamilton-esque" -- while we do not require it to be typed, you can use a separate
     configuration-reoslver function (and include type information). This lambda function must return
     a decorator.
+
     2. The `when` argument is the point at which you want to resolve the decorator. Currently, we
     only support `ResolveAt.CONFIG_AVAILABLE`, which means that the decorator will be resolved at compile
     time, E.G. when the driver is instantiated.
+
     3. This is then run and dynamically resolved.
 
     This is powerful, but the code is uglier. It's meant to be used in some very specific cases,

--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -87,16 +87,13 @@ class resolve(DynamicResolver):
             return s1 + s2
 
     Note how this works:
-    
     1. The `decorate_with` argument is a function that gives you the decorator you want to apply.
     Currently its "hamilton-esque" -- while we do not require it to be typed, you can use a separate
     configuration-reoslver function (and include type information). This lambda function must return
     a decorator.
-    
     2. The `when` argument is the point at which you want to resolve the decorator. Currently, we
     only support `ResolveAt.CONFIG_AVAILABLE`, which means that the decorator will be resolved at compile
     time, E.G. when the driver is instantiated.
-    
     3. This is then run and dynamically resolved.
 
     This is powerful, but the code is uglier. It's meant to be used in some very specific cases,


### PR DESCRIPTION
Fixed errors in docs of `resolve` decorator

## Changes

- ordered list in markdown needs double linebreak in some cases
- fixed error in `__init__` argument name

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
