### PR TITLE
Add Task Submission / Return Hooks

### DIFF
--- a/docs/reference/lifecycle-hooks/TaskResolutionHook.rst
+++ b/docs/reference/lifecycle-hooks/TaskResolutionHook.rst
@@ -1,0 +1,9 @@
+================================
+lifecycle.api.TaskResolutionHook
+================================
+
+
+.. autoclass:: hamilton.lifecycle.api.TaskResolutionHook
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/TaskReturnHook.rst
+++ b/docs/reference/lifecycle-hooks/TaskReturnHook.rst
@@ -1,9 +1,9 @@
 ================================
-lifecycle.api.TaskResolutionHook
+lifecycle.api.TaskReturnHook
 ================================
 
 
-.. autoclass:: hamilton.lifecycle.api.TaskResolutionHook
+.. autoclass:: hamilton.lifecycle.api.TaskReturnHook
    :special-members: __init__
    :members:
    :inherited-members:

--- a/docs/reference/lifecycle-hooks/TaskSubmissionHook.rst
+++ b/docs/reference/lifecycle-hooks/TaskSubmissionHook.rst
@@ -1,0 +1,9 @@
+================================
+lifecycle.api.TaskSubmissionHook
+================================
+
+
+.. autoclass:: hamilton.lifecycle.api.TaskSubmissionHook
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/docs/reference/lifecycle-hooks/index.rst
+++ b/docs/reference/lifecycle-hooks/index.rst
@@ -24,6 +24,8 @@ looking forward.
    NodeExecutionMethod
    StaticValidator
    GraphConstructionHook
+   TaskSubmissionHook
+   TaskResolutionHook
    TaskExecutionHook
    TaskGroupingHook
 

--- a/docs/reference/lifecycle-hooks/index.rst
+++ b/docs/reference/lifecycle-hooks/index.rst
@@ -25,7 +25,7 @@ looking forward.
    StaticValidator
    GraphConstructionHook
    TaskSubmissionHook
-   TaskResolutionHook
+   TaskReturnHook
    TaskExecutionHook
    TaskGroupingHook
 

