### PR TITLE
Remove implicit assumption about git from `test_git_directory_exists`

### DIFF
--- a/tests/cli/test_logic.py
+++ b/tests/cli/test_logic.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pathlib import Path
+import subprocess
+from unittest import mock
 
 from hamilton import driver
 from hamilton.cli import logic
@@ -24,9 +25,23 @@ from tests.cli.resources import module_v1, module_v2
 
 
 def test_git_directory_exists():
-    git_base_dir = logic.get_git_base_directory()
+    completed_process = subprocess.CompletedProcess(
+        args=["git", "rev-parse", "--show-toplevel"],
+        returncode=0,
+        stdout="/tmp/fake-repo\n",
+        stderr="",
+    )
 
-    assert Path(git_base_dir).exists()
+    with mock.patch("subprocess.run", return_value=completed_process) as run_mock:
+        git_base_dir = logic.get_git_base_directory()
+
+    assert git_base_dir == "/tmp/fake-repo"
+    run_mock.assert_called_once_with(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
 
 def test_map_nodes_to_origins():


### PR DESCRIPTION
While testing 1.90.0rc0 a test failed:
```none
FAILED tests/cli/test_logic.py::test_git_directory_exists - OSError: fatal: not a git repository (or any of the parent directories): .git
```
This is because the `test_git_directory_exists()` integration-style test currently depends on the checkout being a real Git worktree. This PR updates the test to unit-test `get_git_base_directory()` by mocking `subprocess.run`, which makes it stable under `uv run` tarball/sdist environments.

## How I tested this
Test was failing, now it passes.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
