### PR TITLE
Fix typo in parallel-task documentation

### DIFF
--- a/docs/concepts/parallel-task.rst
+++ b/docs/concepts/parallel-task.rst
@@ -134,7 +134,7 @@ Solution:
 * Make sure that your objects are serializable.
 * If you're using a library that doesn't support serialization, then one option is to have Apache Hamilton instantiate
   the object in each parallel block. You can do this by making the code depend on something within the parallel block.
-* Another option is write a customer wrapper function that uses `__set_state__` and `__get_state__` to serialize and deserialize the object.
+* Another option is write a custom wrapper function that uses `__set_state__` and `__get_state__` to serialize and deserialize the object.
 * See `this issue <https://github.com/apache/hamilton/issues/743>`_ for details and possible features to make
   this simpler to deal with.
 


### PR DESCRIPTION
## Changes

Fixes a simple typo. The parallel-task concept docs referred to a "customer wrapper"; I believe it was supposed to mean "custom wrapper".

## How I tested this
(nothing to test)

## Notes
(no notes)

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
