### PR TITLE
Resolve `Annotated` types (PEP 593) on dataflow visualizations

### DIFF
--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -99,7 +99,7 @@ def get_type_as_string(type_: Type) -> Optional[str]:
     :return: string representation of the type. An empty string if everything fails.
     """
 
-    if typing.get_origin(type_) is Annotated:  # differs from typing_inspect.get_origin
+    if _is_annotated_type(type_):
         type_string = get_type_as_string(typing.get_args(type_)[0])
     elif getattr(type_, "__name__", None):
         type_string = type_.__name__

--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -99,7 +99,9 @@ def get_type_as_string(type_: Type) -> Optional[str]:
     :return: string representation of the type. An empty string if everything fails.
     """
 
-    if getattr(type_, "__name__", None):
+    if typing.get_origin(type_) is Annotated:  # differs from typing_inspect.get_origin
+        type_string = get_type_as_string(typing.get_args(type_)[0])
+    elif getattr(type_, "__name__", None):
         type_string = type_.__name__
     elif typing_inspect.get_origin(type_):
         base_type = typing_inspect.get_origin(type_)

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -178,6 +178,7 @@ def test__safe_subclass(candidate, type_, expected):
         (pd.Series),
         (htypes.column[pd.Series, int]),
         (pd.DataFrame),
+        (typing.Annotated[int, "metadata"]),
     ],
 )
 def test_get_type_as_string(type_):
@@ -186,6 +187,12 @@ def test_get_type_as_string(type_):
         type_string = htypes.get_type_as_string(type_)  # noqa: F841
     except Exception as e:
         pytest.fail(f"test get_type_as_string raised: {e}")
+
+
+def test_type_as_string_with_annotated_type():
+    """Tests the custom_subclass_check"""
+    type_string = htypes.get_type_as_string(typing.Annotated[int, "metadata"])  # type: ignore
+    assert type_string == "int"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -9,6 +9,11 @@ import pytest
 from hamilton import htypes
 from hamilton.htypes import check_instance
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 
 class X:
     pass
@@ -178,7 +183,7 @@ def test__safe_subclass(candidate, type_, expected):
         (pd.Series),
         (htypes.column[pd.Series, int]),
         (pd.DataFrame),
-        (typing.Annotated[int, "metadata"]),
+        (Annotated[int, "metadata"]),
     ],
 )
 def test_get_type_as_string(type_):
@@ -191,7 +196,7 @@ def test_get_type_as_string(type_):
 
 def test_type_as_string_with_annotated_type():
     """Tests the custom_subclass_check"""
-    type_string = htypes.get_type_as_string(typing.Annotated[int, "metadata"])  # type: ignore
+    type_string = htypes.get_type_as_string(Annotated[int, "metadata"])  # type: ignore
     assert type_string == "int"
 
 


### PR DESCRIPTION
Recently, I was attempting to use `Annotated` types (PEP 593) for the output of some nodes (see `A`):

```python
from typing import Annotated

def A() -> Annotated[int, "metadata"]:
    return 42

def B(A: int) -> float:
    """Divide A by 3"""
    return A / 3

def C(A: int, B: float) -> float:
    """Square A and multiply by B"""
    return A**2 * B

if __name__ == "__main__":
    import __main__
    from hamilton import driver

    dr = driver.Builder().with_modules(__main__).build()
    result = dr.execute(["C"])
    print(result)
```

The execution works as excepted, but when I run `dr.display_all_functions("dag.png")` the type of `A` is masked as `Annotated` on the resulting graphic:

![dag1](https://github.com/user-attachments/assets/1d190e99-b93f-49bc-ba6f-eb08b2aa41fe)

Ideally, IMHO, we would want to see the underlying type such as:

![dag2](https://github.com/user-attachments/assets/6a06d37b-be53-465b-8042-3f13aee58424)

## Changes

I updated `hamilton.htypes.get_type_as_string` so that it will consider `Annotated` types. Note that it appears that `typing.get_origin` and `typing_inspect.get_origin` do *not* produce the same result for `Annotated` types (see https://github.com/ilevkivskyi/typing_inspect/issues/109).

## How I tested this

I updated the current test for `get_type_as_string` in `test_type_utils.py` and added an additional check focusing on `Annotated` types.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
