### PR TITLE
Parellizable Specific Annotations

### DIFF
--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 import typing
-from typing import Any, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union, Generic
+from typing import Any, Generic, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union
 
 import typing_inspect
 
@@ -295,15 +295,33 @@ class Parallelizable(Iterable[ParallelizableElement], Protocol[ParallelizableEle
 
     pass
 
-class ParallelizableList(list[ParallelizableElement], Parallelizable, Generic[ParallelizableElement]):
+
+class ParallelizableList(
+    list[ParallelizableElement], Parallelizable, Generic[ParallelizableElement]
+):
+    """
+    Marks the output of a function node as parallelizable and also as a list.
+
+    It has the same usage as "Parallelizable", but for returns that are specifically
+    lists, for correct functioning of linters and other tools.
+    """
+
     pass
 
 
-def is_parallelizable(type:Type) -> bool:
+def is_parallelizable(type: Type) -> bool:
+    """
+    Checks if a type is parallelizable.
+
+    :param type: Type to check.
+    :return: True if the type is parallelizable, False otherwise.
+    """
     return type == Parallelizable or Parallelizable in type.__bases__
+
 
 def is_parallelizable_type(type_: Type) -> bool:
     return _get_origin(type_) == Parallelizable
+
 
 class Collect(Iterable[CollectElement], Protocol[CollectElement]):
     """Marks a function node parameter as collectable.

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -68,7 +68,7 @@ def custom_subclass_check(requested_type: Type, param_type: Type):
         has_generic = True
     # TODO -- consider moving into a graph adapter or elsewhere -- this is perhaps a little too
     #  low-level
-    if has_generic and requested_origin_type in (Parallelizable,):
+    if has_generic and is_parallelizable(requested_origin_type):
         (requested_type_arg,) = _get_args(requested_type)
         return custom_subclass_check(requested_type_arg, param_type)
     if has_generic and param_origin_type == Collect:
@@ -295,10 +295,11 @@ class Parallelizable(Iterable[ParallelizableElement], Protocol[ParallelizableEle
 
     pass
 
+def is_parallelizable(type:Type) -> bool:
+    return type == Parallelizable or Parallelizable in type.__bases__
 
 def is_parallelizable_type(type_: Type) -> bool:
     return _get_origin(type_) == Parallelizable
-
 
 class Collect(Iterable[CollectElement], Protocol[CollectElement]):
     """Marks a function node parameter as collectable.

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 import typing
-from typing import Any, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import Any, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union, Generic
 
 import typing_inspect
 
@@ -294,6 +294,10 @@ class Parallelizable(Iterable[ParallelizableElement], Protocol[ParallelizableEle
     """
 
     pass
+
+class ParallelizableList(list[ParallelizableElement], Parallelizable, Generic[ParallelizableElement]):
+    pass
+
 
 def is_parallelizable(type:Type) -> bool:
     return type == Parallelizable or Parallelizable in type.__bases__

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import typing_inspect
 
-from hamilton.htypes import Collect, Parallelizable
+from hamilton.htypes import Collect, Parallelizable, is_parallelizable
 
 """
 Module that contains the primitive components of the graph.
@@ -285,7 +285,7 @@ class Node(object):
         node_source = NodeType.STANDARD
         # TODO - extract this into a function + clean up!
         if typing_inspect.is_generic_type(return_type):
-            if typing_inspect.get_origin(return_type) == Parallelizable:
+            if is_parallelizable(typing_inspect.get_origin(return_type)):
                 node_source = NodeType.EXPAND
         for hint in typing.get_type_hints(fn, **type_hint_kwargs).values():
             if typing_inspect.is_generic_type(hint):

--- a/tests/execution/test_executors.py
+++ b/tests/execution/test_executors.py
@@ -30,6 +30,7 @@ from tests.resources.dynamic_parallelism import (
     parallel_complex,
     parallel_delayed,
     parallel_linear_basic,
+    parallel_list,
 )
 
 ADAPTER = base.DefaultAdapter()
@@ -347,3 +348,14 @@ def test_parallel_end_to_end_with_empty_list():
     parallel_collect_multiple_arguments._reset_counter()
     res = dr.execute(["final"], overrides={"number_of_steps": 0})
     assert res["final"] == parallel_linear_basic._calc(0)
+
+
+def test_parallel_list():
+    dr = (
+        driver.Builder()
+        .with_modules(parallel_list)
+        .enable_dynamic_execution(allow_experimental_mode=True)
+        .build()
+    )
+    result = dr.execute(["final"])
+    assert result["final"] == parallel_linear_basic._calc()

--- a/tests/resources/dynamic_parallelism/parallel_list.py
+++ b/tests/resources/dynamic_parallelism/parallel_list.py
@@ -1,0 +1,51 @@
+from hamilton.htypes import Collect, ParallelizableList
+
+
+# input
+def number_of_steps() -> int:
+    return 6
+
+
+# expand
+def steps(number_of_steps: int) -> ParallelizableList[int]:
+    return list(range(number_of_steps))
+
+
+# process
+def step_squared(steps: int) -> int:
+    return steps**2
+
+
+# process
+def step_cubed(steps: int) -> int:
+    return steps**3
+
+
+def step_squared_plus_step_cubed(step_squared: int, step_cubed: int) -> int:
+    return step_squared + step_cubed
+
+
+# join
+def sum_step_squared_plus_step_cubed(step_squared_plus_step_cubed: Collect[int]) -> int:
+    out = 0
+    for step in step_squared_plus_step_cubed:
+        out += step
+    return out
+
+
+# final
+def final(sum_step_squared_plus_step_cubed: int) -> int:
+    return sum_step_squared_plus_step_cubed
+
+
+def _calc(number_of_steps: int = number_of_steps()) -> int:
+    steps_ = steps(number_of_steps)
+    to_sum = []
+    for step_ in steps_:
+        step_squared_ = step_squared(step_)
+        step_cubed_ = step_cubed(step_)
+        step_squared_plus_step_cubed_ = step_squared_plus_step_cubed(step_squared_, step_cubed_)
+        to_sum.append(step_squared_plus_step_cubed_)
+    sum_step_squared_plus_step_cubed_ = sum_step_squared_plus_step_cubed(to_sum)
+    final_ = final(sum_step_squared_plus_step_cubed_)
+    return final_


### PR DESCRIPTION
When annotating a function with Parallelizable, it is not possible to specify in the annotation what the type returned by the function will actually be, as these are not identified by a linter.

So, in the example:

```python
def hello() -> Parallizable[str]:
  return ["h", "a", "b"]

a = hello()
b = a[0]
```

The type of b is not identified correctly, and no hints occur when writing the call to some method of a.

This issue is especially important for writing functions that can work with or without Hamilton with greater usability.

## Changes

- Changed the verification if a type is Parallelizable to also check for subclasses.
- Added "ParallelizableList", exemplifying the use of the change and allowing the annotation of functions returning lists and must have parallelizable return.

## How I tested this

New "test_parallel_list" in "tests/execution/test_executors.py".

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
