### PR TITLE
Fix `@resolve` decorator not calling `validate()` on returned decorators

### DIFF
--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -170,8 +170,14 @@ class resolve(DynamicResolver):
             if key in config:
                 kwargs[key] = config[key]
         decorator = self.decorate_with(**kwargs)
+
+        # NOTE: cases where `decorator` has no `validate` method should be caught by type checkers
+        # since `decorate_with` is typed as `Callable[..., NodeTransformLifecycle]`. The following
+        # check allows non-conforming functions to be used with `resolve` without immediately
+        # throwing an error, which may be undesirable.
         if hasattr(decorator, "validate"):
             decorator.validate(fn)
+
         return decorator
 
 

--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -169,7 +169,10 @@ class resolve(DynamicResolver):
         for key in self._optional_config:
             if key in config:
                 kwargs[key] = config[key]
-        return self.decorate_with(**kwargs)
+        decorator = self.decorate_with(**kwargs)
+        if hasattr(decorator, "validate"):
+            decorator.validate(fn)
+        return decorator
 
 
 class resolve_from_config(resolve):

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -105,7 +105,7 @@ def test_dynamic_resolve_with_configs():
     assert decorator_resolved.columns == ("a", "b")
 
 
-def test_dynamic_fails_without_power_mode_fails():
+def test_dynamic_resolve_without_power_mode_fails():
     def fn() -> pd.DataFrame:
         return pd.DataFrame()
 

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -17,6 +17,7 @@
 
 from collections.abc import Callable
 
+import pandas as pd
 import pytest
 
 from hamilton import settings
@@ -69,12 +70,17 @@ def test_extract_and_validate_params_unhappy(fn: Callable):
 
 
 def test_dynamic_resolves():
+    # Note: we use an empty DataFrame for validation only. This test would fail at runtime
+    # if we actually tried to execute the DAG because there are no columns "a" or "b" to extract.
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
         decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
     )
     decorator_resolved = decorator.resolve(
-        {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED}, fn=test_dynamic_resolves
+        {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED}, fn=fn
     )
     # This uses an internal component of extract_columns
     # We may want to add a little more comprehensive testing
@@ -83,12 +89,15 @@ def test_dynamic_resolves():
 
 
 def test_dynamic_resolve_with_configs():
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
     decorator = resolve_from_config(
         decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
     )
     decorator_resolved = decorator.resolve(
         {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED},
-        fn=test_dynamic_resolve_with_configs,
+        fn=fn,
     )
     # This uses an internal component of extract_columns
     # We may want to add a little more comprehensive testing
@@ -97,18 +106,15 @@ def test_dynamic_resolve_with_configs():
 
 
 def test_dynamic_fails_without_power_mode_fails():
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
         decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
     )
     with pytest.raises(base.InvalidDecoratorException):
-        decorator_resolved = decorator.resolve(
-            CONFIG_WITH_POWER_MODE_DISABLED, fn=test_dynamic_fails_without_power_mode_fails
-        )
-        # This uses an internal component of extract_columns
-        # We may want to add a little more comprehensive testing
-        # But for now this will work
-        assert decorator_resolved.columns == ("a", "b")
+        decorator.resolve(CONFIG_WITH_POWER_MODE_DISABLED, fn=fn)
 
 
 def test_config_derivation():
@@ -125,6 +131,9 @@ def test_config_derivation():
 
 
 def test_delayed_with_optional():
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
         decorate_with=lambda cols_to_extract, some_cols_you_might_want_to_extract=["c"]: (
@@ -133,7 +142,7 @@ def test_delayed_with_optional():
     )
     resolved = decorator.resolve(
         {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED},
-        fn=test_delayed_with_optional,
+        fn=fn,
     )
     assert list(resolved.columns) == ["a", "b", "c"]
     resolved = decorator.resolve(
@@ -142,12 +151,15 @@ def test_delayed_with_optional():
             "some_cols_you_might_want_to_extract": ["d"],
             **CONFIG_WITH_POWER_MODE_ENABLED,
         },
