### PR TITLE
Refactor _get_loading_kwargs to remove deprecated options

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -165,99 +165,13 @@ class PandasCSVReader(DataLoader):
     @classmethod
     def applicable_types(cls) -> Collection[type]:
         return [DATAFRAME_TYPE]
-
-    def _get_loading_kwargs(self) -> dict[str, Any]:
-        kwargs = {}
-        if self.sep is not None:
-            kwargs["sep"] = self.sep
-        if self.delimiter is not None:
-            kwargs["delimiter"] = self.delimiter
-        if self.header is not None:
-            kwargs["header"] = self.header
-        if self.names is not None:
-            kwargs["names"] = self.names
-        if self.index_col is not None:
-            kwargs["index_col"] = self.index_col
-        if self.usecols is not None:
-            kwargs["usecols"] = self.usecols
-        if self.dtype is not None:
-            kwargs["dtype"] = self.dtype
-        if self.engine is not None:
-            kwargs["engine"] = self.engine
-        if self.converters is not None:
-            kwargs["converters"] = self.converters
-        if self.true_values is not None:
-            kwargs["true_values"] = self.true_values
-        if self.false_values is not None:
-            kwargs["false_values"] = self.false_values
-        if self.skipinitialspace is not None:
-            kwargs["skipinitialspace"] = self.skipinitialspace
-        if self.skiprows is not None:
-            kwargs["skiprows"] = self.skiprows
-        if self.nrows is not None:
-            kwargs["nrows"] = self.nrows
-        if self.na_values is not None:
-            kwargs["na_values"] = self.na_values
-        if self.keep_default_na is not None:
-            kwargs["keep_default_na"] = self.keep_default_na
-        if self.na_filter is not None:
-            kwargs["na_filter"] = self.na_filter
-        if Version(pd.__version__) < Version("2.2") and self.verbose is not None:
-            kwargs["verbose"] = self.verbose
-        if self.skip_blank_lines is not None:
-            kwargs["skip_blank_lines"] = self.skip_blank_lines
-        if self.parse_dates is not None:
-            kwargs["parse_dates"] = self.parse_dates
-        if Version(pd.__version__) < Version("2.2") and self.keep_date_col is not None:
-            kwargs["keep_date_col"] = self.keep_date_col
-        if self.date_format is not None:
-            kwargs["date_format"] = self.date_format
-        if self.dayfirst is not None:
-            kwargs["dayfirst"] = self.dayfirst
-        if self.cache_dates is not None:
-            kwargs["cache_dates"] = self.cache_dates
-        if self.iterator is not None:
-            kwargs["iterator"] = self.iterator
-        if self.chunksize is not None:
-            kwargs["chunksize"] = self.chunksize
-        if self.compression is not None:
-            kwargs["compression"] = self.compression
-        if self.thousands is not None:
-            kwargs["thousands"] = self.thousands
-        if self.lineterminator is not None:
-            kwargs["lineterminator"] = self.lineterminator
-        if self.quotechar is not None:
-            kwargs["quotechar"] = self.quotechar
-        if self.quoting is not None:
-            kwargs["quoting"] = self.quoting
-        if self.doublequote is not None:
-            kwargs["doublequote"] = self.doublequote
-        if self.escapechar is not None:
-            kwargs["escapechar"] = self.escapechar
-        if self.comment is not None:
-            kwargs["comment"] = self.comment
-        if self.encoding is not None:
-            kwargs["encoding"] = self.encoding
-        if self.encoding_errors is not None:
-            kwargs["encoding_errors"] = self.encoding_errors
-        if self.dialect is not None:
-            kwargs["dialect"] = self.dialect
-        if self.on_bad_lines is not None:
-            kwargs["on_bad_lines"] = self.on_bad_lines
-        if Version(pd.__version__) < Version("2.2") and self.delim_whitespace is not None:
-            kwargs["delim_whitespace"] = self.delim_whitespace
-        if self.low_memory is not None:
-            kwargs["low_memory"] = self.low_memory
-        if self.memory_map is not None:
-            kwargs["memory_map"] = self.memory_map
-        if self.float_precision is not None:
-            kwargs["float_precision"] = self.float_precision
-        if self.storage_options is not None:
-            kwargs["storage_options"] = self.storage_options
-        if Version(pd.__version__) >= Version("2.0") and self.dtype_backend is not None:
-            kwargs["dtype_backend"] = self.dtype_backend
-
-        return kwargs
+def _get_loading_kwargs(self):
+    kwargs = {}
+    # keep_date_col removed — deprecated in pandas 2.2
+    # verbose removed — deprecated in pandas 2.2
+    if self.delim_whitespace:
+        kwargs["sep"] = r"\s+"   # replaces delim_whitespace=True
+    return kwargs
 
     def load_data(self, type_: type) -> tuple[DATAFRAME_TYPE, dict[str, Any]]:
         df = pd.read_csv(self.path, **self._get_loading_kwargs())


### PR DESCRIPTION
Removed deprecated loading kwargs for pandas < 2.2 and simplified the _get_loading_kwargs method.

<!-- SPDX-License-Identifier: Apache-2.0 -->

--- PR TEMPLATE INSTRUCTIONS (1) ---

Looking to submit a Apache Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
* [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)

Else, if not, please remove this block of text.

--- PR TEMPLATE INSTRUCTIONS (2) ---

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
