### PR TITLE
chore: Replace `pre-commit` with `prek`

### DIFF
--- a/.github/workflows/hamilton-main.yml
+++ b/.github/workflows/hamilton-main.yml
@@ -60,12 +60,12 @@ jobs:
             activate-environment: true
 
         # It's enough to do it on single OS
-        - name: Check linting with pre-commit
+        - name: Check linting with prek
           if: ${{ runner.os == 'Linux' }}
           run: |
             uv sync --dev
-            uv run pre-commit install
-            uv run pre-commit run --all-files
+            uv run prek install
+            uv run prek run --all-files
 
         - name: Check for missing Apache 2 license headers
           if: ${{ runner.os == 'Linux' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
-# pre-commit hooks require a user to have installed `pre-commit`:
-#   $ brew install pre-commit
+# pre-commit hooks require a user to have installed `prek`:
+#   $ brew install prek
 # Then install the hooks within the repo:
 #   $ cd /PATH/TO/REPO
-#   $ pre-commit install
+#   $ prek install
 exclude: '^docs/code-comparisons/'  # skip the code comparisons directory
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -16,7 +16,7 @@ repos:
       - id: ruff-format
         # args: [ --diff ]  # Use for previewing changes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       # ensures files are either empty or end with a blank line

--- a/dev_tools/language_server/pyproject.toml
+++ b/dev_tools/language_server/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pre-commit",
+    "prek",
     "pytest",
 ]
 

--- a/docs/how-tos/pre-commit-hooks.md
+++ b/docs/how-tos/pre-commit-hooks.md
@@ -30,12 +30,12 @@ Note that it's different from testing, which focuses on the behavior of the code
 ## Add pre-commit hooks to your project
 Hooks are a mechanism of the `git` version control system. You can find your project's hooks under the `.git/hooks` directory (it might be hidden by default). There should be many files with the `.sample` extension that serve as example scripts.
 
-The preferred way of working with pre-commit hooks is through the [pre-commit](https://pre-commit.com/) Python library. This library allows you to import and configure hooks for your repository with a `.pre-commit-config.yaml` file.
+The preferred way of working with pre-commit hooks is through the [prek](https://github.com/j178/prek/) library. This library allows you to import and configure hooks for your repository with a `.pre-commit-config.yaml` file.
 
 ### Steps to get started
-1. install the pre-commit library
+1. install the prek library
     ```python
-    pip install pre-commit
+    pip install prek
     ```
 
 2. add a `.pre-commit-config.yaml` to your repository
@@ -44,7 +44,7 @@ The preferred way of working with pre-commit hooks is through the [pre-commit](h
     repos:
         # repository with hook definitions
     -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v2.3.0  # release version of the repo
+        rev: v6.0.0  # release version of the repo
         hooks:  # list of hooks from the repo to include in this project
         -   id: end-of-file-fixer
         -   id: trailing-whitespace
@@ -60,13 +60,13 @@ The preferred way of working with pre-commit hooks is through the [pre-commit](h
 
 3. install the hooks defined in `.pre-commit-config.yaml`
     ```console
-    pre-commit install
+    prek install
     ```
     Now, hooks will automatically run on `git commit`
 
 4. to manually run hooks
     ```console
-    pre-commit run --all-files
+    prek run --all-files
     ```
 
 ## Custom Apache Hamilton pre-commit hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ visualization = ["graphviz", "networkx"]
 
 [dependency-groups]
 dev = [
-  "pre-commit",
+  "prek",
   "ruff==0.5.7", # this should match `.pre-commit-config.yaml`
 ]
 test = [
@@ -157,7 +157,7 @@ docs = [
   "pyarrow >= 1.0.0",
   "pydantic >=2.0",
   "pyspark",
-    "openlineage-python",
+  "openlineage-python",
   "PyYAML",
   "ray",
   "readthedocs-sphinx-ext<2.3", # read the docs pins

--- a/ui/sdk/.github/workflows/unit-tests.yml
+++ b/ui/sdk/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: Run pre-commit hooks
       run: |
-        pre-commit run --all-files
+        prek run --all-files
     - name: Test with pytest
       run: |
         pip install -r requirements-test.txt

--- a/ui/sdk/.pre-commit-config.yaml
+++ b/ui/sdk/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
-# pre-commit hooks require a user to have installed `pre-commit`:
-#   $ brew install pre-commit
+# pre-commit hooks require a user to have installed `prek`:
+#   $ brew install prek
 # Then install the hooks within the repo:
 #   $ cd /PATH/TO/REPO
-#   $ pre-commit install
+#   $ prek install
 
 repos:
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
@@ -12,12 +12,12 @@ repos:
         - id: ruff
           args: [ --fix , --exit-non-zero-on-fix ]
 -   repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 26.1.0
     hooks:
     - id: black
       args: [--line-length=100]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     # ensures files are either empty or end with a blank line

--- a/ui/sdk/developer_setup.md
+++ b/ui/sdk/developer_setup.md
@@ -53,10 +53,10 @@ pip install \
     -r ./requirements-test.txt
 ```
 
-Set up `pre-commit`, which will run some lightweight formatting and linting tasks on every commit.
+Set up `prek`, which will run some lightweight formatting and linting tasks on every commit.
 
 ```shell
-pre-commit install
+prek install
 ```
 
 ### Create a pull request
@@ -83,10 +83,10 @@ Make changes, commit them, and push them to your fork.
 git push origin HEAD
 ```
 
-Test your changes locally with `pre-commit`...
+Test your changes locally with `prek`...
 
 ```shell
-pre-commit run --all-files
+prek run --all-files
 ```
 
 ...and by following the steps in ["How to run unit tests"](#how-to-run-unit-tests).

--- a/ui/sdk/requirements-dev.txt
+++ b/ui/sdk/requirements-dev.txt
@@ -1,6 +1,6 @@
 black
 openapi-python-client
 pandera # for cli examples
-pre-commit
+prek
 ruff
 scikit-learn # for cli examples

--- a/writeups/developer_setup.md
+++ b/writeups/developer_setup.md
@@ -54,10 +54,10 @@ Please be informed to use escape characters or wrap the argument in quote as sho
 pip install '.[dev,test]'
 ```
 
-Set up `pre-commit`, which will run some lightweight formatting and linting tasks on every commit.
+Set up `prek`, which will run some lightweight formatting and linting tasks on every commit.
 
 ```shell
-pre-commit install
+prek install
 ```
 
 ### Create a pull request
@@ -84,10 +84,10 @@ Make changes, commit them, and push them to your fork.
 git push origin HEAD
 ```
 
-Test your changes locally with `pre-commit`...
+Test your changes locally with `prek`...
 
 ```shell
-pre-commit run --all-files
+prek run --all-files
 ```
 
 ...and by following the steps in ["How to run unit tests"](#how-to-run-unit-tests).
@@ -113,7 +113,7 @@ The following values for `TASK` are recognized:
 * `async` = unit tests using the async driver
 * `dask` = unit tests using the `dask` adapter
 * `integrations` = tests on integrations with other frameworks
-* `pre-commit` = static analysis (i.e. linting)
+* `prek` = static analysis (i.e. linting)
 * `pyspark` = unit tests using the `spark` adapter
 * `ray` = unit tests using the `ray` adapter
 * `tests` = core unit tests with minimal requirements


### PR DESCRIPTION
Modernize tooling: prek

## Changes
- Use `prek` as a drop-in replacement for `pre-commit`.
- Update docs where appropriate.

## How I tested this
Local

## Notes
A similar transition was done in Apache Airflow with very positive feedback.

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
