### PR TITLE
Add NDJSON support in polars

### DIFF
--- a/examples/polars/materialization/my_script.py
+++ b/examples/polars/materialization/my_script.py
@@ -78,6 +78,13 @@ materializers = [
         file="./df.json",
         combine=df_builder,
     ),
+    # materialize the dataframe to an ndjson file
+    to.ndjson(
+        dependencies=output_columns,
+        id="df_to_ndjson",
+        file="./df.ndjson",
+        combine=df_builder,
+    ),
     to.avro(
         dependencies=output_columns,
         id="df_to_avro",
@@ -117,6 +124,7 @@ materialization_results, additional_outputs = dr.materialize(
         "df_to_parquet_build_result",
         "df_to_feather_build_result",
         "df_to_json_build_result",
+        "df_to_ndjson_build_result",
         "df_to_avro_build_result",
         "df_to_spreadsheet_build_result",
         "df_to_database_build_result",
@@ -127,6 +135,7 @@ print(materialization_results)
 print(additional_outputs["df_to_parquet_build_result"])
 print(additional_outputs["df_to_feather_build_result"])
 print(additional_outputs["df_to_json_build_result"])
+print(additional_outputs["df_to_ndjson_build_result"])
 print(additional_outputs["df_to_avro_build_result"])
 print(additional_outputs["df_to_spreadsheet_build_result"])
 print(additional_outputs["df_to_database_build_result"])

--- a/tests/plugins/test_polars_extensions.py
+++ b/tests/plugins/test_polars_extensions.py
@@ -37,6 +37,8 @@ from hamilton.plugins.polars_post_1_0_0_extensions import (  # isort: skip
     PolarsFeatherWriter,
     PolarsJSONReader,
     PolarsJSONWriter,
+    PolarsNDJSONReader,
+    PolarsNDJSONWriter,
     PolarsParquetReader,
     PolarsParquetWriter,
     PolarsSpreadsheetReader,
@@ -124,6 +126,22 @@ def test_polars_json(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
 
     assert PolarsJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsJSONReader.applicable_types() == [pl.DataFrame]
+    assert df2.shape == (2, 2)
+    assert "schema" not in kwargs2
+    polars.testing.assert_frame_equal(df, df2)
+
+
+def test_polars_ndjson(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
+    file = tmp_path / "test.ndjson"
+    writer = PolarsNDJSONWriter(file=file)
+    writer.save_data(df)
+
+    reader = PolarsNDJSONReader(source=file)
+    kwargs2 = reader._get_loading_kwargs()
+    df2, metadata = reader.load_data(pl.DataFrame)
+
+    assert PolarsNDJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsNDJSONReader.applicable_types() == [pl.DataFrame]
     assert df2.shape == (2, 2)
     assert "schema" not in kwargs2
     polars.testing.assert_frame_equal(df, df2)

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -37,6 +37,8 @@ from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsFeatherWriter,
     PolarsJSONReader,
     PolarsJSONWriter,
+    PolarsNDJSONReader,
+    PolarsNDJSONWriter,
     PolarsParquetWriter,
     PolarsSpreadsheetReader,
     PolarsSpreadsheetWriter,
@@ -140,6 +142,22 @@ def test_polars_json(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
     assert PolarsJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsJSONReader.applicable_types() == [pl.DataFrame]
+    assert df2.shape == (2, 2)
+    assert "schema" not in kwargs2
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    file = tmp_path / "test.ndjson"
+    writer = PolarsNDJSONWriter(file=file)
+    writer.save_data(df)
+
+    reader = PolarsNDJSONReader(source=file)
+    kwargs2 = reader._get_loading_kwargs()
+    df2, metadata = reader.load_data(pl.DataFrame)
+
+    assert PolarsNDJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsNDJSONReader.applicable_types() == [pl.DataFrame]
     assert df2.shape == (2, 2)
     assert "schema" not in kwargs2
     assert_frame_equal(df.collect(), df2)


### PR DESCRIPTION
This PR implements NDJSON (newline-delimited JSON) reader and writer support for Polars, following the same pattern as the existing JSON reader/writer implementation. 
coming from #1197

## Changes
- Added PolarsNDJSONReader class in hamilton/plugins/polars_post_1_0_0_extensions.py
- Added PolarsNDJSONWriter class in hamilton/plugins/polars_post_1_0_0_extensions.py
- Supports writing NDJSON files using data.write_ndjson()

- Registered both classes in `register_data_loaders()` function to make them available through the materialization system
- Added the following tests:
  - test_polars_ndjson() in tests/plugins/test_polars_extensions.py for DataFrame support
  - test_polars_ndjson() in tests/plugins/test_polars_lazyframe_extensions.py for LazyFrame support
- Added example in examples/polars/materialization/my_script.py

## How I tested this
Ran the specific NDJSON tests:
- pytest tests/plugins/test_polars_extensions.py::test_polars_ndjson -v
- pytest tests/plugins/test_polars_lazyframe_extensions.py::test_polars_ndjson -v
Both tests passed

## Notes

## Checklist

- [Y] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [Y] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
