### PR TITLE
Fix `xgboost` errors in CI

### DIFF
--- a/tests/plugins/test_xgboost_extensions.py
+++ b/tests/plugins/test_xgboost_extensions.py
@@ -18,7 +18,7 @@ def fitted_xgboost_model() -> xgboost.XGBModel:
 @pytest.fixture
 def fitted_xgboost_booster() -> xgboost.Booster:
     dtrain = xgboost.DMatrix([[0]], label=[[0]])
-    booster = xgboost.train({"objective": "binary:logistic"}, dtrain, 1)
+    booster = xgboost.train({"objective": "binary:logistic", "base_score": 0.5}, dtrain, 1)
     return booster
 
 


### PR DESCRIPTION
This is an attempt to fix `xgboost` errors in CI related to `test_xgboost_booster_json_writer` and `test_xgboost_booster_json_reader` where the following error is encountered:

```
Check failed: base_score > 0.0f && base_score < 1.0f: base_score must be in (0,1) for logistic loss, got: 0
```

Currently blocking #1287 and #1294 

## Changes

I added a default `base_score` to the `fitted_xgboost_booster` fixture.

## How I tested this

N/A

## Notes

Oddly enough this, these errors never show up on my machine (Windows). Which is usually reversed!

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
