### PR TITLE
Fix `dlt` plugin with changes to `loader_file_format`

### DIFF
--- a/hamilton/plugins/dlt_extensions.py
+++ b/hamilton/plugins/dlt_extensions.py
@@ -56,8 +56,8 @@ class DltResourceLoader(DataLoader):
         pipeline = dlt.pipeline(
             pipeline_name="Hamilton-DltResourceLoader", destination="filesystem"
         )
-        pipeline.extract(self.resource)
-        normalize_info = pipeline.normalize(loader_file_format="parquet")
+        pipeline.extract(self.resource, loader_file_format="parquet")
+        normalize_info = pipeline.normalize()
 
         partition_file_paths = []
         package = normalize_info.load_packages[0]


### PR DESCRIPTION
A recent change to `dlt` in https://github.com/dlt-hub/dlt/pull/2430 moved the `loader_file_format` parameter from `pipeline.normalize` to `pipeline.extract`. This caused CI tests for the `dlt` plugin to fail (most notably in #1305).

## Changes

Updated `tests/plugins/test_dlt_extensions.py`, moving `loader_file_format` from `pipeline.normalize` to `pipeline.extract`.

## How I tested this

Covered by existing `tests/plugins/test_dlt_extensions.py`.

## Notes

N/A

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