-        fn=test_delayed_with_optional,
+        fn=fn,
     )
     assert list(resolved.columns) == ["a", "b", "d"]
 
 
 def test_delayed_without_power_mode_fails():
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
         decorate_with=lambda cols_to_extract, some_cols_you_might_want_to_extract=["c"]: (
@@ -157,14 +169,14 @@ def test_delayed_without_power_mode_fails():
     with pytest.raises(base.InvalidDecoratorException):
         decorator.resolve(
             {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_DISABLED},
-            fn=test_delayed_with_optional,
+            fn=fn,
         )
 
 
 def test_dynamic_resolve_with_extract_fields():
     """Test that @resolve with @extract_fields calls validate() correctly."""
 
-    def my_function() -> dict[str, int]:
+    def fn() -> dict[str, int]:
         return {"a": 1, "b": 2}
 
     decorator = resolve(
@@ -173,7 +185,7 @@ def test_dynamic_resolve_with_extract_fields():
     )
     decorator_resolved = decorator.resolve(
         {"fields": {"a": int, "b": int}, **CONFIG_WITH_POWER_MODE_ENABLED},
-        fn=my_function,
+        fn=fn,
     )
     assert hasattr(decorator_resolved, "resolved_fields")
     assert decorator_resolved.resolved_fields == {"a": int, "b": int}

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -189,3 +189,64 @@ def test_dynamic_resolve_with_extract_fields():
     )
     assert hasattr(decorator_resolved, "resolved_fields")
     assert decorator_resolved.resolved_fields == {"a": int, "b": int}
+
+
+def test_resolve_from_config_with_extract_fields():
+    """Test @resolve_from_config with @extract_fields calls validate() correctly."""
+
+    def fn() -> dict[str, int]:
+        return {"a": 1, "b": 2}
+
+    decorator = resolve_from_config(
+        decorate_with=lambda fields: extract_fields(fields),
+    )
+    decorator_resolved = decorator.resolve(
+        {"fields": {"a": int, "b": int}, **CONFIG_WITH_POWER_MODE_ENABLED},
+        fn=fn,
+    )
+    assert hasattr(decorator_resolved, "resolved_fields")
+    assert decorator_resolved.resolved_fields == {"a": int, "b": int}
+
+
+def test_resolve_propagates_validate_failure():
+    """Test that validate() failures are propagated through resolve."""
+
+    def fn() -> str:
+        return "not what you were expecting..."
+
+    decorator = resolve(
+        when=ResolveAt.CONFIG_AVAILABLE,
+        decorate_with=lambda fields: extract_fields(fields),
+    )
+    with pytest.raises(base.InvalidDecoratorException):
+        decorator.resolve(
+            {"fields": {"a": int, "b": int}, **CONFIG_WITH_POWER_MODE_ENABLED},
+            fn=fn,
+        )
+
+
+def test_resolve_with_arbitrary_decorator():
+    """Test behavior when decorate_with returns something that is not a NodeTransformLifecycle."""
+
+    # NOTE: do we actually want this test to pass?
+
+    # A decorator that doesn't inherit from NodeTransformLifecycle (but still uses kwargs only)
+    class ArbitraryDecorator:
+        def __init__(self, a: int, b: int) -> None:
+            pass
+
+        def __call__(self, f: Callable) -> Callable:
+            return f
+
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
+    decorator = resolve(
+        when=ResolveAt.CONFIG_AVAILABLE,
+        decorate_with=lambda kwargs: ArbitraryDecorator(**kwargs),
+    )
+    decorator_resolved = decorator.resolve(
+        {"kwargs": {"a": 1, "b": 2}, **CONFIG_WITH_POWER_MODE_ENABLED},
+        fn=fn,
+    )
+    assert isinstance(decorator_resolved, ArbitraryDecorator)

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -26,6 +26,7 @@ from hamilton.function_modifiers import (
     base,
     extract_columns,
     extract_fields,
+    parameterize_sources,
     resolve,
     resolve_from_config,
 )
@@ -189,6 +190,26 @@ def test_dynamic_resolve_with_extract_fields():
     )
     assert hasattr(decorator_resolved, "resolved_fields")
     assert decorator_resolved.resolved_fields == {"a": int, "b": int}
