### PR TITLE
Remove license comments from databackend.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,8 @@ repos:
           ^\.github/|
           ^docs/|
           ^examples/|
-          ^dev_tools/language_server/tests/ls_setup\.py$
+          ^dev_tools/language_server/tests/ls_setup\.py$|
+          ^hamilton/experimental/databackend.py$
         args:
           - --comment-style
           - "|#|"
@@ -69,8 +70,7 @@ repos:
           (?x)
           ^\.github/|
           ^docs/|
-          ^examples/|
-          ^hamilton/experimental/databackend.py
+          ^examples/
         args:
           - --comment-style
           - "|#|"

--- a/hamilton/experimental/databackend.py
+++ b/hamilton/experimental/databackend.py
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 """Below is a file from `databackend` v0.0.2 found on GitHub
 permalink: https://github.com/machow/databackend/blob/214832bab6990098d52a4a2fae935f5d9ae8dc3c/databackend/__init__.py
 """


### PR DESCRIPTION
Removed Apache License comments from the file.

This Apache header should not have been added - see point 3 in https://www.apache.org/legal/src-headers.html#3party