--- a/hamilton/execution/executors.py
+++ b/hamilton/execution/executors.py
@@ -464,9 +464,9 @@ def run_graph_to_completion(
                 finally:
                     execution_state.update_task_state(task.task_id, state, result)
                     if TaskState.is_terminal(state):
-                        if task.adapter.does_hook("post_task_resolution", is_async=False):
+                        if task.adapter.does_hook("post_task_return", is_async=False):
                             task.adapter.call_all_lifecycle_hooks_sync(
-                                "post_task_resolution",
+                                "post_task_return",
                                 run_id=task.run_id,
                                 task_id=task.task_id,
                                 nodes=task.nodes,

--- a/hamilton/execution/executors.py
+++ b/hamilton/execution/executors.py
@@ -177,14 +177,17 @@ class TaskFutureWrappingFunction(TaskFuture):
         self._exception = None
 
     def get_state(self):
-        try:
-            self._results = self.function()
-        except Exception as e:
-            logger.exception("Task failed")
-            self._exception = e
+        if self._exception is not None:
             return TaskState.FAILED
-        finally:
-            self._done = True
+        if not self._done:
+            try:
+                self._results = self.function()
+            except Exception as e:
+                logger.exception("Task failed")
+                self._exception = e
+                return TaskState.FAILED
+            finally:
+                self._done = True
         return TaskState.SUCCESSFUL
 
     def get_result(self):

--- a/hamilton/execution/executors.py
+++ b/hamilton/execution/executors.py
@@ -427,7 +427,7 @@ def run_graph_to_completion(
                             task_id=task.task_id,
                             nodes=task.nodes,
                             success=state == TaskState.SUCCESSFUL,
-                            error=None,  # FIXME -- we should get the error here
+                            error=None,  # TODO -- we could get the error from the task future
                             result=result,
                             spawning_task_id=task.spawning_task_id,
                             purpose=task.purpose,

--- a/hamilton/execution/grouping.py
+++ b/hamilton/execution/grouping.py
@@ -154,6 +154,14 @@ class TaskImplementation(TaskSpec):
         super(TaskImplementation, self).__post_init__()
         self.task_id = self.determine_task_id(self.base_id, self.spawning_task_id, self.group_id)
 
+    def __hash__(self) -> int:
+        return hash(self.task_id)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TaskImplementation):
+            return False
+        return self.task_id == other.task_id
+
 
 class GroupingStrategy(abc.ABC):
     """Base class for grouping nodes"""

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -10,6 +10,8 @@ from .api import (  # noqa: F401
     StaticValidator,
     TaskExecutionHook,
     TaskGroupingHook,
+    TaskResolutionHook,
+    TaskSubmissionHook,
 )
 from .base import LifecycleAdapter  # noqa: F401
 from .default import (  # noqa: F401
@@ -43,4 +45,6 @@ __all__ = [
     "TaskGroupingHook",
     "FunctionInputOutputTypeChecker",
     "NoEdgeAndInputTypeChecking",
+    "TaskResolutionHook",
+    "TaskSubmissionHook",
 ]

--- a/hamilton/lifecycle/__init__.py
+++ b/hamilton/lifecycle/__init__.py
@@ -10,7 +10,7 @@ from .api import (  # noqa: F401
     StaticValidator,
     TaskExecutionHook,
     TaskGroupingHook,
-    TaskResolutionHook,
+    TaskReturnHook,
     TaskSubmissionHook,
 )
 from .base import LifecycleAdapter  # noqa: F401
@@ -45,6 +45,6 @@ __all__ = [
     "TaskGroupingHook",
     "FunctionInputOutputTypeChecker",
     "NoEdgeAndInputTypeChecking",
-    "TaskResolutionHook",
+    "TaskReturnHook",
     "TaskSubmissionHook",
 ]

--- a/hamilton/lifecycle/api.py
+++ b/hamilton/lifecycle/api.py
@@ -469,7 +469,7 @@ class TaskResolutionHook(BasePostTaskResolution, abc.ABC):
         purpose: NodeGroupPurpose,
         **future_kwargs,
     ):
-        """Runs after a task (future) has been resolved into a returns value. By definition this is
+        """Runs after a task (future) has been resolved into a return value. By definition this is
         run *outside* of the task executor,on the process that executed the driver.
 
         :param run_id: ID of the run this is under.

--- a/hamilton/lifecycle/api.py
+++ b/hamilton/lifecycle/api.py
@@ -32,7 +32,7 @@ from hamilton.lifecycle.base import (
     BasePostTaskExecute,
     BasePostTaskExpand,
     BasePostTaskGroup,
-    BasePostTaskResolution,
+    BasePostTaskReturn,
     BasePreGraphExecute,
     BasePreNodeExecute,
     BasePreTaskExecute,
@@ -427,12 +427,12 @@ class TaskSubmissionHook(BasePreTaskSubmission, abc.ABC):
         pass
 
 
-class TaskResolutionHook(BasePostTaskResolution, abc.ABC):
-    """Implement this to hook into the task resolution process. Tasks are submitted to an executor,
-    which then returns a task future to be resolved at a later time when the task is complete."""
+class TaskReturnHook(BasePostTaskReturn, abc.ABC):
+    """Implement this to hook into the task return process. Tasks are submitted to an executor,
+    which executes the task and returns the results (or raises an error)."""
 
     @override
-    def post_task_resolution(
+    def post_task_return(
         self,
         *,
         run_id: str,
@@ -444,7 +444,7 @@ class TaskResolutionHook(BasePostTaskResolution, abc.ABC):
         spawning_task_id: Optional[str],
         purpose: NodeGroupPurpose,
     ):
-        self.run_after_task_resolution(
+        self.run_after_task_return(
             run_id=run_id,
             task_id=task_id,
             nodes=nodes,
@@ -456,7 +456,7 @@ class TaskResolutionHook(BasePostTaskResolution, abc.ABC):
         )
 
     @abc.abstractmethod
-    def run_after_task_resolution(
+    def run_after_task_return(
         self,
         *,
         run_id: str,
@@ -469,8 +469,8 @@ class TaskResolutionHook(BasePostTaskResolution, abc.ABC):
         purpose: NodeGroupPurpose,
         **future_kwargs,
     ):
-        """Runs after a task (future) has been resolved into a return value. By definition this is
-        run *outside* of the task executor,on the process that executed the driver.
+        """Runs after a task has been returned from a executor. By definition this is run *outside*
+        of the task executor, on the process that executed the driver.
 
         :param run_id: ID of the run this is under.
         :param task_id: ID of the task that was just executed.

--- a/hamilton/lifecycle/base.py
+++ b/hamilton/lifecycle/base.py
@@ -410,6 +410,60 @@ class BasePreGraphExecuteAsync(abc.ABC):
         pass
 
 
+@lifecycle.base_hook("post_task_group")
+class BasePostTaskGroup(abc.ABC):
+    @abc.abstractmethod
+    def post_task_group(self, *, run_id: str, task_ids: List[str]):
+        """Hook that is called immediately after a task group is created. Note that this is only useful in dynamic
+        execution, although we reserve the right to add this back into the standard hamilton execution pattern.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param task_ids: IDs of tasks that are in the group."""
+        pass
+
+
+@lifecycle.base_hook("post_task_expand")
+class BasePostTaskExpand(abc.ABC):
+    @abc.abstractmethod
+    def post_task_expand(self, *, run_id: str, task_id: str, parameters: Dict[str, Any]):
+        """Hook that is called immediately after a task is expanded into separate task. Note that this is only useful
+        in dynamic execution.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param task_id: ID of the task.
+        :param parameters: Parameters that are being passed to each of the expanded tasks."""
+        pass
+
+
+@lifecycle.base_hook("pre_task_submission")
+class BasePreTaskSubmission(abc.ABC):
+    @abc.abstractmethod
+    def pre_task_submission(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        nodes: List["node.Node"],
+        inputs: Dict[str, Any],
+        overrides: Dict[str, Any],
+        spawning_task_id: Optional[str],
+        purpose: NodeGroupPurpose,
+    ):
+        """Hook that is called immediately prior to task submission to an executor as a task future.
+        Note that this is only useful in dynamic execution, although we reserve the right to add this back
+        into the standard hamilton execution pattern.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param task_id: ID of the task.
+        :param nodes: Nodes that are being executed.
+        :param inputs: Inputs to the task.
+        :param overrides: Overrides to task execution.
+        :param spawning_task_id: ID of the task that spawned this task.
+        :param purpose: Purpose of the current task group.
+        """
+        pass
+
+
 @lifecycle.base_hook("pre_task_execute")
 class BasePreTaskExecute(abc.ABC):
     @abc.abstractmethod
@@ -626,31 +680,6 @@ class BasePostNodeExecuteAsync(abc.ABC):
         pass
 
 
-@lifecycle.base_hook("post_task_group")
-class BasePostTaskGroup(abc.ABC):
-    @abc.abstractmethod
-    def post_task_group(self, *, run_id: str, task_ids: List[str]):
-        """Hook that is called immediately after a task group is created. Note that this is only useful in dynamic
-        execution, although we reserve the right to add this back into the standard hamilton execution pattern.
-
-        :param run_id: ID of the run, unique in scope of the driver.
-        :param task_ids: IDs of tasks that are in the group."""
-        pass
-
-
-@lifecycle.base_hook("post_task_expand")
-class BasePostTaskExpand(abc.ABC):
-    @abc.abstractmethod
-    def post_task_expand(self, *, run_id: str, task_id: str, parameters: Dict[str, Any]):
-        """Hook that is called immediately after a task is expanded into separate task. Note that this is only useful
-        in dynamic execution.
-
-        :param run_id: ID of the run, unique in scope of the driver.
-        :param task_id: ID of the task.
-        :param parameters: Parameters that are being passed to each of the expanded tasks."""
-        pass
-
-
 @lifecycle.base_hook("post_task_execute")
 class BasePostTaskExecute(abc.ABC):
     @abc.abstractmethod
@@ -703,6 +732,36 @@ class BasePostTaskExecuteAsync(abc.ABC):
         :param task_id: ID of the task
         :param nodes: Nodes that were executed
         :param results: Results of the task
+        :param success: Whether or not the task executed successfully
+        :param error: The error that was raised, if any
+        :param spawning_task_id: ID of the task that spawned this task
+        :param purpose: Purpose of the current task group
+        """
+        pass
+
+
+@lifecycle.base_hook("post_task_resolution")
+class BasePostTaskResolution(abc.ABC):
+    @abc.abstractmethod
+    def post_task_resolution(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        nodes: List["node.Node"],
+        result: Any,
+        success: bool,
+        error: Exception,
+        spawning_task_id: Optional[str],
+        purpose: NodeGroupPurpose,
+    ):
+        """Hook called immediately after a task future (as submitted to a task executor) is resolved.
+        Note that this is only useful in dynamic execution, although we reserve the right to add this
+        back into the standard hamilton execution pattern.
+
+        :param run_id: ID of the run, unique in scope of the driver.
+        :param task_id: ID of the task
+        :param result: Return value of the task (from task future resolution).
         :param success: Whether or not the task executed successfully
         :param error: The error that was raised, if any
         :param spawning_task_id: ID of the task that spawned this task

--- a/hamilton/lifecycle/base.py
+++ b/hamilton/lifecycle/base.py
@@ -426,7 +426,7 @@ class BasePostTaskGroup(abc.ABC):
 class BasePostTaskExpand(abc.ABC):
     @abc.abstractmethod
     def post_task_expand(self, *, run_id: str, task_id: str, parameters: Dict[str, Any]):
-        """Hook that is called immediately after a task is expanded into separate task. Note that this is only useful
+        """Hook that is called immediately after a task is expanded into parallelizable tasks. Note that this is only useful
         in dynamic execution.
 
         :param run_id: ID of the run, unique in scope of the driver.

--- a/hamilton/lifecycle/base.py
+++ b/hamilton/lifecycle/base.py
@@ -740,10 +740,10 @@ class BasePostTaskExecuteAsync(abc.ABC):
         pass
 
 
-@lifecycle.base_hook("post_task_resolution")
-class BasePostTaskResolution(abc.ABC):
+@lifecycle.base_hook("post_task_return")
+class BasePostTaskReturn(abc.ABC):
     @abc.abstractmethod
-    def post_task_resolution(
+    def post_task_return(
         self,
         *,
         run_id: str,
@@ -755,13 +755,13 @@ class BasePostTaskResolution(abc.ABC):
         spawning_task_id: Optional[str],
         purpose: NodeGroupPurpose,
     ):
-        """Hook called immediately after a task future (as submitted to a task executor) is resolved.
-        Note that this is only useful in dynamic execution, although we reserve the right to add this
-        back into the standard hamilton execution pattern.
+        """Hook called immediately after a task returns from an executor. Note that this is only
+        useful in dynamic execution, although we reserve the right to add this back into the
+        standard hamilton execution pattern.
 
         :param run_id: ID of the run, unique in scope of the driver.
         :param task_id: ID of the task
-        :param result: Return value of the task (from task future resolution).
+        :param result: Return value of the task.
         :param success: Whether or not the task executed successfully
         :param error: The error that was raised, if any
         :param spawning_task_id: ID of the task that spawned this task
@@ -843,7 +843,7 @@ LifecycleAdapter = Union[
     BasePostTaskGroup,
     BasePostTaskExpand,
     BasePreTaskSubmission,
-    BasePostTaskResolution,
+    BasePostTaskReturn,
     BasePreTaskExecute,
     BasePreTaskExecuteAsync,
     BasePreNodeExecute,

--- a/hamilton/lifecycle/base.py
+++ b/hamilton/lifecycle/base.py
@@ -842,6 +842,8 @@ LifecycleAdapter = Union[
     BasePreGraphExecuteAsync,
     BasePostTaskGroup,
     BasePostTaskExpand,
+    BasePreTaskSubmission,
+    BasePostTaskResolution,
     BasePreTaskExecute,
     BasePreTaskExecuteAsync,
     BasePreNodeExecute,

--- a/tests/lifecycle/lifecycle_adapters_for_testing.py
+++ b/tests/lifecycle/lifecycle_adapters_for_testing.py
@@ -18,10 +18,12 @@ from hamilton.lifecycle.base import (
     BasePostTaskExecute,
     BasePostTaskExpand,
     BasePostTaskGroup,
+    BasePostTaskResolution,
     BasePreDoAnythingHook,
     BasePreGraphExecute,
     BasePreNodeExecute,
     BasePreTaskExecute,
+    BasePreTaskSubmission,
     BaseValidateGraph,
     BaseValidateNode,
     LifecycleAdapterSet,
@@ -147,6 +149,37 @@ class TrackingPostNodeExecuteHook(ExtendToTrackCalls, BasePostNodeExecute):
         error: Optional[Exception],
         result: Any,
         task_id: Optional[str] = None,
+    ):
+        pass
+
+
+class TrackingPreTaskSubmissionHook(ExtendToTrackCalls, BasePreTaskSubmission):
+    def pre_task_submission(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        nodes: List[Node],
+        inputs: Dict[str, Any],
+        overrides: Dict[str, Any],
+        spawning_task_id: str | None,
+        purpose: NodeGroupPurpose,
+    ):
+        pass
+
+
+class TrackingPostTaskResolutionHook(ExtendToTrackCalls, BasePostTaskResolution):
+    def post_task_resolution(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        nodes: List[Node],
+        result: Any,
+        success: bool,
+        error: Exception,
+        spawning_task_id: str | None,
+        purpose: NodeGroupPurpose,
     ):
         pass
 

--- a/tests/lifecycle/lifecycle_adapters_for_testing.py
+++ b/tests/lifecycle/lifecycle_adapters_for_testing.py
@@ -18,7 +18,7 @@ from hamilton.lifecycle.base import (
     BasePostTaskExecute,
     BasePostTaskExpand,
     BasePostTaskGroup,
-    BasePostTaskResolution,
+    BasePostTaskReturn,
     BasePreDoAnythingHook,
     BasePreGraphExecute,
     BasePreNodeExecute,
@@ -168,8 +168,8 @@ class TrackingPreTaskSubmissionHook(ExtendToTrackCalls, BasePreTaskSubmission):
         pass
 
 
-class TrackingPostTaskResolutionHook(ExtendToTrackCalls, BasePostTaskResolution):
-    def post_task_resolution(
+class TrackingPostTaskReturnHook(ExtendToTrackCalls, BasePostTaskReturn):
+    def post_task_return(
         self,
         *,
         run_id: str,

--- a/tests/lifecycle/lifecycle_adapters_for_testing.py
+++ b/tests/lifecycle/lifecycle_adapters_for_testing.py
@@ -162,7 +162,7 @@ class TrackingPreTaskSubmissionHook(ExtendToTrackCalls, BasePreTaskSubmission):
         nodes: List[Node],
         inputs: Dict[str, Any],
         overrides: Dict[str, Any],
-        spawning_task_id: str | None,
+        spawning_task_id: Optional[str],
         purpose: NodeGroupPurpose,
     ):
         pass
@@ -178,7 +178,7 @@ class TrackingPostTaskResolutionHook(ExtendToTrackCalls, BasePostTaskResolution)
         result: Any,
         success: bool,
         error: Exception,
-        spawning_task_id: str | None,
+        spawning_task_id: Optional[str],
         purpose: NodeGroupPurpose,
     ):
         pass

--- a/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
+++ b/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
@@ -422,7 +422,7 @@ def test_multi_hook():
             nodes: List[Node],
             inputs: Dict[str, Any],
             overrides: Dict[str, Any],
-            spawning_task_id: str | None,
+            spawning_task_id: Optional[str],
             purpose: NodeGroupPurpose,
         ):
             pass
@@ -436,7 +436,7 @@ def test_multi_hook():
             result: Any,
             success: bool,
             error: Exception,
-            spawning_task_id: str | None,
+            spawning_task_id: Optional[str],
             purpose: NodeGroupPurpose,
         ):
             pass

--- a/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
+++ b/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
@@ -16,7 +16,7 @@ from hamilton.lifecycle.base import (
     BasePostTaskExecute,
     BasePostTaskExpand,
     BasePostTaskGroup,
-    BasePostTaskResolution,
+    BasePostTaskReturn,
     BasePreDoAnythingHook,
     BasePreGraphExecute,
     BasePreNodeExecute,
@@ -33,7 +33,7 @@ from .lifecycle_adapters_for_testing import (
     TrackingPostTaskExecuteHook,
     TrackingPostTaskExpandHook,
     TrackingPostTaskGroupHook,
-    TrackingPostTaskResolutionHook,
+    TrackingPostTaskReturnHook,
     TrackingPreNodeExecuteHook,
     TrackingPreTaskSubmissionHook,
 )
@@ -274,9 +274,9 @@ def test_individual_pre_task_submission_hook():
     }
 
 
-def test_individual_post_task_resolution_hook():
-    hook_name = "post_task_resolution"
-    hook = TrackingPostTaskResolutionHook(name=hook_name)
+def test_individual_post_task_return_hook():
+    hook_name = "post_task_return"
+    hook = TrackingPostTaskReturnHook(name=hook_name)
     dr = _sample_driver(hook)
     dr.execute(["output"], inputs={"n_iters_input": 5})
     relevant_calls = [item for item in hook.calls if item.name == hook_name]
@@ -326,7 +326,7 @@ def test_multi_hook():
         BasePostTaskGroup,
         BasePostTaskExpand,
         BasePreTaskSubmission,
-        BasePostTaskResolution,
+        BasePostTaskReturn,
         ExtendToTrackCalls,
     ):
         def pre_task_execute(
@@ -427,7 +427,7 @@ def test_multi_hook():
         ):
             pass
 
-        def post_task_resolution(
+        def post_task_return(
             self,
             *,
             run_id: str,
@@ -458,7 +458,7 @@ def test_multi_hook():
         "post_task_execute": 10,
         "post_graph_execute": 1,
         "pre_task_submission": 10,
-        "post_task_resolution": 10,
+        "post_task_return": 10,
         "post_task_group": 1,
         "post_task_expand": 1,
     }

--- a/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
+++ b/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
@@ -252,15 +252,15 @@ def test_individual_pre_task_submission_hook():
     dr = _sample_driver(hook)
     dr.execute(["output"], inputs={"n_iters_input": 5})
     relevant_calls = [item for item in hook.calls if item.name == hook_name]
-    assert len(relevant_calls) == 10
+    assert len(relevant_calls) == 10  # Total number of tasks
     spawning_task_ids = Counter([item.bound_kwargs["spawning_task_id"] for item in relevant_calls])
-    assert spawning_task_ids == {"expand-parallel_over": 5, None: 5}
+    assert spawning_task_ids == {"expand-parallel_over": 5, None: 5}  # Number of parallel tasks
     purposes = Counter([item.bound_kwargs["purpose"] for item in relevant_calls])
     assert purposes == {
-        NodeGroupPurpose.EXECUTE_BLOCK: 5,
-        NodeGroupPurpose.EXECUTE_SINGLE: 3,
-        NodeGroupPurpose.EXPAND_UNORDERED: 1,
-        NodeGroupPurpose.GATHER: 1,
+        NodeGroupPurpose.EXPAND_UNORDERED: 1,  # Expanding task - 'parallel_over'
+        NodeGroupPurpose.EXECUTE_BLOCK: 5,  # Tasks group from 'parallel_over'
+        NodeGroupPurpose.GATHER: 1,  # Gathering task - 'collect'
+        NodeGroupPurpose.EXECUTE_SINGLE: 3,  # All other tasks outside parallelization - single node
     }
     nodes = {node.name for item in relevant_calls for node in item.bound_kwargs["nodes"]}
     assert nodes == {
@@ -280,15 +280,15 @@ def test_individual_post_task_resolution_hook():
     dr = _sample_driver(hook)
     dr.execute(["output"], inputs={"n_iters_input": 5})
     relevant_calls = [item for item in hook.calls if item.name == hook_name]
-    assert len(relevant_calls) == 10
+    assert len(relevant_calls) == 10  # Total number of tasks
     spawning_task_ids = Counter([item.bound_kwargs["spawning_task_id"] for item in relevant_calls])
-    assert spawning_task_ids == {"expand-parallel_over": 5, None: 5}
+    assert spawning_task_ids == {"expand-parallel_over": 5, None: 5}  # Number of parallel tasks
     purposes = Counter([item.bound_kwargs["purpose"] for item in relevant_calls])
     assert purposes == {
-        NodeGroupPurpose.EXECUTE_BLOCK: 5,
-        NodeGroupPurpose.EXECUTE_SINGLE: 3,
-        NodeGroupPurpose.EXPAND_UNORDERED: 1,
-        NodeGroupPurpose.GATHER: 1,
+        NodeGroupPurpose.EXPAND_UNORDERED: 1,  # Expanding task - 'parallel_over'
+        NodeGroupPurpose.EXECUTE_BLOCK: 5,  # Tasks group from 'parallel_over'
+        NodeGroupPurpose.GATHER: 1,  # Gathering task - 'collect'
+        NodeGroupPurpose.EXECUTE_SINGLE: 3,  # All other tasks outside parallelization - single node
     }
     nodes = {node.name for item in relevant_calls for node in item.bound_kwargs["nodes"]}
     assert nodes == {


### PR DESCRIPTION
Current pre/post task execution hooks may run on out-of-process executors potentially causing issues with certain logging and stateful adapters. This PR adds additional hooks that are run *before* a task is submitted to an executor and *after* a task future is resolved - both on the main process.

## Changes

I added task submission / resolution hooks (`BasePreTaskSubmission` and `BasePostTaskResolution`) and adapters (`TaskSubmissionHook` and `TaskResolutionHook`) to the codebase as well as updated the main task execution function `run_graph_to_completion` to call the new hooks. In support of this I made `TaskImplementation` hashable via it's `task_id` in order to avoid a parallel structure - @elijahbenizzy perhaps in the future this could be used to a queue-based task processor?

## How I tested this

I added individual tests for both `TaskSubmissionHook` and `TaskResolutionHook` and added them to `test_multi_hook`.

## Notes
1. The docs for `TaskSubmissionHook` and `TaskResolutionHook`, as well some other task execution hooks, have been updated. I think we could add some more details - maybe a flow chart of when the individual hooks are called? I can add that if the current changes seems reasonable.
2. `TaskResolutionHook` currently has an optional  `error` attribute. I am on the fence as to whether or not this is needed. My thinking is that since `TaskFuture` essentially wraps `concurrent.futures.Future` we could forward the `exception` call. Thoughts? Currently `error`  is always `None`.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