+
+
+def test_resolve_with_parameterize_sources():
+    """Test that @resolve with @parameterize_sources calls validate() correctly."""
+
+    def fn(x: int, y: int) -> int:
+        return x + y
+
+    decorator = resolve(
+        when=ResolveAt.CONFIG_AVAILABLE,
+        decorate_with=lambda: parameterize_sources(result_1={"x": "source_x", "y": "source_y"}),
+    )
+    decorator_resolved = decorator.resolve(
+        {**CONFIG_WITH_POWER_MODE_ENABLED},
+        fn=fn,
+    )
+    assert "result_1" in decorator_resolved.parameterization
+    mapping = decorator_resolved.parameterization["result_1"]
+    assert mapping["x"].source == "source_x"
+    assert mapping["y"].source == "source_y"
 
 
 def test_resolve_from_config_with_extract_fields():

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -249,7 +249,7 @@ def test_resolve_propagates_validate_failure():
 def test_resolve_with_arbitrary_decorator():
     """Test behavior when decorate_with returns something that is not a NodeTransformLifecycle."""
 
-    # NOTE: do we actually want this test to pass?
+    # NOTE: we want to ensure we don't interfere with other decorators on functions.
 
     # A decorator that doesn't inherit from NodeTransformLifecycle (but still uses kwargs only)
     class ArbitraryDecorator:

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -24,6 +24,7 @@ from hamilton.function_modifiers import (
     ResolveAt,
     base,
     extract_columns,
+    extract_fields,
     resolve,
     resolve_from_config,
 )
@@ -86,7 +87,8 @@ def test_dynamic_resolve_with_configs():
         decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
     )
     decorator_resolved = decorator.resolve(
-        {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED}, fn=test_dynamic_resolves
+        {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED},
+        fn=test_dynamic_resolve_with_configs,
     )
     # This uses an internal component of extract_columns
     # We may want to add a little more comprehensive testing
@@ -157,3 +159,21 @@ def test_delayed_without_power_mode_fails():
             {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_DISABLED},
             fn=test_delayed_with_optional,
         )
+
+
+def test_dynamic_resolve_with_extract_fields():
+    """Test that @resolve with @extract_fields calls validate() correctly."""
+
+    def my_function() -> dict[str, int]:
+        return {"a": 1, "b": 2}
+
+    decorator = resolve(
+        when=ResolveAt.CONFIG_AVAILABLE,
+        decorate_with=lambda fields: extract_fields(fields),
+    )
+    decorator_resolved = decorator.resolve(
+        {"fields": {"a": int, "b": int}, **CONFIG_WITH_POWER_MODE_ENABLED},
+        fn=my_function,
+    )
+    assert hasattr(decorator_resolved, "resolved_fields")
+    assert decorator_resolved.resolved_fields == {"a": int, "b": int}


### PR DESCRIPTION
Hello!

This PR makes a trivial change to the delayed evaluation decorator (`@resolve`) so that it works with decorators such as `@extract_fields` which require their `validate()` method to have been called. Concretely, the "fix" is to call `validate()` (if it is defined) in `resolve.resolve`, before returning it.

Prior to this change, using `@resolve` with `@extract_fields` results in an `AttributeError: 'extract_fields' object has no attribute 'resolved_fields'`.

## Changes

Mainly..

- Call `decorator.validate()` before returning the decorator from `resolve.resolve`.
- Add a unit test to test the combination of `resolve` and `extract_fields` specifically

Also..

- Tweaked other unit tests in the same module which were failing after this change; performing the validation step checks for proper function annotations, so added dummy annodated functions inside these tests.
- Removed an unreachable assert from `test_dynamic_fails_without_power_mode_fails`, and renamed it `test_dynamic_resolve_...`

## How I tested this

```sh
pytest tests/functions_modifieds/test_delayed.py
```

## Notes

Intended to fix #1409 - I have the same goals/issues.

This is my first contribution to this project. As a novice, the `CONTRIBUTING.md` guidelines could do with more detail! Note that the link to the developer setup guide appears broken.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] (N/A) New functions are documented (with a description, list of inputs, and expected output)
- [ ] (N/A) Placeholder code is flagged / future TODOs are captured in comments
- [ ] (N/A) Project documentation has been updated if adding/changing functionality.
