### PR TITLE
Pin `ddtrace` until deprecated module can be evaluated

### DIFF
--- a/hamilton/plugins/h_ddog.py
+++ b/hamilton/plugins/h_ddog.py
@@ -8,6 +8,8 @@ from hamilton.lifecycle import base
 
 logger = logging.getLogger(__name__)
 try:
+    # TODO: this works for ddtrace < 3.0; Span was deprecated in 3.0
+    # See https://github.com/DataDog/dd-trace-py/pull/12186
     from ddtrace import Span, context, tracer
 except ImportError as e:
     logger.error("ImportError: %s", e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dask-core = ["dask-core"]
 dask-dataframe = ["dask[dataframe]"]
 dask-diagnostics = ["dask[diagnostics]"]
 dask-distributed = ["dask[distributed]"]
-datadog = ["ddtrace"]
+datadog = ["ddtrace<3.0"]
 dev = [
   "pre-commit",
   "ruff==0.5.7", # this should match `.pre-commit-config.yaml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
   "commonmark==0.9.1", # read the docs pins
   "dask-expr; python_version == '3.9'",
   "dask[distributed]",
-  "ddtrace",
+  "ddtrace<3.0",
   "diskcache",
   # required for all the plugins
   "dlt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dask-core = ["dask-core"]
 dask-dataframe = ["dask[dataframe]"]
 dask-diagnostics = ["dask[diagnostics]"]
 dask-distributed = ["dask[distributed]"]
-datadog = ["ddtrace<3.0"]
+datadog = ["ddtrace<3.0"]  # Temporary pin until h_ddog.py import is fixed for >3.0 version
 dev = [
   "pre-commit",
   "ruff==0.5.7", # this should match `.pre-commit-config.yaml`


### PR DESCRIPTION
Recent releases of `ddtrace` have deprecated certain tracing modules/types (in particular `Span`). This causes some tests to fail (namely docs). This PR pins the `ddtrace` version to unblock tests until a more detailed solution can merged. For more details see: https://github.com/DataDog/dd-trace-py/pull/12186.

## Changes

Updated `pyporject.toml` to pin `ddtrace` to `<3.0` for the `datadog` extra.

## How I tested this

N/A

## Notes

N/A

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
