### PR TITLE
Adds matomo analytics to docs

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,23 @@
+{% extends "!page.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(["disableCookies"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://analytics.apache.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '87']);
+    var d=document, g=d.createElement('script'),
+s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+{% endblock %}


### PR DESCRIPTION
[Adds matomo analytics to docs](https://github.com/apache/hamilton/commit/4f839d0b1110b295d7ee939f82ee400c0cd2676c) 

   This uses the recommended way to extend the template that furo uses.

## Changes
- adds template to sphinx with matomo tracking code

## How I tested this
- locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
