### PR TITLE
Fix local (Windows) tests

### DIFF
--- a/hamilton/io/utils.py
+++ b/hamilton/io/utils.py
@@ -35,7 +35,8 @@ def get_file_metadata(path: Union[str, Path, PathLike]) -> Dict[str, Any]:
     notes = f"File metadata is unsupported for scheme: {scheme} or path: {path} does not exist."
 
     # Check if the path is a local file path (Windows drive can be listed as a scheme)
-    if (parsed.scheme == "" or parsed.scheme.isalpha()) and os.path.exists(path):
+    is_win_path = parsed.scheme and len(parsed.scheme) == 1 and parsed.scheme.isalpha()
+    if (parsed.scheme == "" or is_win_path) and os.path.exists(path):
         size = os.path.getsize(path)
         last_modified = os.path.getmtime(path)
         notes = ""

--- a/hamilton/io/utils.py
+++ b/hamilton/io/utils.py
@@ -34,7 +34,8 @@ def get_file_metadata(path: Union[str, Path, PathLike]) -> Dict[str, Any]:
     timestamp = datetime.now().utcnow().timestamp()
     notes = f"File metadata is unsupported for scheme: {scheme} or path: {path} does not exist."
 
-    if parsed.scheme == "" and os.path.exists(path):
+    # Check if the path is a local file path (Windows drive can be listed as a scheme)
+    if (parsed.scheme == "" or parsed.scheme.isalpha()) and os.path.exists(path):
         size = os.path.getsize(path)
         last_modified = os.path.getmtime(path)
         notes = ""

--- a/tests/caching/metadata_store/test_base.py
+++ b/tests/caching/metadata_store/test_base.py
@@ -45,7 +45,8 @@ def _mock_cache_key(
 
 
 @pytest.fixture
-def metadata_store(request, tmp_path):
+def metadata_store(request, tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("result_store")
     metadata_store_cls = request.param
     metadata_store = _instantiate_metadata_store(metadata_store_cls, tmp_path)
 

--- a/tests/caching/result_store/test_base.py
+++ b/tests/caching/result_store/test_base.py
@@ -16,7 +16,8 @@ def _instantiate_result_store(result_store_cls, tmp_path):
 
 
 @pytest.fixture
-def result_store(request, tmp_path):
+def result_store(request, tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("result_store")
     result_store_cls = request.param
     result_store = _instantiate_result_store(result_store_cls, tmp_path)
 

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -1,9 +1,12 @@
+import os
 import pathlib
 import sqlite3
 from typing import Union
+from unittest import mock
 
 import pandas as pd
 import pytest
+import tzdata
 from pandas.testing import assert_frame_equal
 from sqlalchemy import create_engine
 
@@ -238,6 +241,7 @@ def test_pandas_orc_writer(tmp_path: pathlib.Path) -> None:
     assert metadata["dataframe_metadata"]["column_names"] == ["col1", "col2"]
 
 
+@mock.patch.dict(os.environ, {"TZDIR": os.path.join(os.path.dirname(tzdata.__file__), "zoneinfo")})
 def test_pandas_orc_reader(tmp_path: pathlib.Path) -> None:
     path_to_test = "tests/resources/data/test_load_from_data.orc"
     reader = PandasORCReader(path=path_to_test)

--- a/tests/plugins/test_plotly_extensions.py
+++ b/tests/plugins/test_plotly_extensions.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 
 import plotly.graph_objects as go
 import pytest
@@ -12,6 +13,10 @@ def figure():
     yield go.Figure(data=go.Scatter(x=[1, 2, 3, 4, 5], y=[10, 14, 18, 24, 30], mode="markers"))
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Windows does not currently support plotly static image export",
+)
 def test_plotly_static_writer(figure: go.Figure, tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "figure.png"
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -66,6 +66,7 @@ def test__load_config_new(tmp_path_factory):
     assert a_id == actual_config["DEFAULT"]["anonymous_id"]
 
 
+@mock.patch.dict(os.environ, {"HAMILTON_TELEMETRY_ENABLED": ""})
 def test__check_config_and_environ_for_telemetry_flag_not_present():
     """Tests not present in both."""
     conf = configparser.ConfigParser()
@@ -73,6 +74,7 @@ def test__check_config_and_environ_for_telemetry_flag_not_present():
     assert actual is False
 
 
+@mock.patch.dict(os.environ, {"HAMILTON_TELEMETRY_ENABLED": ""})
 def test__check_config_and_environ_for_telemetry_flag_in_config():
     """tests getting from config."""
     conf = configparser.ConfigParser()


### PR DESCRIPTION
I have been encountering errors and/or failures when running the test suite, locally, on a Windows machine. This pull request includes several changes aimed at allowing the test suite to pass. All changes, expect the first one, are confined to the offending tests.

## Changes

### File Handling Improvements:
* `hamilton/io/utils.py`: Enhanced the `get_file_metadata` function to correctly handle Windows drive paths where the `scheme` from `parse.urlparse` may include the Windows drive letter.

### Testing Fixture Updates:
* `tests/caching`:  Because the `metadata_store` and `result_store` used the same temporary directory, deletions during clean-up were running into Window's file share locking. Switched to the `tmp_path_factory` fixture and decoupled the paths for the `metadata_store` and `result_store`

### Environment Variable Mocking:
* `tests/plugins/test_pandas_extensions.py`: Added mocking for the `TZDIR` environment variable in the `test_pandas_orc_reader` test. Note this is due to how Windows interacts with the IANA timezone database.
* `tests/test_telemetry.py`: Added mocking for the `HAMILTON_TELEMETRY_ENABLED` environment variable in telemetry configuration tests. Previous tests were changing `os.environ` directly leading to issues if the user already had ``HAMILTON_TELEMETRY_ENABLED` set.

### Platform-Specific Test Adjustments:
* `tests/plugins/test_plotly_extensions.py`: Added a platform check to skip the `test_plotly_static_writer` test on Windows. There are some issue with using the `plotly` dependency `kaleido` to generate static images on Windows.

## How I tested this

N/A

## Notes

N/A

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
