### PR TITLE
Fix a Type Hint and Link in Parallel Execution Documentation

### DIFF
--- a/docs/concepts/parallel-task.rst
+++ b/docs/concepts/parallel-task.rst
@@ -102,7 +102,7 @@ Thus, when you write a DAG like this (a simple map-reduce pattern):
     def url_loaded(url: str) -> str:
         return _load(urls)
 
-    def counts(url_loaded: str) -> str:
+    def counts(url_loaded: str) -> int:
         return len(url_loaded.split(" "))
 
     def total_words(counts: Collect[int]) -> int:
@@ -135,7 +135,7 @@ Solution:
 * If you're using a library that doesn't support serialization, then one option is to have Hamilton instantiate
   the object in each parallel block. You can do this by making the code depend on something within the parallel block.
 * Another option is write a customer wrapper function that uses `__set_state__` and `__get_state__` to serialize and deserialize the object.
-* See [this issue](https://github.com/DAGWorks-Inc/hamilton/issues/743) for details and possible features to make
+* See `this issue <https://github.com/DAGWorks-Inc/hamilton/issues/743>`_ for details and possible features to make
   this simpler to deal with.
 
 


### PR DESCRIPTION
Just addressing 2 small issues I noticed in the Parallel Execution documentation. Thanks for working on this great project!

## Changes
- Fixed (what I presume) is a typo in the docs for Parallel Execution, as well as a link that was formatted for markdown instead of RST.

## How I tested this
- Built docs locally and verified updates.

## Checklist

- [ x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
